### PR TITLE
Offload store_recording SQLite write to background thread

### DIFF
--- a/crates/xagent-sandbox/src/governor.rs
+++ b/crates/xagent-sandbox/src/governor.rs
@@ -5,12 +5,23 @@
 //! All state is persisted in a SQLite database (`xagent.db`), enabling resume
 //! and post-hoc analysis of the evolution tree.
 
+use std::sync::mpsc::{self, SyncSender};
+use std::thread::JoinHandle;
+
 use rand::Rng;
 use rusqlite::{params, Connection, Result as SqlResult};
 use serde::Serialize;
 use xagent_shared::{BrainConfig, GovernorConfig};
 
 use crate::momentum::MutationMomentum;
+
+/// Payload sent to the background recording-writer thread.
+struct RecordingPayload {
+    node_id: i64,
+    agent_count: i64,
+    tick_count: i64,
+    data: Vec<u8>,
+}
 
 use crate::agent::{crossover_config, mutate_config_with_strength, Agent, HEATMAP_RES};
 
@@ -85,6 +96,47 @@ pub struct Governor {
     cached_tree_nodes: Option<Vec<TreeNode>>,
     /// Per-island mutation momentum vectors.
     pub momentums: Vec<MutationMomentum>,
+    /// Channel sender for offloading recording writes to a background thread.
+    recording_sender: Option<SyncSender<RecordingPayload>>,
+    /// Handle to the background writer thread (joined on drop).
+    writer_thread: Option<JoinHandle<()>>,
+}
+
+/// Spawn a background thread that owns a dedicated SQLite connection and
+/// drains `RecordingPayload` messages from a bounded channel, writing each
+/// one to the `generation_recording` table.
+fn spawn_recording_writer(db_path: &str) -> (SyncSender<RecordingPayload>, JoinHandle<()>) {
+    let (tx, rx) = mpsc::sync_channel::<RecordingPayload>(4);
+    let path = db_path.to_owned();
+    let handle = std::thread::Builder::new()
+        .name("recording-writer".into())
+        .spawn(move || {
+            let db = match Connection::open(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("[recording-writer] failed to open DB: {e}");
+                    return;
+                }
+            };
+            let _ = db.execute_batch("PRAGMA journal_mode=WAL;");
+            for payload in rx {
+                if let Err(e) = db.execute(
+                    "INSERT OR REPLACE INTO generation_recording \
+                     (node_id, agent_count, tick_count, data) \
+                     VALUES (?1, ?2, ?3, ?4)",
+                    params![
+                        payload.node_id,
+                        payload.agent_count,
+                        payload.tick_count,
+                        payload.data
+                    ],
+                ) {
+                    eprintln!("[recording-writer] DB write failed: {e}");
+                }
+            }
+        })
+        .expect("failed to spawn recording-writer thread");
+    (tx, handle)
 }
 
 impl Governor {
@@ -195,6 +247,8 @@ impl Governor {
             .map(|_| MutationMomentum::new(config.momentum_decay))
             .collect();
 
+        let (tx, handle) = spawn_recording_writer(db_path);
+
         Ok(Self {
             db,
             config,
@@ -207,6 +261,8 @@ impl Governor {
             cached_best_score: -1.0,
             cached_tree_nodes: None,
             momentums,
+            recording_sender: Some(tx),
+            writer_thread: Some(handle),
         })
     }
 
@@ -271,6 +327,8 @@ impl Governor {
         }
         momentums.truncate(num_islands);
 
+        let (tx, handle) = spawn_recording_writer(db_path);
+
         let mut gov = Self {
             db,
             config,
@@ -283,6 +341,8 @@ impl Governor {
             cached_best_score: -1.0,
             cached_tree_nodes: None,
             momentums,
+            recording_sender: Some(tx),
+            writer_thread: Some(handle),
         };
         gov.refresh_best_score();
         Ok(gov)
@@ -917,9 +977,15 @@ impl Governor {
         );
     }
 
-    /// Store a generation's recording as a little-endian f32 BLOB in the
-    /// database.  `recording` is the `GenerationRecording` to persist.
+    /// Serialize a generation's recording and send it to the background
+    /// writer thread for asynchronous SQLite persistence.  Never blocks
+    /// the caller — if the channel is full a warning is logged and the
+    /// recording is dropped.
     pub fn store_recording(&self, recording: &crate::replay::GenerationRecording) {
+        let sender = match self.recording_sender.as_ref() {
+            Some(s) => s,
+            None => return,
+        };
         let node_id = match self.current_node_id {
             Some(id) => id,
             None => return,
@@ -986,12 +1052,17 @@ impl Governor {
             return;
         }
 
-        let _ = self.db.execute(
-            "INSERT OR REPLACE INTO generation_recording \
-             (node_id, agent_count, tick_count, data)
-             VALUES (?1, ?2, ?3, ?4)",
-            params![node_id, agent_count, tick_count, bytes],
-        );
+        let payload = RecordingPayload {
+            node_id,
+            agent_count,
+            tick_count,
+            data: bytes,
+        };
+
+        if let Err(mpsc::TrySendError::Full(_)) = sender.try_send(payload) {
+            eprintln!("[governor] recording channel full — dropping recording for node {node_id}");
+        }
+        // TrySendError::Disconnected is silently ignored (writer thread died).
     }
 
     /// Load a generation's recording from the database.
@@ -1146,6 +1217,16 @@ impl Governor {
             }
         }
         map
+    }
+}
+
+impl Drop for Governor {
+    fn drop(&mut self) {
+        // Drop the sender first so the writer thread's recv loop exits.
+        drop(self.recording_sender.take());
+        if let Some(handle) = self.writer_thread.take() {
+            let _ = handle.join();
+        }
     }
 }
 

