### PR TITLE
docs: add performance invariants ground rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,12 @@
 - `rust-toolchain.toml` — pins Rust stable channel for CI and local dev
 - Release flow: tag on `develop` (`git tag v0.x.0 && git push origin v0.x.0`) triggers the full pipeline
 
+## Performance Invariants
+- Per-tick simulation logic belongs in WGSL shaders, never in Rust
+- The CPU main loop submits GPU dispatches (batched) and collects async readback results (non-blocking)
+- Recording/telemetry/history functions run once per frame, sampling the latest state
+- No CPU-side work should scale with `ticks_to_run` — the GPU kernel processes up to 64,000 ticks per dispatch
+
 ## Code Style
 - Specs: `docs/superpowers/specs/`, Plans: `docs/superpowers/plans/`
 - Commit prefixes: `feat:`, `fix:`, `perf:`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@
 - Per-tick simulation logic belongs in WGSL shaders, never in Rust
 - The CPU main loop submits GPU dispatches (batched) and collects async readback results (non-blocking)
 - Recording/telemetry/history functions run once per frame, sampling the latest state
-- No CPU-side work should scale with `ticks_to_run` — the GPU kernel processes up to 64,000 ticks per dispatch
+- No CPU-side work should scale with `ticks_to_run` — up to 64,000 ticks may be scheduled per frame/batch call, with GPU work dispatched in chunks
 
 ## Code Style
 - Specs: `docs/superpowers/specs/`, Plans: `docs/superpowers/plans/`

--- a/README.md
+++ b/README.md
@@ -505,7 +505,18 @@ Minimal assumptions. A reward function encodes the designer's notion of what's "
 
 ---
 
-## 11. Testing
+## 11. Performance Invariants
+
+The simulation's throughput depends on keeping per-tick work on the GPU. These rules are non-negotiable:
+
+- **Per-tick simulation logic belongs in WGSL shaders, never in Rust.** Physics, brain passes, food detection, death/respawn -- all of it runs in compute shaders. Adding per-tick logic on the CPU side defeats the fused-kernel architecture.
+- **The CPU main loop submits GPU dispatches (batched) and collects async readback results (non-blocking).** The Rust side orchestrates dispatches, maps readback buffers, and feeds the UI. It never steps the simulation itself.
+- **Recording, telemetry, and history functions run once per frame, sampling the latest state.** CSV logging, replay recording, and UI snapshot updates happen at frame cadence, not tick cadence.
+- **No CPU-side work should scale with `ticks_to_run`.** The GPU kernel processes up to 64,000 ticks per dispatch. If a proposed change adds a Rust loop that iterates `ticks_to_run` times, it violates this invariant.
+
+---
+
+## 12. Testing
 
 ```bash
 # Run all tests across the workspace
@@ -533,7 +544,7 @@ cargo test -p xagent-brain -- brain_prediction_error_decreases_with_repeated_inp
 
 ---
 
-## 12. Future Directions
+## 13. Future Directions
 
 - **Multi-agent communication** — Agents could emit and perceive signals (sound, visual markers), enabling emergent social behaviors, cooperation, or competition.
 - **Dynamic memory growth** — Allow memory capacity to expand based on environmental complexity, simulating neuroplasticity.

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ The simulation's throughput depends on keeping per-tick work on the GPU. These r
 - **Per-tick simulation logic belongs in WGSL shaders, never in Rust.** Physics, brain passes, food detection, death/respawn -- all of it runs in compute shaders. Adding per-tick logic on the CPU side defeats the fused-kernel architecture.
 - **The CPU main loop submits GPU dispatches (batched) and collects async readback results (non-blocking).** The Rust side orchestrates dispatches, maps readback buffers, and feeds the UI. It never steps the simulation itself.
 - **Recording, telemetry, and history functions run once per frame, sampling the latest state.** CSV logging, replay recording, and UI snapshot updates happen at frame cadence, not tick cadence.
-- **No CPU-side work should scale with `ticks_to_run`.** The GPU kernel processes up to 64,000 ticks per dispatch. If a proposed change adds a Rust loop that iterates `ticks_to_run` times, it violates this invariant.
+- **No CPU-side simulation work should scale with `ticks_to_run` beyond trivial bookkeeping.** The GPU tick budget is capped at 64,000 ticks per frame, and execution may be split across multiple batched dispatches. Rust may still do lightweight per-tick accounting (for example, counters or governance bookkeeping), but any per-tick simulation, physics, sensing, or brain computation on the CPU violates this invariant.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a "Performance Invariants" section (section 11) to `README.md` documenting four ground rules: per-tick logic stays in WGSL, CPU submits batched dispatches with non-blocking readback, recording/telemetry runs once per frame, and no CPU work scales with `ticks_to_run`.
- Adds a matching "Performance Invariants" section to `CLAUDE.md` so AI assistants are aware of these constraints.

Closes #41

## Test plan
- [ ] Verify README renders correctly on GitHub (section numbering, formatting)
- [ ] Verify CLAUDE.md section appears between Architecture and Code Style

🤖 Generated with [Claude Code](https://claude.com/claude-code)