### PR TITLE
Fix orbit camera starting below agent on mode entry

### DIFF
--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1360,7 +1360,7 @@ impl ApplicationHandler for App {
                         self.camera.orbit_distance = diff.length().clamp(5.0, 200.0);
                         self.camera.orbit_yaw = diff.z.atan2(diff.x);
                         self.camera.orbit_pitch =
-                            (diff.y / diff.length()).asin().clamp(-1.4, -0.05);
+                            (diff.y / diff.length()).asin().clamp(0.05, 1.4);
                     }
                 }
                 self.camera.orbit_mode = self.orbit_mode;

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1357,9 +1357,10 @@ impl ApplicationHandler for App {
                 if self.orbit_mode && !self.camera.orbit_mode {
                     if let Some(agent) = self.agents.get(self.selected_agent_idx) {
                         let diff = self.camera.position - agent.body.body.position;
-                        self.camera.orbit_distance = diff.length().clamp(5.0, 200.0);
+                        let len = diff.length().max(0.001);
+                        self.camera.orbit_distance = len.clamp(5.0, 200.0);
                         self.camera.orbit_yaw = diff.z.atan2(diff.x);
-                        self.camera.orbit_pitch = (diff.y / diff.length()).asin().clamp(0.05, 1.4);
+                        self.camera.orbit_pitch = (diff.y / len).asin().clamp(0.05, 1.4);
                     }
                 }
                 self.camera.orbit_mode = self.orbit_mode;

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1359,8 +1359,7 @@ impl ApplicationHandler for App {
                         let diff = self.camera.position - agent.body.body.position;
                         self.camera.orbit_distance = diff.length().clamp(5.0, 200.0);
                         self.camera.orbit_yaw = diff.z.atan2(diff.x);
-                        self.camera.orbit_pitch =
-                            (diff.y / diff.length()).asin().clamp(0.05, 1.4);
+                        self.camera.orbit_pitch = (diff.y / diff.length()).asin().clamp(0.05, 1.4);
                     }
                 }
                 self.camera.orbit_mode = self.orbit_mode;


### PR DESCRIPTION
## Summary
- Orbit pitch initialization clamped to `(-1.4, -0.05)` — always negative, placing the camera below the agent on entry
- Mouse drag clamps to `(0.05, 1.4)`, so any interaction would jolt the camera above
- Fixed by aligning the initialization clamp to `(0.05, 1.4)` to match

## Test plan
- [ ] Toggle orbit mode — camera should start above the selected agent, not below
- [ ] Drag to rotate — no sudden pitch flip on first interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)