--- a/crates/xagent-sandbox/src/governor.rs
+++ b/crates/xagent-sandbox/src/governor.rs
@@ -218,7 +218,9 @@ impl Governor {
         world_config_json: &str,
     ) -> SqlResult<Self> {
         let db = Connection::open(db_path)?;
-        db.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        db.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
+        )?;
         init_schema(&db)?;
 
         let governor_json = serde_json::to_string(&config).unwrap_or_default();
@@ -257,9 +259,15 @@ impl Governor {
             .map(|_| MutationMomentum::new(config.momentum_decay))
             .collect();
 
-        let (recording_sender, writer_thread) = match spawn_recording_writer(db_path) {
-            Some((tx, h)) => (Some(tx), Some(h)),
-            None => (None, None),
+        // Skip background writer for in-memory DBs — each Connection::open(":memory:")
+        // creates an independent database, so the writer thread would not see the schema.
+        let (recording_sender, writer_thread) = if db_path == ":memory:" {
+            (None, None)
+        } else {
+            match spawn_recording_writer(db_path) {
+                Some((tx, h)) => (Some(tx), Some(h)),
+                None => (None, None),
+            }
         };
 
         Ok(Self {
@@ -283,7 +291,9 @@ impl Governor {
     /// for the most recent run.
     pub fn resume(db_path: &str) -> SqlResult<Self> {
         let db = Connection::open(db_path)?;
-        db.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        db.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
+        )?;
 
         // Run migrations for any new columns (idempotent — silently ignores duplicates)
         let _ = db.execute_batch("ALTER TABLE node ADD COLUMN island_id INTEGER;");
@@ -340,9 +350,14 @@ impl Governor {
         }
         momentums.truncate(num_islands);
 
-        let (recording_sender, writer_thread) = match spawn_recording_writer(db_path) {
-            Some((tx, h)) => (Some(tx), Some(h)),
-            None => (None, None),
+        // Skip background writer for in-memory DBs (see Governor::new for rationale).
+        let (recording_sender, writer_thread) = if db_path == ":memory:" {
+            (None, None)
+        } else {
+            match spawn_recording_writer(db_path) {
+                Some((tx, h)) => (Some(tx), Some(h)),
+                None => (None, None),
+            }
         };
 
         let mut gov = Self {

--- a/crates/xagent-sandbox/src/governor.rs
+++ b/crates/xagent-sandbox/src/governor.rs
@@ -105,7 +105,10 @@ pub struct Governor {
 /// Spawn a background thread that owns a dedicated SQLite connection and
 /// drains `RecordingPayload` messages from a bounded channel, writing each
 /// one to the `generation_recording` table.
-fn spawn_recording_writer(db_path: &str) -> (SyncSender<RecordingPayload>, JoinHandle<()>) {
+///
+/// Returns `None` if the thread cannot be spawned, allowing the caller to
+/// continue without recording support.
+fn spawn_recording_writer(db_path: &str) -> Option<(SyncSender<RecordingPayload>, JoinHandle<()>)> {
     let (tx, rx) = mpsc::sync_channel::<RecordingPayload>(4);
     let path = db_path.to_owned();
     let handle = std::thread::Builder::new()
@@ -114,11 +117,13 @@ fn spawn_recording_writer(db_path: &str) -> (SyncSender<RecordingPayload>, JoinH
             let db = match Connection::open(&path) {
                 Ok(c) => c,
                 Err(e) => {
-                    eprintln!("[recording-writer] failed to open DB: {e}");
+                    log::error!("[recording-writer] failed to open DB: {e}");
                     return;
                 }
             };
-            let _ = db.execute_batch("PRAGMA journal_mode=WAL;");
+            let _ = db.execute_batch(
+                "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
+            );
             for payload in rx {
                 if let Err(e) = db.execute(
                     "INSERT OR REPLACE INTO generation_recording \
@@ -131,12 +136,17 @@ fn spawn_recording_writer(db_path: &str) -> (SyncSender<RecordingPayload>, JoinH
                         payload.data
                     ],
                 ) {
-                    eprintln!("[recording-writer] DB write failed: {e}");
+                    log::error!("[recording-writer] DB write failed: {e}");
                 }
             }
-        })
-        .expect("failed to spawn recording-writer thread");
-    (tx, handle)
+        });
+    match handle {
+        Ok(h) => Some((tx, h)),
+        Err(e) => {
+            log::warn!("[recording-writer] failed to spawn thread: {e} — recording disabled");
+            None
+        }
+    }
 }
 
 impl Governor {
@@ -247,7 +257,10 @@ impl Governor {
             .map(|_| MutationMomentum::new(config.momentum_decay))
             .collect();
 
-        let (tx, handle) = spawn_recording_writer(db_path);
+        let (recording_sender, writer_thread) = match spawn_recording_writer(db_path) {
+            Some((tx, h)) => (Some(tx), Some(h)),
+            None => (None, None),
+        };
 
         Ok(Self {
             db,
@@ -261,8 +274,8 @@ impl Governor {
             cached_best_score: -1.0,
             cached_tree_nodes: None,
             momentums,
-            recording_sender: Some(tx),
-            writer_thread: Some(handle),
+            recording_sender,
+            writer_thread,
         })
     }
 
@@ -327,7 +340,10 @@ impl Governor {
         }
         momentums.truncate(num_islands);
 
-        let (tx, handle) = spawn_recording_writer(db_path);
+        let (recording_sender, writer_thread) = match spawn_recording_writer(db_path) {
+            Some((tx, h)) => (Some(tx), Some(h)),
+            None => (None, None),
+        };
 
         let mut gov = Self {
             db,
@@ -341,8 +357,8 @@ impl Governor {
             cached_best_score: -1.0,
             cached_tree_nodes: None,
             momentums,
-            recording_sender: Some(tx),
-            writer_thread: Some(handle),
+            recording_sender,
+            writer_thread,
         };
         gov.refresh_best_score();
         Ok(gov)
@@ -977,10 +993,10 @@ impl Governor {
         );
     }
 
-    /// Serialize a generation's recording and send it to the background
-    /// writer thread for asynchronous SQLite persistence.  Never blocks
-    /// the caller — if the channel is full a warning is logged and the
-    /// recording is dropped.
+    /// Serialize a generation's recording (synchronous) and send the
+    /// resulting blob to the background writer thread for asynchronous
+    /// SQLite persistence.  The channel send is non-blocking — if the
+    /// channel is full a warning is logged and the recording is dropped.
     pub fn store_recording(&self, recording: &crate::replay::GenerationRecording) {
         let sender = match self.recording_sender.as_ref() {
             Some(s) => s,
@@ -1060,7 +1076,7 @@ impl Governor {
         };
 
         if let Err(mpsc::TrySendError::Full(_)) = sender.try_send(payload) {
-            eprintln!("[governor] recording channel full — dropping recording for node {node_id}");
+            log::warn!("[governor] recording channel full — dropping recording for node {node_id}");
         }
         // TrySendError::Disconnected is silently ignored (writer thread died).
     }

--- a/crates/xagent-sandbox/src/governor.rs
+++ b/crates/xagent-sandbox/src/governor.rs
@@ -151,8 +151,14 @@ fn spawn_recording_writer(db_path: &str) -> Option<(SyncSender<RecordingPayload>
             // Wait for the writer thread to confirm successful DB setup.
             // If it exits early (DB open/config failure), the ready_tx is
             // dropped and recv returns Err — disable recording in that case.
-            match ready_rx.recv() {
+            match ready_rx.recv_timeout(std::time::Duration::from_secs(5)) {
                 Ok(()) => Some((tx, h)),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    log::warn!(
+                        "[recording-writer] writer thread did not signal ready within 5 s — recording disabled"
+                    );
+                    None
+                }
                 Err(_) => {
                     log::warn!(
                         "[recording-writer] writer thread failed DB setup — recording disabled"
@@ -1283,7 +1289,17 @@ impl Drop for Governor {
         // Drop the sender first so the writer thread's recv loop exits.
         drop(self.recording_sender.take());
         if let Some(handle) = self.writer_thread.take() {
-            let _ = handle.join();
+            match handle.join() {
+                Ok(()) => {}
+                Err(payload) => {
+                    let msg = payload
+                        .downcast_ref::<&str>()
+                        .copied()
+                        .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
+                        .unwrap_or("(non-string panic)");
+                    log::error!("[recording-writer] thread panicked: {msg}");
+                }
+            }
         }
     }
 }

--- a/crates/xagent-sandbox/src/governor.rs
+++ b/crates/xagent-sandbox/src/governor.rs
@@ -121,9 +121,12 @@ fn spawn_recording_writer(db_path: &str) -> Option<(SyncSender<RecordingPayload>
                     return;
                 }
             };
-            let _ = db.execute_batch(
+            if let Err(e) = db.execute_batch(
                 "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
-            );
+            ) {
+                log::error!("[recording-writer] PRAGMA configuration failed: {e}");
+                return;
+            }
             for payload in rx {
                 if let Err(e) = db.execute(
                     "INSERT OR REPLACE INTO generation_recording \

--- a/crates/xagent-sandbox/src/governor.rs
+++ b/crates/xagent-sandbox/src/governor.rs
@@ -110,6 +110,7 @@ pub struct Governor {
 /// continue without recording support.
 fn spawn_recording_writer(db_path: &str) -> Option<(SyncSender<RecordingPayload>, JoinHandle<()>)> {
     let (tx, rx) = mpsc::sync_channel::<RecordingPayload>(4);
+    let (ready_tx, ready_rx) = mpsc::sync_channel::<()>(1);
     let path = db_path.to_owned();
     let handle = std::thread::Builder::new()
         .name("recording-writer".into())
@@ -127,6 +128,8 @@ fn spawn_recording_writer(db_path: &str) -> Option<(SyncSender<RecordingPayload>
                 log::error!("[recording-writer] PRAGMA configuration failed: {e}");
                 return;
             }
+            // Signal that DB setup succeeded before entering the receive loop.
+            let _ = ready_tx.send(());
             for payload in rx {
                 if let Err(e) = db.execute(
                     "INSERT OR REPLACE INTO generation_recording \
@@ -144,7 +147,20 @@ fn spawn_recording_writer(db_path: &str) -> Option<(SyncSender<RecordingPayload>
             }
         });
     match handle {
-        Ok(h) => Some((tx, h)),
+        Ok(h) => {
+            // Wait for the writer thread to confirm successful DB setup.
+            // If it exits early (DB open/config failure), the ready_tx is
+            // dropped and recv returns Err — disable recording in that case.
+            match ready_rx.recv() {
+                Ok(()) => Some((tx, h)),
+                Err(_) => {
+                    log::warn!(
+                        "[recording-writer] writer thread failed DB setup — recording disabled"
+                    );
+                    None
+                }
+            }
+        }
         Err(e) => {
             log::warn!("[recording-writer] failed to spawn thread: {e} — recording disabled");
             None
@@ -1015,7 +1031,7 @@ impl Governor {
     /// resulting blob to the background writer thread for asynchronous
     /// SQLite persistence.  The channel send is non-blocking — if the
     /// channel is full a warning is logged and the recording is dropped.
-    pub fn store_recording(&self, recording: &crate::replay::GenerationRecording) {
+    pub fn store_recording(&mut self, recording: &crate::replay::GenerationRecording) {
         let sender = match self.recording_sender.as_ref() {
             Some(s) => s,
             None => return,
@@ -1093,10 +1109,18 @@ impl Governor {
             data: bytes,
         };
 
-        if let Err(mpsc::TrySendError::Full(_)) = sender.try_send(payload) {
-            log::warn!("[governor] recording channel full — dropping recording for node {node_id}");
+        match sender.try_send(payload) {
+            Ok(()) => {}
+            Err(mpsc::TrySendError::Full(_)) => {
+                log::warn!(
+                    "[governor] recording channel full — dropping recording for node {node_id}"
+                );
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                log::warn!("[governor] recording writer thread died — disabling recording");
+                self.recording_sender = None;
+            }
         }
-        // TrySendError::Disconnected is silently ignored (writer thread died).
     }
 
     /// Load a generation's recording from the database.

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -754,7 +754,7 @@ impl App {
     /// Evaluate the current generation, advance to the next (or finish).
     fn advance_generation(&mut self) {
         // Persist the recording to SQLite before moving to the next generation
-        if let (Some(ref recording), Some(ref gov)) = (&self.recording, &self.governor) {
+        if let (Some(ref recording), Some(ref mut gov)) = (&self.recording, &mut self.governor) {
             gov.store_recording(recording);
         }
         self.last_recording = self.recording.take();


### PR DESCRIPTION
Closes #29

## Summary
- Spawns a dedicated `recording-writer` thread with its own WAL-mode SQLite connection
- `store_recording` sends serialized payload over a bounded `sync_channel(4)` via `try_send` — never blocks the main thread
- If the channel is full, logs a warning and drops the recording
- Clean shutdown via `Drop`: drops sender, joins writer thread to flush pending writes

## Test plan
- [ ] Run simulation through multiple generations — recordings still appear in DB
- [ ] No frame hitches at generation boundaries from recording writes
- [ ] Clean app shutdown — no hanging threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)