### PR TITLE
Make generation-boundary GPU operations non-blocking

### DIFF
--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -1347,7 +1347,18 @@ impl GpuKernel {
 
     /// Non-blocking: kick off async readback of one agent's brain state.
     /// Results are collected via `try_collect_agent_state`.
-    pub fn request_agent_state(&mut self, index: u32) {
+    pub fn request_agent_state(&mut self, index: u32) -> bool {
+        if index >= self.agent_count {
+            log::warn!(
+                "[GPU] request_agent_state: index {index} out of bounds (agent_count={})",
+                self.agent_count
+            );
+            return false;
+        }
+        if self.agent_state_staging.is_some() {
+            log::warn!("[GPU] request_agent_state: previous readback still in flight — skipping");
+            return false;
+        }
         let i = index as usize;
         let bs = self.layout.brain_stride;
 
@@ -1436,6 +1447,7 @@ impl GpuKernel {
             had_error,
             brain_stride: bs,
         });
+        true
     }
 
     /// Non-blocking poll: returns `Some(Some(state))` when ready,

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -27,6 +27,18 @@ pub struct AgentTelemetry {
     pub exploration_rate: f32,
 }
 
+/// In-flight async readback of a single agent's brain state.
+struct AgentStateReadback {
+    brain_staging: wgpu::Buffer,
+    pattern_staging: wgpu::Buffer,
+    history_staging: wgpu::Buffer,
+    brain_size: u64,
+    pattern_size: u64,
+    history_size: u64,
+    ready: Arc<AtomicBool>,
+    brain_stride: usize,
+}
+
 /// Terrain heightmap vertices per side.
 const TERRAIN_VPS: usize = 129;
 /// Biome grid resolution (cells per side).
@@ -76,6 +88,9 @@ pub struct GpuKernel {
     staging_in_flight: [bool; 2],        // submitted, not yet collected
     staging_ready: [Arc<AtomicBool>; 2], // map_async callback fired
     state_cache: Vec<f32>,
+
+    // ── Async agent-state readback (for non-blocking generation transitions) ──
+    agent_state_staging: Option<AgentStateReadback>,
 
     // ── Config ──
     world_config: WorldConfig,
@@ -867,6 +882,7 @@ impl GpuKernel {
             state_cache: vec![0.0; n * PHYS_STRIDE],
             world_config: world_config.clone(),
             layout,
+            agent_state_staging: None,
             brain_tick_stride,
             has_subgroup,
         }
@@ -1324,6 +1340,208 @@ impl GpuKernel {
             hist_offset,
             bytemuck::cast_slice(&state.history),
         );
+    }
+
+    /// Non-blocking: kick off async readback of one agent's brain state.
+    /// Results are collected via `try_collect_agent_state`.
+    pub fn request_agent_state(&mut self, index: u32) {
+        let i = index as usize;
+        let bs = self.layout.brain_stride;
+
+        let brain_size = (bs * 4) as u64;
+        let pat_size = (PATTERN_STRIDE * 4) as u64;
+        let hist_size = (HISTORY_STRIDE * 4) as u64;
+
+        let make_staging = |label, size| {
+            self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(label),
+                size,
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            })
+        };
+
+        let brain_staging = make_staging("agent_state_brain_staging", brain_size);
+        let pattern_staging = make_staging("agent_state_pattern_staging", pat_size);
+        let history_staging = make_staging("agent_state_history_staging", hist_size);
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("agent_state_readback"),
+            });
+
+        let brain_offset = (i * bs * 4) as u64;
+        encoder.copy_buffer_to_buffer(
+            &self.brain_state_buf,
+            brain_offset,
+            &brain_staging,
+            0,
+            brain_size,
+        );
+        let pat_offset = (i * PATTERN_STRIDE * 4) as u64;
+        encoder.copy_buffer_to_buffer(&self.pattern_buf, pat_offset, &pattern_staging, 0, pat_size);
+        let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
+        encoder.copy_buffer_to_buffer(
+            &self.history_buf,
+            hist_offset,
+            &history_staging,
+            0,
+            hist_size,
+        );
+
+        self.queue.submit(std::iter::once(encoder.finish()));
+
+        // Set up map_async on all three staging buffers. We use a single
+        // shared ready flag: the last map_async callback to fire sets it.
+        // Since all three copies are in the same command encoder submission,
+        // wgpu maps them in order; the history buffer (last) signals ready.
+        let ready = Arc::new(AtomicBool::new(false));
+
+        brain_staging
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, |_| {});
+        pattern_staging
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, |_| {});
+        let flag = ready.clone();
+        history_staging
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, move |result| {
+                if result.is_ok() {
+                    flag.store(true, Ordering::Release);
+                }
+            });
+
+        self.agent_state_staging = Some(AgentStateReadback {
+            brain_staging,
+            pattern_staging,
+            history_staging,
+            brain_size,
+            pattern_size: pat_size,
+            history_size: hist_size,
+            ready,
+            brain_stride: bs,
+        });
+    }
+
+    /// Non-blocking poll: returns Some(state) when the async readback is
+    /// complete, None if still in flight or nothing was requested.
+    pub fn try_collect_agent_state(&mut self) -> Option<AgentBrainState> {
+        let readback = self.agent_state_staging.as_ref()?;
+        self.device.poll(wgpu::Maintain::Poll);
+        if !readback.ready.load(Ordering::Acquire) {
+            return None;
+        }
+
+        let readback = self.agent_state_staging.take().unwrap();
+        let mut state = AgentBrainState::new_for(readback.brain_stride);
+
+        let brain_data = readback.brain_staging.slice(..readback.brain_size);
+        let mapped = brain_data.get_mapped_range();
+        state.brain_state.clear();
+        state
+            .brain_state
+            .extend_from_slice(bytemuck::cast_slice(&mapped));
+        drop(mapped);
+        readback.brain_staging.unmap();
+
+        let pat_data = readback.pattern_staging.slice(..readback.pattern_size);
+        let mapped = pat_data.get_mapped_range();
+        state.patterns.clear();
+        state
+            .patterns
+            .extend_from_slice(bytemuck::cast_slice(&mapped));
+        drop(mapped);
+        readback.pattern_staging.unmap();
+
+        let hist_data = readback.history_staging.slice(..readback.history_size);
+        let mapped = hist_data.get_mapped_range();
+        state.history.clear();
+        state
+            .history
+            .extend_from_slice(bytemuck::cast_slice(&mapped));
+        drop(mapped);
+        readback.history_staging.unmap();
+
+        Some(state)
+    }
+
+    /// Batch-upload brain states for all agents in a single write per buffer.
+    /// `states` is a closure that returns the `AgentBrainState` for agent index `i`.
+    pub fn batch_write_agent_states<F>(&self, count: usize, states: F)
+    where
+        F: Fn(usize) -> AgentBrainState,
+    {
+        let bs = self.layout.brain_stride;
+        let mut brain_data = Vec::with_capacity(count * bs);
+        let mut pattern_data = Vec::with_capacity(count * PATTERN_STRIDE);
+        let mut history_data = Vec::with_capacity(count * HISTORY_STRIDE);
+
+        for i in 0..count {
+            let s = states(i);
+            brain_data.extend_from_slice(&s.brain_state);
+            pattern_data.extend_from_slice(&s.patterns);
+            history_data.extend_from_slice(&s.history);
+        }
+
+        self.queue
+            .write_buffer(&self.brain_state_buf, 0, bytemuck::cast_slice(&brain_data));
+        self.queue
+            .write_buffer(&self.pattern_buf, 0, bytemuck::cast_slice(&pattern_data));
+        self.queue
+            .write_buffer(&self.history_buf, 0, bytemuck::cast_slice(&history_data));
+    }
+
+    /// Non-blocking version of `reset_agents`. Returns false if async staging
+    /// buffers are still in flight (caller should retry next frame).
+    pub fn try_reset_agents(&mut self, brain_config: &BrainConfig) -> bool {
+        // Check if any staging buffer is still in flight.
+        for i in 0..2 {
+            if self.staging_in_flight[i] {
+                self.device.poll(wgpu::Maintain::Poll);
+                if !self.staging_ready[i].load(Ordering::Acquire) {
+                    return false; // not ready yet — caller retries next frame
+                }
+                let buf_size = (self.agent_count as usize * PHYS_STRIDE * 4) as u64;
+                let slice = self.state_staging[i].slice(..buf_size);
+                let _data = slice.get_mapped_range();
+                drop(_data);
+                self.state_staging[i].unmap();
+                self.staging_in_flight[i] = false;
+            }
+            self.staging_ready[i].store(false, Ordering::Release);
+        }
+        self.staging_idx = 0;
+
+        let n = self.agent_count as usize;
+
+        // Fresh brain state, pattern memory, and action history.
+        let mut rng = rand::rng();
+        let mut brain_data = Vec::with_capacity(n * self.layout.brain_stride);
+        let mut pattern_data = Vec::with_capacity(n * PATTERN_STRIDE);
+        let mut history_data = Vec::with_capacity(n * HISTORY_STRIDE);
+        for _ in 0..n {
+            brain_data.extend_from_slice(&init_brain_state_for(
+                brain_config,
+                &self.layout,
+                &mut rng,
+            ));
+            pattern_data.extend_from_slice(&init_pattern_memory());
+            history_data.extend_from_slice(&init_action_history());
+        }
+        self.queue
+            .write_buffer(&self.brain_state_buf, 0, bytemuck::cast_slice(&brain_data));
+        self.queue
+            .write_buffer(&self.pattern_buf, 0, bytemuck::cast_slice(&pattern_data));
+        self.queue
+            .write_buffer(&self.history_buf, 0, bytemuck::cast_slice(&history_data));
+        self.queue.write_buffer(
+            &self.brain_config_buf,
+            0,
+            bytemuck::cast_slice(&build_config_for(brain_config, &self.layout)),
+        );
+        true
     }
 
     /// Helper: blocking read of a buffer range into a pre-sized Vec<f32>.

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -3,7 +3,7 @@
 //! Composes all phase WGSL fragments into one shader, creates a unified
 //! buffer set and pipeline, and runs N ticks per dispatch(1,1,1).
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use wgpu;
@@ -35,7 +35,10 @@ struct AgentStateReadback {
     brain_size: u64,
     pattern_size: u64,
     history_size: u64,
-    ready: Arc<AtomicBool>,
+    /// Counts how many of the 3 map_async callbacks have fired successfully.
+    mapped_count: Arc<AtomicU8>,
+    /// Set if any map_async callback reports an error.
+    had_error: Arc<AtomicBool>,
     brain_stride: usize,
 }
 
