### PR TITLE
feat: episodic motor memory — make memory useful for evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,12 +500,12 @@ cargo test -p xagent-brain -- brain_prediction_error_decreases_with_repeated_inp
 
 ### Test Coverage Summary
 
-**58 tests total** across the workspace:
+**98 tests total** across the workspace:
 
 | Crate | Tests | Scope |
 |-------|------:|-------|
-| **xagent-brain** | 44 | Encoder similarity/determinism, memory store/recall/decay/associations/temporal sequences, predictor convergence/gradient descent, homeostasis multi-timescale gradients/urgency/distress curves, action selector exploration/exploitation/credit assignment, capacity manager adaptive budgets, brain integration (100-tick stability, extreme inputs, prediction error convergence) |
-| **xagent-sandbox** | 14 | Physics (movement, rotation, gravity, NaN sanitization), agent lifecycle (energy depletion, death, food consumption), terrain (determinism, interpolation smoothness, input validation), sensory extraction (vision dimensions, interoception accuracy) |
+| **xagent-brain** | 79 | Encoder similarity/determinism/adaptation, memory store/recall/decay/associations/temporal sequences/motor context/valence updates, predictor convergence/gradient descent/rollout dynamics, homeostasis multi-timescale gradients/urgency/distress curves, action selector memory-informed blending/exploration/exploitation/credit assignment, capacity manager adaptive budgets, brain integration (100-tick stability, extreme inputs, prediction error convergence, motor context storage) |
+| **xagent-sandbox** | 19 | Physics (movement, rotation, gravity, NaN sanitization, metabolic brain drain), agent lifecycle (energy depletion, death, food consumption), terrain (determinism, interpolation smoothness, input validation), sensory extraction (vision dimensions, interoception accuracy), evolution (config mutation/crossover, fitness evaluation) |
 
 ---
 

--- a/crates/xagent-brain/README.md
+++ b/crates/xagent-brain/README.md
@@ -241,23 +241,23 @@ All components are orchestrated by `Brain::tick()`, which runs once per simulati
 
 ### 4.2 Pattern Memory (`memory.rs`)
 
-**What it does**: Stores encoded states as `Pattern` objects in a fixed-capacity bank. Patterns can be recalled by similarity, associated with each other through co-occurrence, linked temporally (predecessor/successor), and decay over time unless reinforced.
+**What it does**: Stores encoded states as `Pattern` objects in a fixed-capacity bank. Each pattern captures not just the sensory state but also the motor command that was active and the homeostatic outcome (valence) at storage time — forming situation-action-outcome triplets. Patterns can be recalled by similarity, associated with each other through co-occurrence, linked temporally (predecessor/successor), and decay over time unless reinforced.
 
-**Why it exists**: This is the agent's experience store — analogous to episodic memory. It allows the agent to recognize familiar situations, anticipate what comes next (via temporal links), and build associations between co-occurring experiences. The fixed capacity means old, unused memories are eventually overwritten by new ones, implementing a form of forgetting.
+**Why it exists**: This is the agent's episodic motor memory — it allows the agent to recognize familiar situations, recall what actions worked (or failed) in similar states, anticipate what comes next (via temporal links), and build associations between co-occurring experiences. The motor context enables memory-informed action selection: recalled patterns directly suggest actions based on past outcomes. The fixed capacity means old, unused memories are eventually overwritten by new ones, implementing a form of forgetting.
 
 **How it works**:
 
 #### Storage
 
-When `store()` is called:
+When `store()` is called with the encoded state, motor command (forward, turn), and homeostatic gradient (outcome valence):
 1. A slot is found — either an empty one, or the one with the lowest reinforcement (weakest memory gets overwritten).
 2. If overwriting, temporal links pointing to the old pattern are cleaned up (`unlink_temporal`).
-3. The new pattern is created with `reinforcement=1.0`, `activation_count=1`, and the current tick.
+3. The new pattern is created with `reinforcement=1.0`, `activation_count=1`, the current tick, and the motor/valence context.
 4. Temporal links are established: the previous pattern's `successor` points here, and this pattern's `predecessor` points back. Both forward (0.5 strength) and backward (0.3 strength) associations are created.
 
 #### Recall by Similarity
 
-`recall()` computes cosine similarity between the query and all stored patterns, sorts by similarity, and returns the top-N (capped by `budget`). Each recalled pattern gets its `last_accessed` tick updated and `activation_count` incremented.
+`recall()` computes cosine similarity between the query and all stored patterns, sorts by similarity, and returns the top-N (capped by `budget`) as `RecalledPattern` structs. Each `RecalledPattern` contains the encoded state, similarity score, stored motor command (forward, turn), and outcome valence — providing the action selector with situation-action-outcome context. Each recalled pattern gets its `last_accessed` tick updated and `activation_count` incremented.
 
 ```rust
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
@@ -268,8 +268,6 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     (dot / (mag_a * mag_b)).clamp(-1.0, 1.0)
 }
 ```
-
-There is also `recall_weighted()` which returns `(EncodedState, similarity_score)` pairs for use by the predictor's context-weighted blending.
 
 #### Association Links with Generation Validation
 
@@ -319,9 +317,10 @@ With a severity of 0.2 (used on agent death), the weakest memories are wiped whi
 
 #### Learning
 
-`learn()` does two things:
+`learn()` does three things:
 1. **Reinforcement**: Patterns similar to the current state (cosine similarity > 0.3) are reinforced proportional to `similarity × learning_rate × (1 - error)`. Low prediction error strengthens matching patterns more.
-2. **Co-occurrence association**: Patterns that are *both* highly similar to the current state (similarity > 0.5) are associated with each other via bidirectional links with strength `learning_rate × 0.1`.
+2. **Retroactive valence update**: Similar patterns have their `outcome_valence` nudged toward the current homeostatic gradient via an EMA: `valence += sim × (learning_rate × 0.3) × (gradient - valence)`. This lets the agent update its assessment of past situations — "I thought this was bad, but it led to food" — creating a running evaluation that informs future action selection.
+3. **Co-occurrence association**: Patterns that are *both* highly similar to the current state (similarity > 0.5) are associated with each other via bidirectional links with strength `learning_rate × 0.1`.
 
 **Key constants**:
 
@@ -502,24 +501,46 @@ global_bias[a] = global_bias[a] × 0.995 + accumulated_credit[a] × 0.08
 
 The last 64 actions are tracked with zero per-tick heap allocation (pre-allocated ring buffer for state snapshots). The most recent action gets full credit; an action from 30 ticks ago gets `exp(-30 × 0.04) ≈ 30%` of the credit.
 
+#### Memory-Informed Motor Blending
+
+After the reactive policy computes raw motor output and prospective evaluation adjusts it, recalled patterns contribute their stored motor commands weighted by similarity and outcome valence:
+
+```
+mem_fwd = Σ (similarity × valence × stored_forward) / Σ |similarity × valence|
+mem_trn = Σ (similarity × valence × stored_turn)   / Σ |similarity × valence|
+mix = memory_strength × 0.4   // memory contributes up to 40% of motor signal
+fwd = fwd × (1 - mix) + mem_fwd × mix
+```
+
+- **Positive valence**: "do what I did before" — reinforces the recalled motor command
+- **Negative valence**: "do the opposite" — the sign flip steers away from past mistakes
+- **Low similarity**: contributes little (similarity weights the influence)
+- **Memory strength** scales with the average |similarity × valence| across recalled patterns, clamped to [0, 1]
+
+This creates a direct pathway from memory to action — agents with larger memory accumulate a richer library of situation-action-outcome triplets that directly guide behavior.
+
 #### Adaptive Exploration Rate
 
-The exploration rate is computed dynamically each tick:
+The exploration rate is computed dynamically each tick, based on **policy confidence** rather than recall count:
 
 ```rust
-let stability = recalled.len() as f32 / 16.0;
+let raw_signal = fwd.abs() + trn.abs();  // combined motor output magnitude
+let policy_confidence = (raw_signal / 2.0).clamp(0.0, 1.0);
 let novelty_bonus = (prediction_error * 2.0).min(0.4);
 let urgency_penalty = (urgency * 0.4).min(0.5);
-exploration_rate = (0.5 - stability * 0.15 + novelty_bonus + curiosity_bonus - urgency_penalty)
+exploration_rate = (0.5 - policy_confidence * 0.25 + novelty_bonus + curiosity_bonus - urgency_penalty)
     .clamp(0.10, 0.85);
 ```
 
 - **Base rate is 0.5** — agent exploits ~50% of the time by default
-- **More recalled patterns** (stable environment) → less exploration (stability weight 0.15)
+- **Strong policy signal** (trained weights + memory advice) → less exploration
+- **Untrained agent** (weights ≈ 0, no memory) → high exploration (exploration IS the strategy)
 - **Higher prediction error** (novel situation) → more exploration
 - **Higher curiosity bonus** (sensory monotony) → more exploration
 - **Higher urgency** (danger) → less exploration (exploit known-good actions)
-- **Exploration floor is 10%** — even at maximum urgency, agents explore at least 10% of the time, preventing total exploitation lock-in
+- **Exploration floor is 10%** — even at maximum urgency, agents explore at least 10% of the time
+
+Previously, exploration was inversely proportional to the number of recalled patterns (`stability = recalled.len() / 16.0`). This created perverse evolutionary pressure: agents with larger memory recalled more patterns, explored less, and followed untrained policy weights — effectively paralyzing themselves. The policy-confidence approach decouples exploration from memory capacity, allowing evolution to find the optimal brain size without exploration penalties.
 
 #### Uniform Random Exploration
 

