### PR TITLE
Fix simulation not ticking after start

### DIFF
--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1564,8 +1564,9 @@ impl ApplicationHandler for App {
                     self.camera.update(dt);
                 }
 
-                // Poll background kernel creation so it gets collected
-                // even while the tick gate below suppresses accumulation.
+                // Ensure background kernel creation is started if needed and
+                // collected when ready, even while the tick gate below
+                // suppresses accumulation.
                 self.ensure_gpu_kernel();
 
                 // ── simulation ticks (fixed timestep, adaptive budget) ──
@@ -1582,8 +1583,6 @@ impl ApplicationHandler for App {
                         ((self.sim_accumulator / SIM_DT) as u32).min(self.gpu_tick_budget);
 
                     if ticks_to_run > 0 {
-                        self.ensure_gpu_kernel();
-
                         if let Some(ref mut mk) = self.gpu_kernel {
                             let state_updated = mk.try_collect_state();
                             let t0 = Instant::now();

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1564,6 +1564,10 @@ impl ApplicationHandler for App {
                     self.camera.update(dt);
                 }
 
+                // Poll background kernel creation so it gets collected
+                // even while the tick gate below suppresses accumulation.
+                self.ensure_gpu_kernel();
+
                 // ── simulation ticks (fixed timestep, adaptive budget) ──
                 // Skip ticks while a generation transition is in flight to
                 // avoid GPU contention with the async readback/reset.


### PR DESCRIPTION
## Summary
- `ensure_gpu_kernel()` is now called before the tick gate so the background kernel thread result is collected on the next frame
- Without this, `pending_kernel.is_none()` in the gate prevented the poll from ever running, leaving the simulation frozen

Closes #39

## Test plan
- [ ] Start a new evolution run — agents should begin moving immediately after kernel init
- [ ] Resume an existing run — same behavior
- [ ] Generation transitions still work (kernel recreation path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)