@@ -1392,26 +1395,35 @@ impl GpuKernel {
 
         self.queue.submit(std::iter::once(encoder.finish()));
 
-        // Set up map_async on all three staging buffers. We use a single
-        // shared ready flag: the last map_async callback to fire sets it.
-        // Since all three copies are in the same command encoder submission,
-        // wgpu maps them in order; the history buffer (last) signals ready.
-        let ready = Arc::new(AtomicBool::new(false));
+        // Set up map_async on all three staging buffers. Each callback
+        // increments a shared counter; we only consider the readback ready
+        // when all 3 have completed. If any fails, we set an error flag so
+        // the caller can abandon the readback instead of hanging forever.
+        let mapped_count = Arc::new(AtomicU8::new(0));
+        let had_error = Arc::new(AtomicBool::new(false));
 
-        brain_staging
-            .slice(..)
-            .map_async(wgpu::MapMode::Read, |_| {});
-        pattern_staging
-            .slice(..)
-            .map_async(wgpu::MapMode::Read, |_| {});
-        let flag = ready.clone();
-        history_staging
-            .slice(..)
-            .map_async(wgpu::MapMode::Read, move |result| {
+        let make_callback = |count: Arc<AtomicU8>, err: Arc<AtomicBool>| {
+            move |result: Result<(), wgpu::BufferAsyncError>| {
                 if result.is_ok() {
-                    flag.store(true, Ordering::Release);
+                    count.fetch_add(1, Ordering::Release);
+                } else {
+                    err.store(true, Ordering::Release);
                 }
-            });
+            }
+        };
+
+        brain_staging.slice(..).map_async(
+            wgpu::MapMode::Read,
+            make_callback(mapped_count.clone(), had_error.clone()),
+        );
+        pattern_staging.slice(..).map_async(
+            wgpu::MapMode::Read,
+            make_callback(mapped_count.clone(), had_error.clone()),
+        );
+        history_staging.slice(..).map_async(
+            wgpu::MapMode::Read,
+            make_callback(mapped_count.clone(), had_error.clone()),
+        );
 
         self.agent_state_staging = Some(AgentStateReadback {
             brain_staging,
@@ -1420,18 +1432,37 @@ impl GpuKernel {
             brain_size,
             pattern_size: pat_size,
             history_size: hist_size,
-            ready,
+            mapped_count,
+            had_error,
             brain_stride: bs,
         });
     }
 
-    /// Non-blocking poll: returns Some(state) when the async readback is
-    /// complete, None if still in flight or nothing was requested.
-    pub fn try_collect_agent_state(&mut self) -> Option<AgentBrainState> {
+    /// Non-blocking poll: returns `Some(Some(state))` when ready,
+    /// `Some(None)` if a map_async error occurred (readback abandoned),
+    /// or `None` if still in flight or nothing was requested.
+    pub fn try_collect_agent_state(&mut self) -> Option<Option<AgentBrainState>> {
         let readback = self.agent_state_staging.as_ref()?;
         self.device.poll(wgpu::Maintain::Poll);
-        if !readback.ready.load(Ordering::Acquire) {
-            return None;
+
+        // If any mapping failed, abandon the readback.
+        if readback.had_error.load(Ordering::Acquire) {
+            log::error!("[GPU] agent-state map_async failed — abandoning readback");
+            let rb = self.agent_state_staging.take().unwrap();
+            // Unmap any buffers that did succeed to avoid leaking.
+            let _ =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| rb.brain_staging.unmap()));
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                rb.pattern_staging.unmap()
+            }));
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                rb.history_staging.unmap()
+            }));
+            return Some(None);
+        }
+
+        if readback.mapped_count.load(Ordering::Acquire) < 3 {
+            return None; // not all 3 buffers mapped yet
         }
 
         let readback = self.agent_state_staging.take().unwrap();