--- a/crates/xagent-brain/src/action.rs
+++ b/crates/xagent-brain/src/action.rs
@@ -121,7 +121,7 @@ impl ActionSelector {
         &mut self,
         current: &EncodedState,
         prediction: &EncodedState,
-        recalled: &[(EncodedState, f32)],
+        recalled: &[crate::memory::RecalledPattern],
         homeostatic_gradient: f32,
         prediction_error: f32,
         urgency: f32,
@@ -138,18 +138,9 @@ impl ActionSelector {
         // 2. Temporal credit assignment.
         self.assign_credit(homeostatic_gradient);
 
-        // 3. Adaptive exploration rate.
-        // Base 0.5 for continuous motor: additive noise of ±0.5 produces
-        // vigorous movement comparable to the old discrete system's random
-        // full-strength actions. Both forward and turn channels get real
-        // signal so credit assignment can learn both steering and thrust.
-        // As the policy learns (weights grow), it dominates the noise and
-        // behavior smoothly transitions from random to directed.
-        let stability = recalled.len() as f32 / 16.0;
+        // 3. Exploration rate variables (computed after motor output, see step 7).
         let novelty_bonus = (prediction_error * 2.0).min(0.4);
         let urgency_penalty = (urgency * 0.4).min(0.5);
-        self.exploration_rate =
-            (0.5 - stability * 0.15 + novelty_bonus + curiosity_bonus - urgency_penalty).clamp(0.10, 0.85);
 
         // 4. Compute raw motor outputs from encoded state.
         let mut fwd = self.forward_bias;
@@ -174,11 +165,38 @@ impl ActionSelector {
             trn += confidence * ANTICIPATION_WEIGHT * (trn_future - trn);
         }
 
-        // 6. Clean output through tanh squashing.
+        // 6. Memory-informed motor blending: recalled patterns suggest
+        //    actions based on past outcomes in similar states.
+        let mut mem_fwd = 0.0_f32;
+        let mut mem_trn = 0.0_f32;
+        let mut total_weight = 0.0_f32;
+        for rp in recalled {
+            let w = rp.similarity * rp.outcome_valence;
+            mem_fwd += w * rp.motor_forward;
+            mem_trn += w * rp.motor_turn;
+            total_weight += w.abs();
+        }
+        if total_weight > 1e-6 {
+            mem_fwd /= total_weight;
+            mem_trn /= total_weight;
+            let memory_strength = (total_weight / recalled.len().max(1) as f32).clamp(0.0, 1.0);
+            let mix = memory_strength * 0.4;
+            fwd = fwd * (1.0 - mix) + mem_fwd * mix;
+            trn = trn * (1.0 - mix) + mem_trn * mix;
+        }
+
+        // 7. Adaptive exploration rate: based on policy confidence, not recall count.
+        let raw_signal = fwd.abs() + trn.abs();
+        let policy_confidence = (raw_signal / 2.0).clamp(0.0, 1.0);
+        self.exploration_rate =
+            (0.5 - policy_confidence * 0.25 + novelty_bonus + curiosity_bonus - urgency_penalty)
+                .clamp(0.10, 0.85);
+
+        // 8. Clean output through tanh squashing.
         let fwd_clean = crate::fast_tanh(fwd);
         let trn_clean = crate::fast_tanh(trn);
 
-        // 7. Add exploration noise.
+        // 9. Add exploration noise.
         let fwd_noisy =
             (fwd_clean + rng.random_range(-1.0..1.0) * self.exploration_rate).clamp(-1.0, 1.0);
         let trn_noisy =
@@ -190,7 +208,7 @@ impl ActionSelector {
             self.exploitative_actions += 1;
         }
 
-        // 8. Record actual motor output (including noise) + state snapshot + gradient in ring buffer.
+        // 10. Record actual motor output (including noise) + state snapshot + gradient in ring buffer.
         // We record the noisy output because that's what the agent actually did --
         // credit should reinforce the executed action, including exploratory noise.
         self.record_motor(fwd_noisy, trn_noisy, homeostatic_gradient);
@@ -393,9 +411,46 @@ impl ActionSelector {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::RecalledPattern;
 
     fn make_state(vals: &[f32]) -> EncodedState {
         EncodedState::from_slice(vals)
+    }
+
+    #[test]
+    fn recalled_positive_valence_biases_motor_output() {
+        let dim = 4;
+        let mut sel = ActionSelector::new(dim);
+
+        // Create a recalled pattern with strong positive valence and forward thrust
+        let recalled = vec![RecalledPattern {
+            state: crate::encoder::EncodedState::from_slice(&[1.0, 0.0, 0.0, 0.0]),
+            similarity: 0.9,
+            motor_forward: 0.8,
+            motor_turn: -0.5,
+            outcome_valence: 0.5,
+        }];
+
+        let state = crate::encoder::EncodedState::from_slice(&[1.0, 0.0, 0.0, 0.0]);
+        let prediction = crate::encoder::EncodedState::from_slice(&[1.0, 0.0, 0.0, 0.0]);
+
+        // Run many times and average to cancel out noise
+        let mut total_fwd = 0.0;
+        let n = 200;
+        for _ in 0..n {
+            let cmd = sel.select(&state, &prediction, &recalled, 0.0, 0.0, 0.0, 0.0);
+            total_fwd += cmd.forward;
+        }
+        let avg_fwd = total_fwd / n as f32;
+
+        // With positive valence recalled pattern suggesting 0.8 forward,
+        // average should be biased positive (untrained policy weights = 0,
+        // so without memory the average would be ~0 from symmetric noise)
+        assert!(
+            avg_fwd > 0.05,
+            "Memory with positive valence should bias forward output positive: avg={}",
+            avg_fwd,
+        );
     }
 
     #[test]
@@ -405,7 +460,7 @@ mod tests {
         let pred = make_state(&[0.5, 0.3, -0.1, 0.2]);
 
         for _ in 0..100 {
-            let cmd = sel.select(&state, &pred, &[], 0.0, 0.1, 0.0, 0.0);
+            let cmd = sel.select(&state, &pred, &[] as &[RecalledPattern], 0.0, 0.1, 0.0, 0.0);
             assert!(
                 cmd.forward >= -1.0 && cmd.forward <= 1.0,
                 "forward {} out of bounds",
@@ -427,14 +482,14 @@ mod tests {
 
         // Phase 1: baseline gradient (0.0)
         for _ in 0..30 {
-            sel.select(&state, &pred, &[], 0.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], 0.0, 0.1, 0.0, 0.0);
         }
 
         let fwd_before: f32 = sel.forward_weights.iter().sum();
 
         // Phase 2: positive gradient (+1.0) -- improvement from baseline
         for _ in 0..30 {
-            sel.select(&state, &pred, &[], 1.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], 1.0, 0.1, 0.0, 0.0);
         }
 
         let fwd_after: f32 = sel.forward_weights.iter().sum();
@@ -460,12 +515,12 @@ mod tests {
 
         // Phase 1: baseline gradient (0.0)
         for _ in 0..30 {
-            sel.select(&state, &pred, &[], 0.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], 0.0, 0.1, 0.0, 0.0);
         }
 
         // Phase 2: negative gradient (-1.0) -- worsening from baseline
         for _ in 0..30 {
-            sel.select(&state, &pred, &[], -1.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], -1.0, 0.1, 0.0, 0.0);
         }
 
         // With negative gradient transition, recent motor commands should
@@ -488,7 +543,7 @@ mod tests {
         // Force high exploration rate by using high prediction error.
         let mut outputs = Vec::new();
         for _ in 0..50 {
-            let cmd = sel.select(&state, &pred, &[], 0.0, 0.9, 0.0, 0.0);
+            let cmd = sel.select(&state, &pred, &[] as &[RecalledPattern], 0.0, 0.9, 0.0, 0.0);
             outputs.push(cmd.forward);
         }
 
@@ -509,7 +564,7 @@ mod tests {
 
         // Build up history.
         for _ in 0..20 {
-            sel.select(&state, &pred, &[], 0.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], 0.0, 0.1, 0.0, 0.0);
         }
         assert!(sel.history_len > 0, "Should have history after selecting");
 
@@ -530,10 +585,10 @@ mod tests {
 
         // Build some non-trivial weights.
         for _ in 0..30 {
-            sel.select(&state, &pred, &[], 0.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], 0.0, 0.1, 0.0, 0.0);
         }
         for _ in 0..30 {
-            sel.select(&state, &pred, &[], 1.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], 1.0, 0.1, 0.0, 0.0);
         }
 
         let exported = sel.export_weights();
@@ -571,10 +626,10 @@ mod tests {
 
         // Build a forward preference.
         for _ in 0..30 {
-            sel.select(&state, &pred, &[], 0.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], 0.0, 0.1, 0.0, 0.0);
         }
         for _ in 0..30 {
-            sel.select(&state, &pred, &[], 1.0, 0.1, 0.0, 0.0);
+            sel.select(&state, &pred, &[] as &[RecalledPattern], 1.0, 0.1, 0.0, 0.0);
         }
 
         // Now test: current state is neutral, prediction is the trained state.
@@ -588,7 +643,7 @@ mod tests {
         for _ in 0..20 {
             let mut sel_copy_n = ActionSelector::new(4);
             sel_copy_n.import_weights(&sel.export_weights());
-            let cmd = sel_copy_n.select(&neutral, &neutral, &[], 0.0, 0.01, 0.0, 0.0);
+            let cmd = sel_copy_n.select(&neutral, &neutral, &[] as &[RecalledPattern], 0.0, 0.01, 0.0, 0.0);
             fwd_neutral.push(cmd.forward);
         }
 
@@ -597,7 +652,7 @@ mod tests {
         for _ in 0..20 {
             let mut sel_copy_p = ActionSelector::new(4);
             sel_copy_p.import_weights(&sel.export_weights());
-            let cmd = sel_copy_p.select(&neutral, &dangerous_pred, &[], 0.0, 0.01, 0.0, 0.0);
+            let cmd = sel_copy_p.select(&neutral, &dangerous_pred, &[] as &[RecalledPattern], 0.0, 0.01, 0.0, 0.0);
             fwd_prospective.push(cmd.forward);
         }
 

--- a/crates/xagent-brain/src/brain.rs
+++ b/crates/xagent-brain/src/brain.rs
@@ -300,10 +300,10 @@ impl Brain {
             action: command.action,
         };
 
-        // 9. Record prediction for next tick's error computation
+        // 10. Record prediction for next tick's error computation
         self.predictor.record_prediction(prediction);
 
-        // 10. Compute behavior quality metrics
+        // 11. Compute behavior quality metrics
         let exploitation_ratio = self.action_selector.exploitation_ratio();
         let exploration_rate = self.action_selector.exploration_rate();
         let decision_quality = (1.0 - scalar_error.clamp(0.0, 1.0))
@@ -311,7 +311,7 @@ impl Brain {
             * (1.0 + homeo_state.gradient).clamp(0.0, 2.0)
             / 2.0;
 
-        // 11. Update telemetry
+        // 12. Update telemetry
         self.last_telemetry = BrainTelemetry {
             tick: self.tick_count,
             prediction_error: scalar_error,
@@ -331,7 +331,7 @@ impl Brain {
             motor_variance: self.motor_fatigue.motor_variance(),
         };
 
-        // 12. Capture decision snapshot for UI stream
+        // 13. Capture decision snapshot for UI stream
         self.last_decision = Some(DecisionSnapshot {
             tick: self.tick_count,
             motor_forward: command.forward,

--- a/crates/xagent-brain/src/brain.rs
+++ b/crates/xagent-brain/src/brain.rs
@@ -214,7 +214,7 @@ impl Brain {
             scalar_error = self.predictor.prediction_error(&prev_prediction, &habituated);
 
             // Learn: update memory reinforcements
-            self.memory.learn(&habituated, scalar_error, modulated_lr);
+            self.memory.learn(&habituated, scalar_error, modulated_lr, homeo_state.raw_gradient);
 
             // Compute error vector into scratch, then learn from it
             // We use the static version to avoid borrow conflict with learn()
@@ -240,8 +240,12 @@ impl Brain {
         };
         self.capacity.report_usage(recalled.len());
 
-        // 5. Predict next state using pre-computed similarity scores
-        let prediction = self.predictor.predict_weighted(&habituated, &recalled);
+        // 5. Predict next state using recalled patterns
+        let recalled_for_predictor: Vec<(EncodedState, f32)> = recalled
+            .iter()
+            .map(|rp| (rp.state.clone(), rp.similarity))
+            .collect();
+        let prediction = self.predictor.predict_weighted(&habituated, &recalled_for_predictor);
 
         // 5b. Multi-step rollout for prospective evaluation.
         let confidence = 1.0 - scalar_error.clamp(0.0, 1.0);
@@ -252,13 +256,7 @@ impl Brain {
             prediction.clone()
         };
 
-        // 6. Store current state as a pattern
-        self.memory.store(habituated.clone());
-
-        // 7. Decay old patterns
-        self.memory.decay(self.config.decay_rate);
-
-        // 8. Select action based on predictions, homeostatic state, and prediction error.
+        // 6. Select action based on predictions, homeostatic state, and prediction error.
         // Credit assignment receives the RAW per-tick gradient (not EMA composite) so
         // food/damage events produce a sharp, strong signal. The composite gradient is
         // still used for exploration rate and modulated learning rate (its smoothing is
@@ -274,12 +272,25 @@ impl Brain {
             curiosity_bonus,
         );
 
-        // 8b. Credit-driven encoder adaptation: amplify raw features that
+        // 6b. Credit-driven encoder adaptation: amplify raw features that
         //     contributed to behaviourally relevant encoded dimensions.
         let credit_signal = self.action_selector.last_credit_signal();
         self.encoder.adapt_from_credit(credit_signal, modulated_lr);
 
-        // 8c. Motor fatigue: dampen output when action variance is low.
+        // 7. Store current state as pattern with motor context.
+        // Uses pre-fatigue motor output (the intended action) and
+        // current homeostatic gradient as outcome signal.
+        self.memory.store(
+            habituated.clone(),
+            command.forward,
+            command.turn,
+            homeo_state.raw_gradient,
+        );
+
+        // 8. Decay old patterns.
+        self.memory.decay(self.config.decay_rate);
+
+        // 9. Motor fatigue: dampen output when action variance is low.
         self.motor_fatigue.update(command.forward, command.turn);
         let fatigue = self.motor_fatigue.fatigue_factor();
         let command = MotorCommand {
@@ -686,6 +697,30 @@ mod tests {
         assert!(
             cmd.forward.abs() > 0.0 || cmd.turn.abs() > 0.0,
             "Respawned agent must be able to produce non-zero motor output"
+        );
+    }
+
+    #[test]
+    fn tick_stores_motor_context_in_memory() {
+        let config = BrainConfig::default();
+        let mut brain = Brain::new(config);
+        let frame = SensoryFrame::new_blank(8, 6);
+
+        // Tick a few times to build up state
+        for _ in 0..10 {
+            brain.tick(&frame);
+        }
+
+        // Memory should have patterns with motor fields set
+        // (not all zeros, since exploration noise produces non-zero motors)
+        let has_nonzero_motor = (0..brain.memory.active_count()).any(|i| {
+            brain.memory.get(i).map_or(false, |p| {
+                p.motor_forward.abs() > 1e-6 || p.motor_turn.abs() > 1e-6
+            })
+        });
+        assert!(
+            has_nonzero_motor,
+            "At least one pattern should have non-zero motor context after ticking"
         );
     }
 }

--- a/crates/xagent-brain/src/lib.rs
+++ b/crates/xagent-brain/src/lib.rs
@@ -28,4 +28,5 @@ pub(crate) fn fast_tanh(x: f32) -> f32 {
 
 pub use brain::{Brain, BrainTelemetry, DecisionSnapshot, LearnedState};
 pub use habituation::SensoryHabituation;
+pub use memory::RecalledPattern;
 pub use motor_fatigue::MotorFatigue;

--- a/crates/xagent-brain/src/memory.rs
+++ b/crates/xagent-brain/src/memory.rs
@@ -51,6 +51,22 @@ pub struct Pattern {
     pub successor: Option<usize>,
     /// Generation counter — incremented each time this slot is written.
     pub generation: u64,
+    /// Motor forward output active when this pattern was stored.
+    pub motor_forward: f32,
+    /// Motor turn output active when this pattern was stored.
+    pub motor_turn: f32,
+    /// Homeostatic gradient at storage time (positive = good outcome).
+    pub outcome_valence: f32,
+}
+
+/// A pattern recalled from memory, including its motor context.
+#[derive(Clone, Debug)]
+pub struct RecalledPattern {
+    pub state: EncodedState,
+    pub similarity: f32,
+    pub motor_forward: f32,
+    pub motor_turn: f32,
+    pub outcome_valence: f32,
 }
 
 /// Fixed-capacity memory bank for temporal patterns.
@@ -116,7 +132,7 @@ impl PatternMemory {
     }
 
     /// Store a new pattern. Overwrites the weakest existing pattern if full.
-    pub fn store(&mut self, state: EncodedState) {
+    pub fn store(&mut self, state: EncodedState, motor_forward: f32, motor_turn: f32, outcome_valence: f32) {
         self.next_generation += 1;
 
         let prev_idx = self.last_stored_idx;
@@ -145,6 +161,9 @@ impl PatternMemory {
             predecessor: prev_idx,
             successor: None,
             generation: self.next_generation,
+            motor_forward,
+            motor_turn,
+            outcome_valence,
         });
 
         // Wire temporal sequence: prev → new
@@ -180,12 +199,12 @@ impl PatternMemory {
     }
 
     /// Recall the top-N most similar patterns, within budget.
-    /// Returns (encoded_state, similarity_score) pairs.
+    /// Returns RecalledPattern values with state, similarity, and motor context.
     pub fn recall(
         &mut self,
         query: &EncodedState,
         budget: usize,
-    ) -> Vec<(EncodedState, f32)> {
+    ) -> Vec<RecalledPattern> {
         let query_norm = compute_norm(query.data());
         self.scored_scratch.clear();
         for (i, p) in self.patterns.iter().enumerate() {
@@ -209,9 +228,13 @@ impl PatternMemory {
         self.scored_scratch
             .iter()
             .filter_map(|&(idx, sim)| {
-                self.patterns[idx]
-                    .as_ref()
-                    .map(|p| (p.state.clone(), sim))
+                self.patterns[idx].as_ref().map(|p| RecalledPattern {
+                    state: p.state.clone(),
+                    similarity: sim,
+                    motor_forward: p.motor_forward,
+                    motor_turn: p.motor_turn,
+                    outcome_valence: p.outcome_valence,
+                })
             })
             .collect()
     }
@@ -520,7 +543,7 @@ impl PatternMemory {
         &mut self,
         scores: &[f32],
         budget: usize,
-    ) -> Vec<(EncodedState, f32)> {
+    ) -> Vec<RecalledPattern> {
         self.scored_scratch.clear();
         for (i, &sim) in scores.iter().enumerate().take(self.capacity) {
             if sim > -1.5 {
@@ -541,9 +564,13 @@ impl PatternMemory {
         self.scored_scratch
             .iter()
             .filter_map(|&(idx, sim)| {
-                self.patterns[idx]
-                    .as_ref()
-                    .map(|p| (p.state.clone(), sim))
+                self.patterns[idx].as_ref().map(|p| RecalledPattern {
+                    state: p.state.clone(),
+                    similarity: sim,
+                    motor_forward: p.motor_forward,
+                    motor_turn: p.motor_turn,
+                    outcome_valence: p.outcome_valence,
+                })
             })
             .collect()
     }
@@ -560,19 +587,19 @@ mod tests {
     #[test]
     fn store_and_recall() {
         let mut mem = PatternMemory::new(10, 4);
-        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]));
-        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]));
+        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.0, 0.0, 0.0);
+        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]), 0.0, 0.0, 0.0);
 
         let results = mem.recall(&make_state(&[0.9, 0.1, 0.0, 0.0]), 1);
         assert_eq!(results.len(), 1);
         // Should recall the pattern most similar to query
-        assert!(results[0].0.data()[0] > 0.5, "Should recall the [1,0,0,0] pattern");
+        assert!(results[0].state.data()[0] > 0.5, "Should recall the [1,0,0,0] pattern");
     }
 
     #[test]
     fn decay_removes_weak_patterns() {
         let mut mem = PatternMemory::new(10, 4);
-        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]));
+        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.0, 0.0, 0.0);
         assert_eq!(mem.active_count(), 1);
 
         // Decay many times — smart decay is slower, so we need more iterations
@@ -586,8 +613,8 @@ mod tests {
     #[test]
     fn frequently_accessed_patterns_decay_slower() {
         let mut mem = PatternMemory::new(10, 4);
-        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]));
-        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]));
+        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.0, 0.0, 0.0);
+        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]), 0.0, 0.0, 0.0);
 
         // Access pattern 0 many times
         for _ in 0..20 {
@@ -608,9 +635,9 @@ mod tests {
     #[test]
     fn temporal_sequence_tracking() {
         let mut mem = PatternMemory::new(10, 4);
-        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0])); // idx 0
-        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0])); // idx 1
-        mem.store(make_state(&[0.0, 0.0, 1.0, 0.0])); // idx 2
+        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.0, 0.0, 0.0); // idx 0
+        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]), 0.0, 0.0, 0.0); // idx 1
+        mem.store(make_state(&[0.0, 0.0, 1.0, 0.0]), 0.0, 0.0, 0.0); // idx 2
 
         // Check successor chain: 0 → 1 → 2
         let p0 = mem.get(0).unwrap();