@@ -1464,7 +1495,7 @@ impl GpuKernel {
         drop(mapped);
         readback.history_staging.unmap();
 
-        Some(state)
+        Some(Some(state))
     }
 
     /// Batch-upload brain states for all agents in a single write per buffer.
@@ -1473,6 +1504,11 @@ impl GpuKernel {
     where
         F: Fn(usize) -> AgentBrainState,
     {
+        debug_assert_eq!(
+            count, self.agent_count as usize,
+            "batch_write_agent_states: count ({}) != agent_count ({})",
+            count, self.agent_count
+        );
         let bs = self.layout.brain_stride;
         let mut brain_data = Vec::with_capacity(count * bs);
         let mut pattern_data = Vec::with_capacity(count * PATTERN_STRIDE);

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -1516,10 +1516,38 @@ impl GpuKernel {
 
         for i in 0..count {
             let s = states(i);
+            debug_assert_eq!(
+                s.brain_state.len(),
+                bs,
+                "agent {}: brain_state length {} != brain_stride {}",
+                i,
+                s.brain_state.len(),
+                bs
+            );
+            debug_assert_eq!(
+                s.patterns.len(),
+                PATTERN_STRIDE,
+                "agent {}: patterns length {} != PATTERN_STRIDE {}",
+                i,
+                s.patterns.len(),
+                PATTERN_STRIDE
+            );
+            debug_assert_eq!(
+                s.history.len(),
+                HISTORY_STRIDE,
+                "agent {}: history length {} != HISTORY_STRIDE {}",
+                i,
+                s.history.len(),
+                HISTORY_STRIDE
+            );
             brain_data.extend_from_slice(&s.brain_state);
             pattern_data.extend_from_slice(&s.patterns);
             history_data.extend_from_slice(&s.history);
         }
+
+        debug_assert_eq!(brain_data.len(), count * bs);
+        debug_assert_eq!(pattern_data.len(), count * PATTERN_STRIDE);
+        debug_assert_eq!(history_data.len(), count * HISTORY_STRIDE);
 
         self.queue
             .write_buffer(&self.brain_state_buf, 0, bytemuck::cast_slice(&brain_data));

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -243,6 +243,8 @@ enum GenTransition {
     AwaitingReset {
         result: AdvanceResult,
         inherited_state: Option<AgentBrainState>,
+        /// Whether population has already been spawned (prevents re-spawn on retry).
+        spawned: bool,
     },
 }
 
@@ -823,6 +825,7 @@ impl App {
                     self.gen_transition = Some(GenTransition::AwaitingReset {
                         result,
                         inherited_state: None,
+                        spawned: false,
                     });
                     return true;
                 }
@@ -831,11 +834,21 @@ impl App {
                 let collected = self.gpu_kernel.as_mut().unwrap().try_collect_agent_state();
 
                 match collected {
-                    Some(state) => {
+                    Some(Some(state)) => {
                         // Readback complete — move to reset phase.
                         self.gen_transition = Some(GenTransition::AwaitingReset {
                             result,
                             inherited_state: Some(state),
+                            spawned: false,
+                        });
+                    }
+                    Some(None) => {
+                        // map_async error — proceed without inherited state
+                        // rather than hanging in AwaitingReadback forever.
+                        self.gen_transition = Some(GenTransition::AwaitingReset {
+                            result,
+                            inherited_state: None,
+                            spawned: false,
                         });
                     }
                     None => {
@@ -848,30 +861,48 @@ impl App {
             GenTransition::AwaitingReset {
                 result,
                 inherited_state,
+                spawned,
             } => {
-                self.finish_generation(result, inherited_state);
+                let (done, spawned) =
+                    self.try_finish_generation(&result, &inherited_state, spawned);
+                if !done {
+                    // Reset not ready yet — re-enqueue for next frame.
+                    self.gen_transition = Some(GenTransition::AwaitingReset {
+                        result,
+                        inherited_state,
+                        spawned,
+                    });
+                    return true;
+                }
                 false
             }
         }
     }
 
-    /// Complete a generation transition once readback data is available.
-    fn finish_generation(
+    /// Try to complete a generation transition. Returns `(done, spawned)`
+    /// where `done` is false if the GPU staging buffers aren't ready yet
+    /// (caller should retry next frame), and `spawned` tracks whether
+    /// population has been spawned (to avoid re-spawning on retry).
+    fn try_finish_generation(
         &mut self,
-        result: AdvanceResult,
-        inherited_state: Option<AgentBrainState>,
-    ) {
+        result: &AdvanceResult,
+        inherited_state: &Option<AgentBrainState>,
+        mut spawned: bool,
+    ) -> (bool, bool) {
         match result {
             AdvanceResult::Continue {
                 configs,
                 messages,
                 mutation_strength,
             } => {
-                for msg in messages {
-                    self.log_msg(msg);
+                if !spawned {
+                    for msg in messages {
+                        self.log_msg(msg.clone());
+                    }
+                    self.spawn_population_from_configs(configs);
+                    spawned = true;
                 }
                 let repeats = self.governor_config.eval_repeats.max(1);
-                self.spawn_population_from_configs(&configs);
 
                 // Reuse existing kernel if population size matches,
                 // otherwise drop and recreate in background.
@@ -882,11 +913,10 @@ impl App {
 
                 if can_reuse {
                     let mk = self.gpu_kernel.as_mut().unwrap();
-                    // Use non-blocking reset; if staging not ready yet we
-                    // fall back to the old blocking reset (rare edge case
-                    // at generation boundary where GPU is backed up).
+                    // Non-blocking reset — return false to retry next frame
+                    // instead of falling back to a blocking busy-wait.
                     if !mk.try_reset_agents(&self.brain_config) {
-                        mk.reset_agents(&self.brain_config);
+                        return (false, spawned);
                     }
                     let agent_data: Vec<_> = self
                         .agents
@@ -909,15 +939,18 @@ impl App {
                     self.ensure_gpu_kernel();
                 }
 
-                // Inherit learned weights: champions get exact weights,
+                // Inherit learned weights: champions get exact brain state,
                 // mutants get perturbed weights for neuroevolution.
-                if let Some(ref state) = inherited_state {
+                if let Some(state) = inherited_state {
                     if let Some(ref mk) = self.gpu_kernel {
-                        let ms = mutation_strength;
+                        let ms = *mutation_strength;
                         let n = self.agents.len();
+                        // Pre-clone once for all champion slots to avoid
+                        // cloning inside the hot closure on every call.
+                        let champion = state.clone();
                         mk.batch_write_agent_states(n, |i| {
                             if i < repeats {
-                                state.clone()
+                                champion.clone()
                             } else {
                                 mutate_brain_state(state, ms)
                             }
@@ -927,12 +960,13 @@ impl App {
             }
             AdvanceResult::Finished { messages } => {
                 for msg in messages {
-                    self.log_msg(msg);
+                    self.log_msg(msg.clone());
                 }
                 self.evo_snapshot.state = EvolutionState::Paused;
                 self.paused = true;
             }
         }
+        (true, spawned)
     }
 
     fn log_msg(&mut self, msg: String) {

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -808,7 +808,7 @@ impl App {
         // Evaluate fitness and decide whether evolution continues.
         // Only kick off the async brain-state readback when the result is
         // Continue — when Finished, no readback is needed.
-        let result = {
+        let (result, readback_requested) = {
             let gov = match self.governor.as_mut() {
                 Some(g) => g,
                 None => return,
@@ -822,21 +822,32 @@ impl App {
 
             // Only read back the best agent's brain state when evolution
             // continues — Finished needs no inherited state.
+            let mut readback_requested = false;
             if matches!(result, AdvanceResult::Continue { .. }) {
                 let best_idx = fitness.first().map(|f| f.agent_index).unwrap_or(0);
                 if let Some(a) = self.agents.get(best_idx) {
                     if let Some(mk) = self.gpu_kernel.as_mut() {
                         mk.request_agent_state(a.brain_idx);
+                        readback_requested = true;
                     }
                 }
             }
 
-            result
+            (result, readback_requested)
         };
 
         match result {
-            AdvanceResult::Continue { .. } => {
+            AdvanceResult::Continue { .. } if readback_requested => {
                 self.gen_transition = Some(GenTransition::AwaitingReadback { result });
+            }
+            AdvanceResult::Continue { .. } => {
+                // No readback was issued (no best agent or no GPU kernel) —
+                // skip directly to reset to avoid deadlocking in AwaitingReadback.
+                self.gen_transition = Some(GenTransition::AwaitingReset {
+                    result,
+                    inherited_state: None,
+                    spawned: false,
+                });
             }
             AdvanceResult::Finished { .. } => {
                 // Skip readback phase entirely — go straight to finish.

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -827,8 +827,9 @@ impl App {
                 let best_idx = fitness.first().map(|f| f.agent_index).unwrap_or(0);
                 if let Some(a) = self.agents.get(best_idx) {
                     if let Some(mk) = self.gpu_kernel.as_mut() {
-                        mk.request_agent_state(a.brain_idx);
-                        readback_requested = true;
+                        if mk.request_agent_state(a.brain_idx) {
+                            readback_requested = true;
+                        }
                     }
                 }
             }

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -21,7 +21,7 @@ use xagent_brain::buffers::{
     P_MAX_INTEGRITY, P_MOTOR_FWD_OUT, P_MOTOR_TURN_OUT, P_POS_X, P_POS_Y, P_POS_Z,
     P_PREDICTION_ERROR, P_TICKS_ALIVE, P_URGENCY_OUT, P_VEL_X, P_VEL_Y, P_VEL_Z, P_YAW,
 };
-use xagent_brain::GpuKernel;
+use xagent_brain::{AgentBrainState, GpuKernel};
 use xagent_sandbox::agent::{mutate_brain_state, mutate_config, Agent, MAX_AGENTS};
 use xagent_sandbox::governor::{check_existing_session, reset_database, AdvanceResult, Governor};
 use xagent_sandbox::headless;
@@ -234,6 +234,18 @@ fn record_agent_histories(agent: &mut Agent) {
     push_hist!(agent.fatigue_history, agent.cached_fatigue_factor);
 }
 
+/// State machine for non-blocking generation transitions.
+/// Each variant represents one phase of the multi-frame handoff.
+enum GenTransition {
+    /// Waiting for async readback of the best agent's brain state.
+    AwaitingReadback { result: AdvanceResult },
+    /// Readback collected; waiting for staging buffers to drain before reset.
+    AwaitingReset {
+        result: AdvanceResult,
+        inherited_state: Option<AgentBrainState>,
+    },
+}
+
 struct App {
     brain_config: BrainConfig,
     world_config: WorldConfig,
@@ -319,6 +331,9 @@ struct App {
     tps_display: f64,
     db_path: String,
     governor_config: GovernorConfig,
+
+    // Non-blocking generation transition state machine
+    gen_transition: Option<GenTransition>,
 
     // GPU fused kernel (all simulation computation in single dispatch)
     gpu_kernel: Option<GpuKernel>,
@@ -453,6 +468,7 @@ impl App {
             tps_display: 0.0,
             db_path: db_path.to_string(),
             governor_config,
+            gen_transition: None,
             gpu_kernel: None,
             pending_kernel: None,
             pending_upload: None,
@@ -751,7 +767,9 @@ impl App {
         }
     }
 
-    /// Evaluate the current generation, advance to the next (or finish).
+    /// Evaluate the current generation and begin the async transition.
+    /// The actual GPU work (readback, reset, upload) spans multiple frames
+    /// via `poll_gen_transition`.
     fn advance_generation(&mut self) {
         // Persist the recording to SQLite before moving to the next generation
         if let (Some(ref recording), Some(ref gov)) = (&self.recording, &self.governor) {
@@ -764,9 +782,9 @@ impl App {
                 .map(|s| s.elapsed().as_secs_f64())
                 .unwrap_or(0.0);
 
-        // Evaluate fitness, then capture best agent's brain state using the
-        // actual composite fitness ranking (not the brain's internal metrics).
-        let (result, inherited_state) = {
+        // Evaluate fitness and kick off async readback of the best agent's
+        // brain state (replaces the old blocking read_agent_state call).
+        let result = {
             let gov = match self.governor.as_mut() {
                 Some(g) => g,
                 None => return,
@@ -778,16 +796,71 @@ impl App {
 
             // fitness is sorted by descending composite_fitness — first entry is best
             let best_idx = fitness.first().map(|f| f.agent_index).unwrap_or(0);
-            let state = self.agents.get(best_idx).and_then(|a| {
-                self.gpu_kernel
-                    .as_ref()
-                    .map(|mk| mk.read_agent_state(a.brain_idx))
-            });
+            if let Some(a) = self.agents.get(best_idx) {
+                if let Some(mk) = self.gpu_kernel.as_mut() {
+                    mk.request_agent_state(a.brain_idx);
+                }
+            }
 
-            (gov.advance(&fitness), state)
+            gov.advance(&fitness)
         };
 
-        // Governor borrow released — safe to call self methods
+        self.gen_transition = Some(GenTransition::AwaitingReadback { result });
+    }
+
+    /// Drive the multi-frame generation transition state machine.
+    /// Called every frame; returns true while a transition is still in progress.
+    fn poll_gen_transition(&mut self) -> bool {
+        let transition = match self.gen_transition.take() {
+            Some(t) => t,
+            None => return false,
+        };
+
+        match transition {
+            GenTransition::AwaitingReadback { result } => {
+                if self.gpu_kernel.is_none() {
+                    // No kernel — proceed without inherited state.
+                    self.gen_transition = Some(GenTransition::AwaitingReset {
+                        result,
+                        inherited_state: None,
+                    });
+                    return true;
+                }
+
+                // Poll for the async agent state readback.
+                let collected = self.gpu_kernel.as_mut().unwrap().try_collect_agent_state();
+
+                match collected {
+                    Some(state) => {
+                        // Readback complete — move to reset phase.
+                        self.gen_transition = Some(GenTransition::AwaitingReset {
+                            result,
+                            inherited_state: Some(state),
+                        });
+                    }
+                    None => {
+                        // Still waiting — re-enqueue for next frame.
+                        self.gen_transition = Some(GenTransition::AwaitingReadback { result });
+                    }
+                }
+                true
+            }
+            GenTransition::AwaitingReset {
+                result,
+                inherited_state,
+            } => {
+                self.finish_generation(result, inherited_state);
+                false
+            }
+        }
+    }
+
+    /// Complete a generation transition once readback data is available.
+    fn finish_generation(
+        &mut self,
+        result: AdvanceResult,
+        inherited_state: Option<AgentBrainState>,
+    ) {
         match result {
             AdvanceResult::Continue {
                 configs,
@@ -809,7 +882,12 @@ impl App {
 
                 if can_reuse {
                     let mk = self.gpu_kernel.as_mut().unwrap();
-                    mk.reset_agents(&self.brain_config);
+                    // Use non-blocking reset; if staging not ready yet we
+                    // fall back to the old blocking reset (rare edge case
+                    // at generation boundary where GPU is backed up).
+                    if !mk.try_reset_agents(&self.brain_config) {
+                        mk.reset_agents(&self.brain_config);
+                    }
                     let agent_data: Vec<_> = self
                         .agents
                         .iter()
@@ -835,16 +913,15 @@ impl App {
                 // mutants get perturbed weights for neuroevolution.
                 if let Some(ref state) = inherited_state {
                     if let Some(ref mk) = self.gpu_kernel {
-                        for (i, agent) in self.agents.iter().enumerate() {
+                        let ms = mutation_strength;
+                        let n = self.agents.len();
+                        mk.batch_write_agent_states(n, |i| {
                             if i < repeats {
-                                // Champion: exact inherited weights
-                                mk.write_agent_state(agent.brain_idx, state);
+                                state.clone()
                             } else {
-                                // Mutant: inherited weights + small perturbation
-                                let mutated = mutate_brain_state(state, mutation_strength);
-                                mk.write_agent_state(agent.brain_idx, &mutated);
+                                mutate_brain_state(state, ms)
                             }
-                        }
+                        });
                     }
                 }
             }
@@ -1374,7 +1451,9 @@ impl ApplicationHandler for App {
                 }
 
                 // ── simulation ticks (fixed timestep, adaptive budget) ──
-                if !self.paused {
+                // Skip ticks while a generation transition is in flight to
+                // avoid GPU contention with the async readback/reset.
+                if !self.paused && self.gen_transition.is_none() {
                     self.sim_accumulator += dt * self.speed_multiplier as f32;
                     // Cap accumulator to 2× budget so debt stays bounded.
                     let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
@@ -1567,12 +1646,18 @@ impl ApplicationHandler for App {
                     }
 
                     // ── Generation completion check (after tick batch) ──
-                    if let Some(gov) = &self.governor {
-                        if gov.generation_complete() {
-                            self.advance_generation();
+                    if self.gen_transition.is_none() {
+                        if let Some(gov) = &self.governor {
+                            if gov.generation_complete() {
+                                self.advance_generation();
+                            }
                         }
                     }
                 }
+
+                // Drive the multi-frame generation transition state machine
+                // (runs even when sim ticks are paused/skipped due to transition).
+                self.poll_gen_transition();
 
                 // Advance replay playback
                 if self.replay_state.active && self.replay_state.playing {

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -342,6 +342,10 @@ struct App {
     pending_kernel: Option<std::thread::JoinHandle<GpuKernel>>,
     /// Data collected for upload once the background kernel is ready.
     pending_upload: Option<PendingUpload>,
+    /// Inherited brain state + mutation strength deferred until a background
+    /// kernel finishes creation (when population size changes at generation
+    /// boundary and `can_reuse` is false).
+    deferred_inherited: Option<(AgentBrainState, f32)>,
 
     // egui_dock tab state
     dock_state: egui_dock::DockState<Tab>,
@@ -474,6 +478,7 @@ impl App {
             gpu_kernel: None,
             pending_kernel: None,
             pending_upload: None,
+            deferred_inherited: None,
             dock_state: egui_dock::DockState::new(vec![Tab::Evolution, Tab::Sandbox]),
             gpu_tick_budget: 32,
             sort_mode: SortMode::Id,
@@ -536,6 +541,22 @@ impl App {
                     mk.upload_agents(&upload.agent_data);
                 }
                 let ac = mk.agent_count();
+
+                // Apply deferred inherited state from a generation transition
+                // that occurred while the kernel was being recreated.
+                if let Some((ref state, mutation_strength)) = self.deferred_inherited.take() {
+                    let repeats = self.governor_config.eval_repeats.max(1);
+                    let n = self.agents.len();
+                    let champion = state.clone();
+                    mk.batch_write_agent_states(n, |i| {
+                        if i < repeats {
+                            champion.clone()
+                        } else {
+                            mutate_brain_state(state, mutation_strength)
+                        }
+                    });
+                }
+
                 self.gpu_kernel = Some(mk);
                 self.log_msg(format!("[GPU] GpuKernel ready ({} agents)", ac));
             }
@@ -784,8 +805,9 @@ impl App {
                 .map(|s| s.elapsed().as_secs_f64())
                 .unwrap_or(0.0);
 
-        // Evaluate fitness and kick off async readback of the best agent's
-        // brain state (replaces the old blocking read_agent_state call).
+        // Evaluate fitness and decide whether evolution continues.
+        // Only kick off the async brain-state readback when the result is
+        // Continue — when Finished, no readback is needed.
         let result = {
             let gov = match self.governor.as_mut() {
                 Some(g) => g,
@@ -796,18 +818,35 @@ impl App {
             gov.log_generation(&fitness);
             gov.update_wall_time(wall_secs);
 
-            // fitness is sorted by descending composite_fitness — first entry is best
-            let best_idx = fitness.first().map(|f| f.agent_index).unwrap_or(0);
-            if let Some(a) = self.agents.get(best_idx) {
-                if let Some(mk) = self.gpu_kernel.as_mut() {
-                    mk.request_agent_state(a.brain_idx);
+            let result = gov.advance(&fitness);
+
+            // Only read back the best agent's brain state when evolution
+            // continues — Finished needs no inherited state.
+            if matches!(result, AdvanceResult::Continue { .. }) {
+                let best_idx = fitness.first().map(|f| f.agent_index).unwrap_or(0);
+                if let Some(a) = self.agents.get(best_idx) {
+                    if let Some(mk) = self.gpu_kernel.as_mut() {
+                        mk.request_agent_state(a.brain_idx);
+                    }
                 }
             }
 
-            gov.advance(&fitness)
+            result
         };
 
-        self.gen_transition = Some(GenTransition::AwaitingReadback { result });
+        match result {
+            AdvanceResult::Continue { .. } => {
+                self.gen_transition = Some(GenTransition::AwaitingReadback { result });
+            }
+            AdvanceResult::Finished { .. } => {
+                // Skip readback phase entirely — go straight to finish.
+                self.gen_transition = Some(GenTransition::AwaitingReset {
+                    result,
+                    inherited_state: None,
+                    spawned: false,
+                });
+            }
+        }
     }
 
     /// Drive the multi-frame generation transition state machine.
@@ -955,6 +994,11 @@ impl App {
                                 mutate_brain_state(state, ms)
                             }
                         });
+                    } else {
+                        // Kernel is being recreated in the background
+                        // (population size changed). Stash inherited state
+                        // so it can be applied once the kernel is ready.
+                        self.deferred_inherited = Some((state.clone(), *mutation_strength));
                     }
                 }
             }

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -864,7 +864,7 @@ impl App {
                 spawned,
             } => {
                 let (done, spawned) =
-                    self.try_finish_generation(&result, &inherited_state, spawned);
+                    self.try_finish_generation(&result, inherited_state.as_ref(), spawned);
                 if !done {
                     // Reset not ready yet — re-enqueue for next frame.
                     self.gen_transition = Some(GenTransition::AwaitingReset {
@@ -886,7 +886,7 @@ impl App {
     fn try_finish_generation(
         &mut self,
         result: &AdvanceResult,
-        inherited_state: &Option<AgentBrainState>,
+        inherited_state: Option<&AgentBrainState>,
         mut spawned: bool,
     ) -> (bool, bool) {
         match result {

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -976,6 +976,11 @@ impl App {
                     self.pending_kernel = None;
                     self.pending_upload = None;
                     self.ensure_gpu_kernel();
+                    // Kernel is being recreated in the background —
+                    // keep the transition active until it's ready.
+                    if self.gpu_kernel.is_none() {
+                        return (false, spawned);
+                    }
                 }
 
                 // Inherit learned weights: champions get exact brain state,
@@ -1531,7 +1536,9 @@ impl ApplicationHandler for App {
                 // ── simulation ticks (fixed timestep, adaptive budget) ──
                 // Skip ticks while a generation transition is in flight to
                 // avoid GPU contention with the async readback/reset.
-                if !self.paused && self.gen_transition.is_none() {
+                // Also skip accumulation when the kernel is being recreated
+                // in the background to prevent catch-up hitch when it lands.
+                if !self.paused && self.gen_transition.is_none() && self.pending_kernel.is_none() {
                     self.sim_accumulator += dt * self.speed_multiplier as f32;
                     // Cap accumulator to 2× budget so debt stays bounded.
                     let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;


### PR DESCRIPTION
Closes #30

## Summary
- `read_agent_state` replaced with async `request_agent_state` / `try_collect_agent_state` pair
- `write_agent_state` replaced with `batch_write_agent_states` — single `write_buffer` per GPU buffer instead of N calls
- `reset_agents` busy-wait loop replaced with non-blocking `try_reset_agents` that returns false if staging isn't ready
- Generation transition is now a `GenTransition` state machine spanning multiple frames: `AwaitingReadback` → `AwaitingReset` → complete
- Simulation ticks are paused during transition to avoid GPU contention

## Test plan
- [ ] Run simulation through multiple generations — evolution proceeds correctly
- [ ] No frame hitches at generation boundaries
- [ ] Best agent's brain state correctly inherits to offspring
- [ ] Population reset works correctly (agents respawn, counters reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)