@@ -627,9 +654,9 @@ mod tests {
     #[test]
     fn association_chain_retrieval() {
         let mut mem = PatternMemory::new(10, 4);
-        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0])); // idx 0
-        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0])); // idx 1
-        mem.store(make_state(&[0.0, 0.0, 1.0, 0.0])); // idx 2
+        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.0, 0.0, 0.0); // idx 0
+        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]), 0.0, 0.0, 0.0); // idx 1
+        mem.store(make_state(&[0.0, 0.0, 1.0, 0.0]), 0.0, 0.0, 0.0); // idx 2
 
         let assoc = mem.retrieve_associated(0, 5);
         assert!(!assoc.is_empty(), "Should find associated patterns");
@@ -638,13 +665,13 @@ mod tests {
     #[test]
     fn capacity_limit_overwrites_weakest() {
         let mut mem = PatternMemory::new(3, 4);
-        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]));
-        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]));
-        mem.store(make_state(&[0.0, 0.0, 1.0, 0.0]));
+        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.0, 0.0, 0.0);
+        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]), 0.0, 0.0, 0.0);
+        mem.store(make_state(&[0.0, 0.0, 1.0, 0.0]), 0.0, 0.0, 0.0);
         assert_eq!(mem.active_count(), 3);
 
         // A 4th store should overwrite the weakest
-        mem.store(make_state(&[0.0, 0.0, 0.0, 1.0]));
+        mem.store(make_state(&[0.0, 0.0, 0.0, 1.0]), 0.0, 0.0, 0.0);
         assert_eq!(mem.active_count(), 3);
     }
 
@@ -653,9 +680,9 @@ mod tests {
         let mut mem = PatternMemory::new(3, 4);
 
         // Fill memory with 3 patterns
-        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0])); // idx 0
-        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0])); // idx 1
-        mem.store(make_state(&[0.0, 0.0, 1.0, 0.0])); // idx 2
+        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.0, 0.0, 0.0); // idx 0
+        mem.store(make_state(&[0.0, 1.0, 0.0, 0.0]), 0.0, 0.0, 0.0); // idx 1
+        mem.store(make_state(&[0.0, 0.0, 1.0, 0.0]), 0.0, 0.0, 0.0); // idx 2
 
         // Verify pattern 1 has association to pattern 0 (backward temporal link)
         let gen0_before = mem.get(0).unwrap().generation;
@@ -664,7 +691,7 @@ mod tests {
         assert!(has_link_to_0, "Pattern 1 should have association to pattern 0");
 
         // Overwrite pattern 0 (all equal reinforcement, so first/weakest is chosen)
-        mem.store(make_state(&[0.9, 0.9, 0.9, 0.9]));
+        mem.store(make_state(&[0.9, 0.9, 0.9, 0.9]), 0.0, 0.0, 0.0);
 
         // Generation should have changed
         let gen0_after = mem.get(0).unwrap().generation;
@@ -691,8 +718,8 @@ mod tests {
         let mut mem = PatternMemory::new(10, 4);
 
         // Store two similar patterns
-        mem.store(make_state(&[0.9, 0.1, 0.0, 0.0]));
-        mem.store(make_state(&[0.1, 0.9, 0.0, 0.0]));
+        mem.store(make_state(&[0.9, 0.1, 0.0, 0.0]), 0.0, 0.0, 0.0);
+        mem.store(make_state(&[0.1, 0.9, 0.0, 0.0]), 0.0, 0.0, 0.0);
 
         // Get initial association strength (from temporal linking)
         let initial_strength = mem.get(0).unwrap()
@@ -725,8 +752,8 @@ mod tests {
         let mut mem = PatternMemory::new(10, dim);
         let s1 = EncodedState::from_slice(&vec![1.0; dim]);
         let s2 = EncodedState::from_slice(&vec![0.5; dim]);
-        mem.store(s1);
-        mem.store(s2);
+        mem.store(s1, 0.0, 0.0, 0.0);
+        mem.store(s2, 0.0, 0.0, 0.0);
         assert_eq!(mem.active_count(), 2);
 
         let before: f32 = mem
@@ -757,11 +784,26 @@ mod tests {
         let dim = 4;
         let mut mem = PatternMemory::new(10, dim);
         let s = EncodedState::from_slice(&vec![1.0; dim]);
-        mem.store(s);
+        mem.store(s, 0.0, 0.0, 0.0);
         assert_eq!(mem.active_count(), 1);
 
         // Apply 100% trauma — should wipe everything
         mem.trauma(1.0);
         assert_eq!(mem.active_count(), 0);
+    }
+
+    #[test]
+    fn pattern_stores_motor_context() {
+        let mut mem = PatternMemory::new(10, 4);
+        mem.store(
+            make_state(&[1.0, 0.0, 0.0, 0.0]),
+            0.8,   // motor_forward
+            -0.3,  // motor_turn
+            0.05,  // outcome_valence
+        );
+        let p = mem.get(0).unwrap();
+        assert!((p.motor_forward - 0.8).abs() < 1e-6);
+        assert!((p.motor_turn - (-0.3)).abs() < 1e-6);
+        assert!((p.outcome_valence - 0.05).abs() < 1e-6);
     }
 }

--- a/crates/xagent-brain/src/memory.rs
+++ b/crates/xagent-brain/src/memory.rs
@@ -305,7 +305,7 @@ impl PatternMemory {
 
     /// Learn from prediction error: reinforce patterns similar to current state
     /// and strengthen co-occurrence associations between recently active patterns.
-    pub fn learn(&mut self, current: &EncodedState, error: f32, learning_rate: f32) {
+    pub fn learn(&mut self, current: &EncodedState, error: f32, learning_rate: f32, gradient: f32) {
         let current_norm = compute_norm(current.data());
         // Collect similarity scores first to avoid borrow conflicts
         let sims: Vec<(usize, f32)> = self
@@ -324,6 +324,9 @@ impl PatternMemory {
             if let Some(ref mut pat) = self.patterns[i] {
                 pat.reinforcement += sim * learning_rate * (1.0 - error);
                 pat.reinforcement = pat.reinforcement.clamp(0.0, MAX_REINFORCEMENT);
+                // Retroactive valence update: nudge toward current gradient
+                let valence_lr = learning_rate * 0.3;
+                pat.outcome_valence += sim * valence_lr * (gradient - pat.outcome_valence);
             }
         }
 
@@ -731,7 +734,7 @@ mod tests {
         // A state similar to both — learn repeatedly
         let current = make_state(&[0.5, 0.5, 0.0, 0.0]);
         for _ in 0..20 {
-            mem.learn(&current, 0.1, 0.1);
+            mem.learn(&current, 0.1, 0.1, 0.0);
         }
 
         // Check that the association strengthened
@@ -790,6 +793,26 @@ mod tests {
         // Apply 100% trauma — should wipe everything
         mem.trauma(1.0);
         assert_eq!(mem.active_count(), 0);
+    }
+
+    #[test]
+    fn learn_updates_outcome_valence() {
+        let mut mem = PatternMemory::new(10, 4);
+        // Store a pattern with neutral valence
+        mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.5, 0.0, 0.0);
+
+        // Learn with a positive gradient near the stored pattern
+        let current = make_state(&[0.9, 0.1, 0.0, 0.0]);
+        for _ in 0..20 {
+            mem.learn(&current, 0.1, 0.1, 0.5);
+        }
+
+        let p = mem.get(0).unwrap();
+        assert!(
+            p.outcome_valence > 0.1,
+            "Valence should become positive after positive gradient: got {}",
+            p.outcome_valence
+        );
     }
 
     #[test]

--- a/crates/xagent-sandbox/src/headless.rs
+++ b/crates/xagent-sandbox/src/headless.rs
@@ -141,6 +141,10 @@ pub fn run_headless(config: FullConfig, db_path: &str, resume: bool, _gpu_brain:
                         agent.brain.config.processing_slots,
                     );
                     agent.body.body.internal.energy -= brain_drain;
+                    if agent.body.body.internal.energy <= 0.0 {
+                        agent.body.body.internal.energy = 0.0;
+                        agent.body.body.alive = false;
+                    }
                     if consumed.is_some() {
                         agent.food_consumed += 1;
                     }

--- a/crates/xagent-sandbox/src/headless.rs
+++ b/crates/xagent-sandbox/src/headless.rs
@@ -135,6 +135,12 @@ pub fn run_headless(config: FullConfig, db_path: &str, resume: bool, _gpu_brain:
                     let consumed = crate::physics::step(
                         &mut agent.body, &motor, &mut world, dt,
                     );
+                    // Metabolic cost: brain capacity drains energy
+                    let brain_drain = crate::physics::metabolic_drain_per_tick(
+                        agent.brain.config.memory_capacity,
+                        agent.brain.config.processing_slots,
+                    );
+                    agent.body.body.internal.energy -= brain_drain;
                     if consumed.is_some() {
                         agent.food_consumed += 1;
                     }

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1389,6 +1389,10 @@ impl ApplicationHandler for App {
                                     agent.brain.config.processing_slots,
                                 );
                                 agent.body.body.internal.energy -= brain_drain;
+                                if agent.body.body.internal.energy <= 0.0 {
+                                    agent.body.body.internal.energy = 0.0;
+                                    agent.body.body.alive = false;
+                                }
                                 if let Some(food_idx) = consumed {
                                     self.food_dirty = true;
                                     agent.food_consumed += 1;

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1383,6 +1383,12 @@ impl ApplicationHandler for App {
                                 let consumed = xagent_sandbox::physics::step(
                                     &mut agent.body, &motor, world, SIM_DT,
                                 );
+                                // Metabolic cost: brain capacity drains energy
+                                let brain_drain = xagent_sandbox::physics::metabolic_drain_per_tick(
+                                    agent.brain.config.memory_capacity,
+                                    agent.brain.config.processing_slots,
+                                );
+                                agent.body.body.internal.energy -= brain_drain;
                                 if let Some(food_idx) = consumed {
                                     self.food_dirty = true;
                                     agent.food_consumed += 1;

--- a/crates/xagent-sandbox/src/physics/mod.rs
+++ b/crates/xagent-sandbox/src/physics/mod.rs
@@ -18,6 +18,20 @@ const TURN_SPEED: f32 = 3.0;
 /// Half the agent's collision height in world units. The agent's feet are at
 /// `ground_height + AGENT_HALF_HEIGHT`, making the full agent 2 units tall.
 const AGENT_HALF_HEIGHT: f32 = 1.0;
+
+/// Metabolic cost per tick for maintaining brain capacity.
+/// Larger memory and processing capacity drain more energy — the
+/// biological cost of a bigger brain.
+const METABOLIC_BASE_COST: f32 = 0.0001;
+const METABOLIC_MEMORY_COST: f32 = 0.00003;
+const METABOLIC_PROCESSING_COST: f32 = 0.0001;
+
+pub fn metabolic_drain_per_tick(memory_capacity: usize, processing_slots: usize) -> f32 {
+    METABOLIC_BASE_COST
+        + memory_capacity as f32 * METABOLIC_MEMORY_COST
+        + processing_slots as f32 * METABOLIC_PROCESSING_COST
+}
+
 /// Maximum distance (in world units) at which an agent can consume a food item.
 /// Slightly larger than the agent's body (2-unit cube) to provide a forgiving
 /// interaction radius without requiring pixel-perfect alignment.

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -500,6 +500,32 @@ fn touch_contacts_populated_near_food() {
     );
 }
 
+// ── Metabolic Tests ────────────────────────────────────────────────────
+
+#[test]
+fn metabolic_cost_drains_energy_proportional_to_capacity() {
+    use xagent_shared::BrainConfig;
+
+    // Two configs: tiny brain vs large brain
+    let small = BrainConfig { memory_capacity: 1, processing_slots: 1, ..BrainConfig::default() };
+    let large = BrainConfig { memory_capacity: 512, processing_slots: 32, ..BrainConfig::default() };
+
+    let small_drain = xagent_sandbox::physics::metabolic_drain_per_tick(
+        small.memory_capacity,
+        small.processing_slots,
+    );
+    let large_drain = xagent_sandbox::physics::metabolic_drain_per_tick(
+        large.memory_capacity,
+        large.processing_slots,
+    );
+
+    assert!(small_drain > 0.0, "Even small brains have baseline cost");
+    assert!(
+        large_drain > small_drain * 10.0,
+        "Large brain should cost significantly more: small={small_drain}, large={large_drain}",
+    );
+}
+
 // ── UI Snapshot Tests ─────────────────────────────────────────────────
 
 #[test]

--- a/docs/superpowers/plans/2026-04-03-episodic-motor-memory.md
+++ b/docs/superpowers/plans/2026-04-03-episodic-motor-memory.md
@@ -1,0 +1,809 @@
+# Episodic Motor Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix memory convergence to (1,1) by making memory directly useful for action selection, decoupling exploration from recall count, and adding metabolic cost for brain capacity.
+
+**Architecture:** Four interdependent changes across the brain crate and sandbox: (1) `RecalledPattern` struct + `Pattern` motor fields in memory.rs, (2) exploration rate + memory-informed blending in action.rs, (3) wiring through brain.rs tick_inner, (4) metabolic energy drain in physics/mod.rs.
+
+**Tech Stack:** Rust, xagent-brain crate, xagent-sandbox crate, xagent-shared crate
+
+---
+
+### Task 1: Add Motor Fields to Pattern and Create RecalledPattern
+
+**Files:**
+- Modify: `crates/xagent-brain/src/memory.rs:31-54` (Pattern struct)
+- Modify: `crates/xagent-brain/src/memory.rs:92-110` (PatternMemory::new)
+- Test: `crates/xagent-brain/src/memory.rs` (inline tests module at line 552)
+
+- [ ] **Step 1: Write failing test for Pattern motor fields**
+
+Add this test at the end of the `tests` module in `memory.rs` (before the closing `}`):
+
+```rust
+#[test]
+fn pattern_stores_motor_context() {
+    let mut mem = PatternMemory::new(10, 4);
+    mem.store(
+        make_state(&[1.0, 0.0, 0.0, 0.0]),
+        0.8,   // motor_forward
+        -0.3,  // motor_turn
+        0.05,  // outcome_valence
+    );
+    let p = mem.get(0).unwrap();
+    assert!((p.motor_forward - 0.8).abs() < 1e-6);
+    assert!((p.motor_turn - (-0.3)).abs() < 1e-6);
+    assert!((p.outcome_valence - 0.05).abs() < 1e-6);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p xagent-brain pattern_stores_motor_context -- --nocapture 2>&1 | head -30`
+Expected: Compilation error — `store()` doesn't accept motor args yet.
+
+- [ ] **Step 3: Add motor fields to Pattern struct**
+
+In `memory.rs`, add three fields to the `Pattern` struct (after `generation: u64` at line 53):
+
+```rust
+    /// Motor forward output active when this pattern was stored.
+    pub motor_forward: f32,
+    /// Motor turn output active when this pattern was stored.
+    pub motor_turn: f32,
+    /// Homeostatic gradient at storage time (positive = good outcome).
+    pub outcome_valence: f32,
+```
+
+- [ ] **Step 4: Update store() signature and body**
+
+Change `store()` at line 119 from:
+```rust
+pub fn store(&mut self, state: EncodedState) {
+```
+to:
+```rust
+pub fn store(&mut self, state: EncodedState, motor_forward: f32, motor_turn: f32, outcome_valence: f32) {
+```
+
+In the `Pattern` initialization block (lines 136-148), add the three new fields:
+```rust
+        self.patterns[slot] = Some(Pattern {
+            state,
+            norm,
+            reinforcement: 1.0,
+            created_at: self.current_tick,
+            last_accessed: self.current_tick,
+            activation_count: 1,
+            associations: [empty_link; MAX_ASSOCIATIONS_PER_PATTERN],
+            association_count: 0,
+            predecessor: prev_idx,
+            successor: None,
+            generation: self.next_generation,
+            motor_forward,
+            motor_turn,
+            outcome_valence,
+        });
+```
+
+- [ ] **Step 5: Fix all existing store() call sites in tests**
+
+Update every existing `mem.store(make_state(...))` call in the `tests` module to pass motor context. Use `0.0, 0.0, 0.0` as defaults for tests that don't care about motor fields. There are calls in these tests:
+- `store_and_recall` (line 563)
+- `decay_removes_weak_patterns` (line 575)
+- `frequently_accessed_patterns_decay_slower` (lines 589-590)
+- `temporal_sequence_tracking` (lines 611-613)
+- `association_chain_retrieval` (lines 630-632)
+- `capacity_limit_overwrites_weakest` (lines 641-644)
+- `overwritten_associations_are_invalidated` (lines 656-658, 667)
+- `co_occurrence_strengthens_associations` (lines 693-694)
+- `trauma_reduces_reinforcement` (lines 726-727)
+- `trauma_removes_weak_patterns` (line 759)
+
+For each, change e.g.:
+```rust
+mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]));
+```
+to:
+```rust
+mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.0, 0.0, 0.0);
+```
+
+- [ ] **Step 6: Create RecalledPattern struct**
+
+Add this struct above the `PatternMemory` struct (before line 56):
+
+```rust
+/// A pattern recalled from memory, including its motor context.
+#[derive(Clone, Debug)]
+pub struct RecalledPattern {
+    pub state: EncodedState,
+    pub similarity: f32,
+    pub motor_forward: f32,
+    pub motor_turn: f32,
+    pub outcome_valence: f32,
+}
+```
+
+- [ ] **Step 7: Update recall() to return Vec\<RecalledPattern\>**
+
+Change `recall()` return type at line 184 from:
+```rust
+    ) -> Vec<(EncodedState, f32)> {
+```
+to:
+```rust
+    ) -> Vec<RecalledPattern> {
+```
+
+Update the result collection at lines 209-216 from:
+```rust
+        self.scored_scratch
+            .iter()
+            .filter_map(|&(idx, sim)| {
+                self.patterns[idx]
+                    .as_ref()
+                    .map(|p| (p.state.clone(), sim))
+            })
+            .collect()
+```
+to:
+```rust
+        self.scored_scratch
+            .iter()
+            .filter_map(|&(idx, sim)| {
+                self.patterns[idx].as_ref().map(|p| RecalledPattern {
+                    state: p.state.clone(),
+                    similarity: sim,
+                    motor_forward: p.motor_forward,
+                    motor_turn: p.motor_turn,
+                    outcome_valence: p.outcome_valence,
+                })
+            })
+            .collect()
+```
+
+- [ ] **Step 8: Update recall_with_gpu_similarities() to return Vec\<RecalledPattern\>**
+
+Change return type at line 519 from:
+```rust
+    ) -> Vec<(EncodedState, f32)> {
+```
+to:
+```rust
+    ) -> Vec<RecalledPattern> {
+```
+
+Update the result collection at lines 541-548 from:
+```rust
+        self.scored_scratch
+            .iter()
+            .filter_map(|&(idx, sim)| {
+                self.patterns[idx]
+                    .as_ref()
+                    .map(|p| (p.state.clone(), sim))
+            })
+            .collect()
+```
+to:
+```rust
+        self.scored_scratch
+            .iter()
+            .filter_map(|&(idx, sim)| {
+                self.patterns[idx].as_ref().map(|p| RecalledPattern {
+                    state: p.state.clone(),
+                    similarity: sim,
+                    motor_forward: p.motor_forward,
+                    motor_turn: p.motor_turn,
+                    outcome_valence: p.outcome_valence,
+                })
+            })
+            .collect()
+```
+
+- [ ] **Step 9: Fix recall() test call sites**
+
+In the test module, `store_and_recall` (line 566) accesses `results[0].0` and `results[0].1`. Update:
+```rust
+        let results = mem.recall(&make_state(&[0.9, 0.1, 0.0, 0.0]), 1);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].state.data()[0] > 0.5, "Should recall the [1,0,0,0] pattern");
+```
+
+In `frequently_accessed_patterns_decay_slower` (line 593), the `recall` call doesn't inspect the return value — no change needed to the assertion, just make sure the return type change compiles.
+
+- [ ] **Step 10: Run all memory tests**
+
+Run: `cargo test -p xagent-brain memory -- --nocapture 2>&1 | tail -20`
+Expected: All 11 tests pass (10 existing + 1 new).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/xagent-brain/src/memory.rs
+git commit -m "feat: add motor fields to Pattern and RecalledPattern return type"
+```
+
+---
+
+### Task 2: Update learn() for Retroactive Valence Updates
+
+**Files:**
+- Modify: `crates/xagent-brain/src/memory.rs:285-317` (learn method)
+- Test: `crates/xagent-brain/src/memory.rs` (inline tests module)
+
+- [ ] **Step 1: Write failing test for valence update**
+
+Add to the memory tests module:
+
+```rust
+#[test]
+fn learn_updates_outcome_valence() {
+    let mut mem = PatternMemory::new(10, 4);
+    // Store a pattern with neutral valence
+    mem.store(make_state(&[1.0, 0.0, 0.0, 0.0]), 0.5, 0.0, 0.0);
+
+    // Learn with a positive gradient near the stored pattern
+    let current = make_state(&[0.9, 0.1, 0.0, 0.0]);
+    for _ in 0..20 {
+        mem.learn(&current, 0.1, 0.1, 0.5);
+    }
+
+    let p = mem.get(0).unwrap();
+    assert!(
+        p.outcome_valence > 0.1,
+        "Valence should become positive after positive gradient: got {}",
+        p.outcome_valence
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p xagent-brain learn_updates_outcome_valence -- --nocapture 2>&1 | head -20`
+Expected: Compilation error — `learn()` doesn't accept `gradient` parameter.
+
+- [ ] **Step 3: Update learn() signature and add valence update**
+
+Change `learn()` signature at line 285 from:
+```rust
+    pub fn learn(&mut self, current: &EncodedState, error: f32, learning_rate: f32) {
+```
+to:
+```rust
+    pub fn learn(&mut self, current: &EncodedState, error: f32, learning_rate: f32, gradient: f32) {
+```
+
+In the reinforcement loop (lines 300-305), add valence update after the reinforcement line:
+```rust
+        for &(i, sim) in &sims {
+            if let Some(ref mut pat) = self.patterns[i] {
+                pat.reinforcement += sim * learning_rate * (1.0 - error);
+                pat.reinforcement = pat.reinforcement.clamp(0.0, MAX_REINFORCEMENT);
+                // Retroactive valence update: nudge toward current gradient
+                let valence_lr = learning_rate * 0.3;
+                pat.outcome_valence += sim * valence_lr * (gradient - pat.outcome_valence);
+            }
+        }
+```
+
+- [ ] **Step 4: Fix existing learn() call sites in tests**
+
+In `co_occurrence_strengthens_associations` (line 706), update:
+```rust
+            mem.learn(&current, 0.1, 0.1);
+```
+to:
+```rust
+            mem.learn(&current, 0.1, 0.1, 0.0);
+```
+
+- [ ] **Step 5: Run all memory tests**
+
+Run: `cargo test -p xagent-brain memory -- --nocapture 2>&1 | tail -20`
+Expected: All 12 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/xagent-brain/src/memory.rs
+git commit -m "feat: add retroactive valence update to memory learn()"
+```
+
+---
+
+### Task 3: Update ActionSelector for Memory-Informed Blending
+
+**Files:**
+- Modify: `crates/xagent-brain/src/action.rs:120-204` (select method)
+- Test: `crates/xagent-brain/src/action.rs` (inline tests module at line 393)
+
+- [ ] **Step 1: Write failing test for memory-informed blending**
+
+Add to the action tests module:
+
+```rust
+#[test]
+fn recalled_positive_valence_biases_motor_output() {
+    use crate::memory::RecalledPattern;
+    let dim = 4;
+    let mut sel = ActionSelector::new(dim);
+
+    // Create a recalled pattern with strong positive valence and forward thrust
+    let recalled = vec![RecalledPattern {
+        state: crate::encoder::EncodedState::from_slice(&[1.0, 0.0, 0.0, 0.0]),
+        similarity: 0.9,
+        motor_forward: 0.8,
+        motor_turn: -0.5,
+        outcome_valence: 0.5,
+    }];
+
+    let state = crate::encoder::EncodedState::from_slice(&[1.0, 0.0, 0.0, 0.0]);
+    let prediction = crate::encoder::EncodedState::from_slice(&[1.0, 0.0, 0.0, 0.0]);
+
+    // Run many times and average to cancel out noise
+    let mut total_fwd = 0.0;
+    let n = 200;
+    for _ in 0..n {
+        let cmd = sel.select(&state, &prediction, &recalled, 0.0, 0.0, 0.0, 0.0);
+        total_fwd += cmd.forward;
+    }
+    let avg_fwd = total_fwd / n as f32;
+
+    // With positive valence recalled pattern suggesting 0.8 forward,
+    // average should be biased positive (untrained policy weights = 0,
+    // so without memory the average would be ~0 from symmetric noise)
+    assert!(
+        avg_fwd > 0.05,
+        "Memory with positive valence should bias forward output positive: avg={}",
+        avg_fwd,
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p xagent-brain recalled_positive_valence_biases_motor_output -- --nocapture 2>&1 | head -30`
+Expected: Compilation error — `select()` still expects `&[(EncodedState, f32)]`.
+
+- [ ] **Step 3: Update select() signature**
+
+Change the `recalled` parameter type at line 124 from:
+```rust
+        recalled: &[(EncodedState, f32)],
+```
+to:
+```rust
+        recalled: &[crate::memory::RecalledPattern],
+```
+
+- [ ] **Step 4: Replace exploration rate formula with policy confidence**
+
+Remove the old stability-based exploration rate block (lines 148-152). The new exploration rate computation goes *after* the raw motor output computation (after line 160). Replace the block:
+
+```rust
+        // 3. Adaptive exploration rate.
+        // Base 0.5 for continuous motor: additive noise of ±0.5 produces
+        // vigorous movement comparable to the old discrete system's random
+        // full-strength actions. Both forward and turn channels get real
+        // signal so credit assignment can learn both steering and thrust.
+        // As the policy learns (weights grow), it dominates the noise and
+        // behavior smoothly transitions from random to directed.
+        let stability = recalled.len() as f32 / 16.0;
+        let novelty_bonus = (prediction_error * 2.0).min(0.4);
+        let urgency_penalty = (urgency * 0.4).min(0.5);
+        self.exploration_rate =
+            (0.5 - stability * 0.15 + novelty_bonus + curiosity_bonus - urgency_penalty).clamp(0.10, 0.85);
+```
+
+with a placeholder comment that will be filled in step 5:
+```rust
+        // 3. Exploration rate (computed after raw motor output, see below).
+        let novelty_bonus = (prediction_error * 2.0).min(0.4);
+        let urgency_penalty = (urgency * 0.4).min(0.5);
+```
+
+- [ ] **Step 5: Reorder select() — raw motor, then exploration, then memory blend**
+
+After the raw motor output computation (after computing `fwd` and `trn` from policy weights), add the exploration rate and memory blending blocks. The full reordered flow after step 2 (credit assignment) becomes:
+
+```rust
+        // 3. Compute raw motor outputs from encoded state.
+        let mut fwd = self.forward_bias;
+        let mut trn = self.turn_bias;
+        for d in 0..dim.min(current.data().len()) {
+            fwd += self.forward_weights[d] * current.data()[d];
+            trn += self.turn_weights[d] * current.data()[d];
+        }
+
+        // 4. Prospective evaluation: if confident, modulate output toward
+        //    predicted future's policy response.
+        let confidence = 1.0 - prediction_error.clamp(0.0, 1.0);
+        if confidence > 0.1 {
+            let mut fwd_future = self.forward_bias;
+            let mut trn_future = self.turn_bias;
+            let pred_len = dim.min(prediction.data().len());
+            for d in 0..pred_len {
+                fwd_future += self.forward_weights[d] * prediction.data()[d];
+                trn_future += self.turn_weights[d] * prediction.data()[d];
+            }
+            fwd += confidence * ANTICIPATION_WEIGHT * (fwd_future - fwd);
+            trn += confidence * ANTICIPATION_WEIGHT * (trn_future - trn);
+        }
+
+        // 5. Memory-informed motor blending: recalled patterns suggest
+        //    actions based on past outcomes in similar states.
+        let mut mem_fwd = 0.0_f32;
+        let mut mem_trn = 0.0_f32;
+        let mut total_weight = 0.0_f32;
+        for rp in recalled {
+            let w = rp.similarity * rp.outcome_valence;
+            mem_fwd += w * rp.motor_forward;
+            mem_trn += w * rp.motor_turn;
+            total_weight += w.abs();
+        }
+        if total_weight > 1e-6 {
+            mem_fwd /= total_weight;
+            mem_trn /= total_weight;
+            let memory_strength = (total_weight / recalled.len().max(1) as f32).clamp(0.0, 1.0);
+            let mix = memory_strength * 0.4;
+            fwd = fwd * (1.0 - mix) + mem_fwd * mix;
+            trn = trn * (1.0 - mix) + mem_trn * mix;
+        }
+
+        // 6. Adaptive exploration rate: based on policy confidence, not recall count.
+        let raw_signal = fwd.abs() + trn.abs();
+        let policy_confidence = (raw_signal / 2.0).clamp(0.0, 1.0);
+        self.exploration_rate =
+            (0.5 - policy_confidence * 0.25 + novelty_bonus + curiosity_bonus - urgency_penalty)
+                .clamp(0.10, 0.85);
+
+        // 7. Clean output through tanh squashing.
+        let fwd_clean = crate::fast_tanh(fwd);
+        let trn_clean = crate::fast_tanh(trn);
+
+        // 8. Add exploration noise.
+        let fwd_noisy =
+            (fwd_clean + rng.random_range(-1.0..1.0) * self.exploration_rate).clamp(-1.0, 1.0);
+        let trn_noisy =
+            (trn_clean + rng.random_range(-1.0..1.0) * self.exploration_rate).clamp(-1.0, 1.0);
+```
+
+- [ ] **Step 6: Fix existing test call sites in action.rs**
+
+All existing tests that call `sel.select(...)` pass `recalled` as `&[(EncodedState, f32)]`. Update them to pass `&[]` (empty slice of `RecalledPattern`) or construct `RecalledPattern` values. The tests are:
+
+- `continuous_output_is_bounded` — change `&[]` to `&[] as &[crate::memory::RecalledPattern]`
+- `positive_gradient_transition_increases_forward` — same
+- `negative_gradient_transition_penalizes_approach` — same
+- `exploration_adds_noise` — same
+- `death_signal_clears_history` — same (also update `assign_death_credit` if it calls select)
+- `weight_export_import_roundtrip` — same
+- `prospection_modulates_output` — same
+
+For each call like:
+```rust
+let cmd = sel.select(&state, &pred, &[], 0.0, 0.0, 0.0, 0.0);
+```
+Change to:
+```rust
+let cmd = sel.select(&state, &pred, &[] as &[crate::memory::RecalledPattern], 0.0, 0.0, 0.0, 0.0);
+```
+
+Or add a type alias at the top of the test module:
+```rust
+use crate::memory::RecalledPattern;
+```
+and use `&[] as &[RecalledPattern]`.
+
+- [ ] **Step 7: Run all action tests**
+
+Run: `cargo test -p xagent-brain action -- --nocapture 2>&1 | tail -20`
+Expected: All 8 tests pass (7 existing + 1 new).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/xagent-brain/src/action.rs
+git commit -m "feat: memory-informed action blending and policy-confidence exploration rate"
+```
+
+---
+
+### Task 4: Wire Changes Through brain.rs tick_inner
+
+**Files:**
+- Modify: `crates/xagent-brain/src/brain.rs:191-342` (tick_inner method)
+- Test: `crates/xagent-brain/src/brain.rs` (inline tests module at line 433)
+
+- [ ] **Step 1: Write failing test for motor context in store**
+
+Add to the brain tests module:
+
+```rust
+#[test]
+fn tick_stores_motor_context_in_memory() {
+    let config = BrainConfig::default();
+    let mut brain = Brain::new(config);
+    let frame = SensoryFrame::new_blank(8, 6);
+
+    // Tick a few times to build up state
+    for _ in 0..10 {
+        brain.tick(&frame);
+    }
+
+    // Memory should have patterns with motor fields set
+    // (not all zeros, since exploration noise produces non-zero motors)
+    let has_nonzero_motor = (0..brain.memory.active_count()).any(|i| {
+        brain.memory.get(i).map_or(false, |p| {
+            p.motor_forward.abs() > 1e-6 || p.motor_turn.abs() > 1e-6
+        })
+    });
+    assert!(
+        has_nonzero_motor,
+        "At least one pattern should have non-zero motor context after ticking"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p xagent-brain tick_stores_motor_context -- --nocapture 2>&1 | head -30`
+Expected: Compilation error — `tick_inner` still calls `store()` with old signature.
+
+- [ ] **Step 3: Update tick_inner to pass motor context to store()**
+
+In `brain.rs:tick_inner`, the current flow is:
+1. Lines 200-230: habituation, homeostasis, prediction error, learn
+2. Lines 232-241: recall
+3. Lines 243-253: predict
+4. Line 256: `self.memory.store(habituated.clone());`
+5. Line 259: `self.memory.decay(self.config.decay_rate);`
+6. Lines 267-275: action selection
+
+Reorder: move store to after action selection, passing motor context. Delete line 256 (`self.memory.store(habituated.clone());`).
+
+After the action selector call (after line 275), before motor fatigue (line 283), insert:
+
+```rust
+        // 8b. Store current state as pattern with motor context.
+        // Uses pre-fatigue motor output (the intended action) and
+        // current homeostatic gradient as outcome signal.
+        self.memory.store(
+            habituated.clone(),
+            command.forward,
+            command.turn,
+            homeo_state.raw_gradient,
+        );
+
+        // 8c. Decay old patterns.
+        self.memory.decay(self.config.decay_rate);
+```
+
+And remove the old store and decay calls at lines 256 and 259.
+
+- [ ] **Step 4: Update learn() call to pass gradient**
+
+Change line 217 from:
+```rust
+            self.memory.learn(&habituated, scalar_error, modulated_lr);
+```
+to:
+```rust
+            self.memory.learn(&habituated, scalar_error, modulated_lr, homeo_state.raw_gradient);
+```
+
+Note: `homeo_state` is computed at line 205-206 *before* the learn call, so `raw_gradient` is available. However, `homeo_state` is declared inside `tick_inner` at line 205. The learn call at line 217 is inside an `if let Some(prev_prediction)` block. Verify that `homeo_state` is in scope — it is, since it's declared at the method level (line 205), not inside the if block.
+
+- [ ] **Step 5: Update recalled pattern usage**
+
+The recall result type changed from `Vec<(EncodedState, f32)>` to `Vec<RecalledPattern>`. Update the code that uses `recalled`:
+
+At the action selector call (lines 267-275), `recalled` is passed as `&recalled`. The `select` method now expects `&[RecalledPattern]` — this matches.
+
+The predictor call at line 244 (`self.predictor.predict_weighted(&habituated, &recalled)`) still expects `&[(EncodedState, f32)]`. We need to convert. Add a helper extraction before the predict call:
+
+```rust
+        // 5. Predict next state using recalled patterns
+        let recalled_for_predictor: Vec<(EncodedState, f32)> = recalled
+            .iter()
+            .map(|rp| (rp.state.clone(), rp.similarity))
+            .collect();
+        let prediction = self.predictor.predict_weighted(&habituated, &recalled_for_predictor);
+```
+
+Also update the capacity report at line 241:
+```rust
+        self.capacity.report_usage(recalled.len());
+```
+This stays the same — `recalled.len()` works on `Vec<RecalledPattern>`.
+
+- [ ] **Step 6: Add RecalledPattern import**
+
+At the top of `brain.rs`, ensure `RecalledPattern` is imported:
+```rust
+use crate::memory::{PatternMemory, RecalledPattern};
+```
+
+If `PatternMemory` is not currently imported explicitly (it's used via `self.memory`), just add `RecalledPattern` to whatever existing import path covers memory types. Check the current imports at the top of brain.rs.
+
+- [ ] **Step 7: Run all brain tests**
+
+Run: `cargo test -p xagent-brain brain -- --nocapture 2>&1 | tail -30`
+Expected: All 11 tests pass (10 existing + 1 new).
+
+- [ ] **Step 8: Run the full xagent-brain test suite**
+
+Run: `cargo test -p xagent-brain -- --nocapture 2>&1 | tail -30`
+Expected: All tests pass across memory, action, brain, predictor modules.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/xagent-brain/src/brain.rs
+git commit -m "feat: wire motor context through tick_inner — store after action, pass gradient to learn"
+```
+
+---
+
+### Task 5: Add Metabolic Energy Drain
+
+**Files:**
+- Modify: `crates/xagent-sandbox/src/physics/mod.rs:105-108` (energy depletion section)
+- Modify: `crates/xagent-sandbox/src/physics/mod.rs:22-23` (function signature of `step`)
+- Test: `crates/xagent-sandbox/tests/integration.rs`
+
+- [ ] **Step 1: Write failing integration test for metabolic cost**
+
+Add to `crates/xagent-sandbox/tests/integration.rs`:
+
+```rust
+#[test]
+fn metabolic_cost_drains_energy_proportional_to_capacity() {
+    use xagent_shared::BrainConfig;
+
+    // Two configs: tiny brain vs large brain
+    let small = BrainConfig { memory_capacity: 1, processing_slots: 1, ..BrainConfig::default() };
+    let large = BrainConfig { memory_capacity: 512, processing_slots: 32, ..BrainConfig::default() };
+
+    let small_drain = xagent_sandbox::physics::metabolic_drain_per_tick(
+        small.memory_capacity,
+        small.processing_slots,
+    );
+    let large_drain = xagent_sandbox::physics::metabolic_drain_per_tick(
+        large.memory_capacity,
+        large.processing_slots,
+    );
+
+    assert!(small_drain > 0.0, "Even small brains have baseline cost");
+    assert!(
+        large_drain > small_drain * 10.0,
+        "Large brain should cost significantly more: small={small_drain}, large={large_drain}",
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p xagent-sandbox metabolic_cost_drains -- --nocapture 2>&1 | head -20`
+Expected: Compilation error — `metabolic_drain_per_tick` doesn't exist.
+
+- [ ] **Step 3: Add metabolic_drain_per_tick function**
+
+In `crates/xagent-sandbox/src/physics/mod.rs`, add a public function after the constants (after line 20):
+
+```rust
+/// Metabolic cost per tick for maintaining brain capacity.
+/// Larger memory and processing capacity drain more energy — the
+/// biological cost of a bigger brain.
+const METABOLIC_BASE_COST: f32 = 0.0001;
+const METABOLIC_MEMORY_COST: f32 = 0.00003;
+const METABOLIC_PROCESSING_COST: f32 = 0.0001;
+
+pub fn metabolic_drain_per_tick(memory_capacity: usize, processing_slots: usize) -> f32 {
+    METABOLIC_BASE_COST
+        + memory_capacity as f32 * METABOLIC_MEMORY_COST
+        + processing_slots as f32 * METABOLIC_PROCESSING_COST
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p xagent-sandbox metabolic_cost_drains -- --nocapture 2>&1 | tail -10`
+Expected: PASS.
+
+- [ ] **Step 5: Apply metabolic drain in the simulation loop**
+
+In `crates/xagent-sandbox/src/main.rs`, find the CPU agent tick loop (around line 1383) where `physics::step` is called. After the physics step, add the metabolic drain:
+
+```rust
+                                let consumed = xagent_sandbox::physics::step(
+                                    &mut agent.body, &motor, world, SIM_DT,
+                                );
+
+                                // Metabolic cost: brain capacity drains energy
+                                let brain_drain = xagent_sandbox::physics::metabolic_drain_per_tick(
+                                    agent.brain.config.memory_capacity,
+                                    agent.brain.config.processing_slots,
+                                );
+                                agent.body.body.internal.energy -= brain_drain;
+```
+
+Also find the GPU agent tick path (around line 1292-1303) and add the same drain there. Look for the equivalent `physics::step` call in the GPU path and add the drain after it.
+
+- [ ] **Step 6: Run the full sandbox test suite**
+
+Run: `cargo test -p xagent-sandbox -- --nocapture 2>&1 | tail -30`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/xagent-sandbox/src/physics/mod.rs crates/xagent-sandbox/src/main.rs crates/xagent-sandbox/tests/integration.rs
+git commit -m "feat: add metabolic energy drain proportional to brain capacity"
+```
+
+---
+
+### Task 6: Export RecalledPattern from xagent-brain crate
+
+**Files:**
+- Modify: `crates/xagent-brain/src/lib.rs` (public exports)
+
+- [ ] **Step 1: Add RecalledPattern to public exports**
+
+In `crates/xagent-brain/src/lib.rs`, find where `PatternMemory` or other memory types are exported. Add `RecalledPattern` to the public API:
+
+```rust
+pub use memory::RecalledPattern;
+```
+
+If there's no existing re-export of memory types, add the line to the `pub use` block or `pub mod memory` declaration.
+
+- [ ] **Step 2: Verify full compilation**
+
+Run: `cargo check -p xagent-sandbox`
+Expected: Clean compilation with no errors.
+
+- [ ] **Step 3: Run all tests across both crates**
+
+Run: `cargo test -p xagent-brain && cargo test -p xagent-sandbox`
+Expected: All tests pass in both crates.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/xagent-brain/src/lib.rs
+git commit -m "feat: export RecalledPattern from xagent-brain public API"
+```
+
+---
+
+### Task 7: Final Integration Verification
+
+**Files:**
+- No new files — verification only
+
+- [ ] **Step 1: Run cargo check on the entire workspace**
+
+Run: `cargo check`
+Expected: Clean compilation across all crates.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `cargo test -p xagent-sandbox`
+Expected: All 87+ tests pass (existing + new tests).
+
+- [ ] **Step 3: Run cargo clippy**
+
+Run: `cargo clippy -p xagent-brain -p xagent-sandbox -- -D warnings 2>&1 | tail -20`
+Expected: No warnings.
+
+- [ ] **Step 4: Commit any clippy fixes if needed**
+
+```bash
+git add -A && git commit -m "fix: address clippy warnings from episodic motor memory changes"
+```
+
+(Skip if no warnings.)

--- a/docs/superpowers/specs/2026-04-03-episodic-motor-memory-design.md
+++ b/docs/superpowers/specs/2026-04-03-episodic-motor-memory-design.md
@@ -1,0 +1,172 @@
+# Episodic Motor Memory & Memory-Fitness Fix
+
+**Date:** 2026-04-03
+**Status:** Approved
+
+## Problem
+
+Evolution converges memory_capacity and processing_slots to 1 (minimum) across all top-performing agents. The best fitness score (~0.33) is achieved by agents with effectively no memory. This is paradoxical — agents with no memory shouldn't outperform agents that can learn from experience.
+
+### Root Causes
+
+1. **Memory suppresses exploration.** The exploration rate formula in `action.rs:148-152` uses `recalled.len() / 16.0` as a "stability" metric that reduces exploration. Agents with larger memory recall more patterns, explore less, and follow an untrained policy (weights ≈ 0) — effectively paralyzing themselves. Agents with memory_capacity=1 stay exploratory and stumble into food/exploration by random movement.
+
+2. **Memory doesn't inform actions.** Recalled patterns are not used in motor output computation at all. The action selector computes `forward = dot(weights, current_state) + bias` — purely reactive. Recalled patterns only blend weakly into the predictor's next-state forecast (via `context_weight=0.2`). Memory has no direct pathway to help the agent choose better actions.
+
+3. **No metabolic cost.** There is no penalty for having memory_capacity=1. Once evolution ratchets down to 1 (via the `.max(1)` floor in mutation), it can only escape via a lucky upward mutation — which is then selected against because of cause #1.
+
+## Design
+
+### 1. Exploration Rate Fix
+
+**File:** `crates/xagent-brain/src/action.rs`
+
+Replace the recall-count-based stability metric with policy confidence based on raw motor output magnitude.
+
+**Current:**
+```rust
+let stability = recalled.len() as f32 / 16.0;
+self.exploration_rate =
+    (0.5 - stability * 0.15 + novelty_bonus + curiosity_bonus - urgency_penalty).clamp(0.10, 0.85);
+```
+
+**New:**
+```rust
+let raw_signal = fwd.abs() + trn.abs();  // from policy weights × current state
+let policy_confidence = (raw_signal / 2.0).clamp(0.0, 1.0);
+self.exploration_rate =
+    (0.5 - policy_confidence * 0.25 + novelty_bonus + curiosity_bonus - urgency_penalty).clamp(0.10, 0.85);
+```
+
+Properties:
+- Untrained agent (weights ≈ 0) → raw_signal ≈ 0 → high exploration
+- Well-trained agent → strong signal → lower exploration
+- Memory size has no effect on exploration rate
+
+Note: `fwd` and `trn` are already computed at lines 155-160. The exploration rate computation (currently at lines 148-152) must move to after step 4 (raw motor output) since it now depends on those values.
+
+### 2. Episodic Motor Memory
+
+**File:** `crates/xagent-brain/src/memory.rs`
+
+Extend `Pattern` struct with motor context:
+
+```rust
+pub motor_forward: f32,     // motor command active when pattern was stored
+pub motor_turn: f32,        // motor command active when pattern was stored
+pub outcome_valence: f32,   // homeostatic gradient at storage time
+```
+
+#### Store Signature
+
+```rust
+pub fn store(&mut self, state: EncodedState, motor_forward: f32, motor_turn: f32, outcome_valence: f32)
+```
+
+Called from `brain.rs:tick_inner` after action selection, passing:
+- `habituated` — the encoded state
+- `command.forward`, `command.turn` — motor output before fatigue damping (intended action)
+- `homeo_state.raw_gradient` — immediate outcome signal
+
+#### Recall Return Type
+
+Replace `Vec<(EncodedState, f32)>` with a named struct:
+
+```rust
+pub struct RecalledPattern {
+    pub state: EncodedState,
+    pub similarity: f32,
+    pub motor_forward: f32,
+    pub motor_turn: f32,
+    pub outcome_valence: f32,
+}
+```
+
+Both `recall()` and `recall_with_gpu_similarities()` return `Vec<RecalledPattern>`.
+
+#### Memory-Informed Action Selection
+
+**File:** `crates/xagent-brain/src/action.rs`
+
+In `ActionSelector::select`, after computing raw policy output (step 4) and prospective evaluation (step 5), blend in memory suggestions:
+
+```
+memory_fwd = Σ (similarity × valence × stored_forward) / Σ |similarity × valence|
+memory_trn = Σ (similarity × valence × stored_turn)   / Σ |similarity × valence|
+```
+
+Properties:
+- Positive valence → "repeat this action" (reinforce successful behavior)
+- Negative valence → "do the opposite" (sign flip avoids past mistakes)
+- Normalization prevents memory from dominating
+
+Blending:
+```
+let memory_strength = (total_weight / recalled.len().max(1) as f32).clamp(0.0, 1.0);
+let mix = memory_strength * 0.4;  // memory contributes up to 40% of motor signal
+fwd = fwd * (1.0 - mix) + memory_fwd * mix;
+trn = trn * (1.0 - mix) + memory_trn * mix;
+```
+
+### 3. Retroactive Valence Update
+
+**File:** `crates/xagent-brain/src/memory.rs`
+
+Extend `learn()` signature to accept the current gradient:
+
+```rust
+pub fn learn(&mut self, current: &EncodedState, error: f32, learning_rate: f32, gradient: f32)
+```
+
+In the existing similarity loop (where reinforcement is updated), also nudge outcome_valence:
+
+```rust
+let valence_lr = learning_rate * 0.3;
+pat.outcome_valence += sim * valence_lr * (gradient - pat.outcome_valence);
+```
+
+This is an EMA toward the current gradient, weighted by similarity. Properties:
+- Patterns near food accumulate positive valence over multiple eating ticks
+- Patterns near danger accumulate negative valence
+- 0.3 factor makes valence updates slower than reinforcement — a running assessment, not a snap judgment
+- Distant patterns (low similarity) are unaffected
+
+### 4. Metabolic Cost
+
+**File:** Agent simulation loop (governor.rs or agent tick)
+
+Per-tick energy drain proportional to brain capacity:
+
+```
+base_cost = 0.0001          // baseline brain metabolism
+capacity_cost = memory_capacity * 0.00003 + processing_slots * 0.0001
+energy_drain_per_tick = base_cost + capacity_cost
+```
+
+Cost regimes over 50,000 tick budget:
+- (1, 1): 0.00013/tick → 6.5 total — negligible
+- (128, 16): 0.00554/tick → 277 total — meaningful, must forage to offset
+- (2048, 128): 0.07434/tick → 3,717 total — expensive, must demonstrably outperform
+
+Applied by subtracting `energy_drain_per_tick` from the agent's energy before passing `energy_signal` to the brain. The brain perceives its own metabolic cost through the homeostatic system — increased hunger → increased urgency → drives foraging.
+
+The cost coefficients are governor-level world constants, not evolvable. The agent evolves how much capacity to carry; the world dictates what that costs.
+
+## Scope Boundaries
+
+**Not changing:**
+- Predictor's `predict_weighted` — continues blending recalled patterns via `context_weight`, benefits from the same recalled patterns
+- Mutation/crossover logic — perturbation formula and bounds for memory_capacity/processing_slots stay the same
+- Fitness function — survival/foraging/exploration weights stay at 0.4/0.3/0.3; metabolic cost feeds through survival
+- Decay, trauma, association chains — untouched
+- `representation_dim` — stays at 32
+- GPU similarity path — same return type change to `RecalledPattern`, same logic
+
+## Change Footprint
+
+| File | Changes |
+|------|---------|
+| `memory.rs` | `Pattern` struct (3 fields), `RecalledPattern` struct, `store()` signature, `learn()` signature, `recall()` return type, `recall_with_gpu_similarities()` return type |
+| `action.rs` | Exploration rate formula (move after raw motor computation, use policy confidence), memory-informed motor blending in `select()` |
+| `brain.rs` | Wire new signatures through `tick_inner()` — store call moves after action selection, learn call passes gradient |
+| `governor.rs` / agent sim | Metabolic energy drain per tick |


### PR DESCRIPTION
## Summary
- **Exploration rate fix** — replaced recall-count-based exploration (which penalized agents with more memory) with policy-confidence-based exploration
- **Episodic motor memory** — patterns now store motor commands and outcome valence; recalled patterns bias action selection via similarity × valence weighting
- **Retroactive valence update** — `learn()` nudges stored pattern valence toward current homeostatic gradient, so memory reflects outcomes over time
- **Metabolic cost** — per-tick energy drain proportional to `memory_capacity` + `processing_slots`, applied in both windowed and headless paths

## Motivation
Evolution consistently converged `memory_capacity` and `processing_slots` to 1 (minimum) because memory provided no behavioral benefit while having no cost. Three compounding issues: exploration rate penalized recall count, recalled patterns couldn't influence actions, and minimal memory was a free lunch.

## Test plan
- [x] 79 xagent-brain unit tests pass (including 4 new: motor context storage, valence update, valence-biased motor output, tick integration)
- [x] 19 xagent-sandbox integration tests pass (including 1 new: metabolic cost proportional to capacity)
- [x] Clippy clean (no new warnings)
- [ ] Run headless evolution to verify memory_capacity no longer collapses to 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)