### PR TITLE
fix: prevent monotony detector from trapping agents in circling

### DIFF
--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -489,10 +489,15 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         // Turn-direction consistency: detect sustained same-direction turning
         // (circling signature). turn_bias → 1 when all turns share the same
         // sign, → 0 when turns are balanced left/right.
-        let turn_denom = max(sum_abs_turn, 0.01);
-        let turn_bias = abs(sum_turn) / turn_denom;
-        // Squared for gentle onset; suppresses variety when turning monotonically
-        let monotony = turn_bias * turn_bias;
+        // Require minimum 16 samples before engaging monotony detection to
+        // prevent early-life trapping on noisy small-sample estimates.
+        var monotony: f32 = 0.0;
+        if (f_len >= 16u) {
+            let turn_denom = max(sum_abs_turn, 0.01);
+            let turn_bias = abs(sum_turn) / turn_denom;
+            // Squared for gentle onset; suppresses variety when turning monotonically
+            monotony = turn_bias * turn_bias;
+        }
 
         let recovery = brain_state[b + O_FATIGUE_RECOVERY];
         let floor_val = brain_state[b + O_FATIGUE_FLOOR];

--- a/crates/xagent-brain/src/shaders/predict_and_act.wgsl
+++ b/crates/xagent-brain/src/shaders/predict_and_act.wgsl
@@ -328,10 +328,15 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     // Turn-direction consistency: detect sustained same-direction turning
     // (circling signature). turn_bias → 1 when all turns share the same
     // sign, → 0 when turns are balanced left/right.
-    let turn_denom = max(sum_abs_turn, 0.01);
-    let turn_bias = abs(sum_turn) / turn_denom;
-    // Squared for gentle onset; suppresses variety when turning monotonically
-    let monotony = turn_bias * turn_bias;
+    // Require minimum 16 samples before engaging monotony detection to
+    // prevent early-life trapping on noisy small-sample estimates.
+    var monotony: f32 = 0.0;
+    if (f_len >= 16u) {
+        let turn_denom = max(sum_abs_turn, 0.01);
+        let turn_bias = abs(sum_turn) / turn_denom;
+        // Squared for gentle onset; suppresses variety when turning monotonically
+        monotony = turn_bias * turn_bias;
+    }
 
     let recovery = brain_state[b + O_FATIGUE_RECOVERY];
     let floor = brain_state[b + O_FATIGUE_FLOOR];

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -348,7 +348,7 @@ pub fn mutate_config_with_strength(
             .clamp(2.0, 10.0),
         fatigue_floor: momentum
             .biased_perturb_f(&mut rng, parent.fatigue_floor, "fatigue_floor", strength)
-            .clamp(0.05, 0.15),
+            .clamp(0.05, 0.4),
         vision_w: parent.vision_w,
         vision_h: parent.vision_h,
         brain_tick_stride: parent.brain_tick_stride,
@@ -652,8 +652,8 @@ mod tests {
                 child.fatigue_recovery_sensitivity,
             );
             assert!(
-                child.fatigue_floor <= 0.15,
-                "fatigue_floor must be ≤ 0.15, got {}",
+                child.fatigue_floor <= 0.4,
+                "fatigue_floor must be ≤ 0.4, got {}",
                 child.fatigue_floor,
             );
             assert!(

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -38,7 +38,7 @@ pub struct BrainConfig {
     #[serde(default = "default_fatigue_recovery_sensitivity")]
     pub fatigue_recovery_sensitivity: f32,
     /// Minimum motor output under fatigue. Lower = harsher dampening.
-    /// Heritable: mutated during breeding, clamped to [0.05, 0.15]. Default 0.1.
+    /// Heritable: mutated during breeding, clamped to [0.05, 0.4]. Default 0.1.
     #[serde(default = "default_fatigue_floor")]
     pub fatigue_floor: f32,
     /// Visual field width in pixels. Default 8.


### PR DESCRIPTION
## Summary
- Add minimum ring buffer fill requirement (`f_len >= 16`) before engaging monotony detection in `brain_tick.wgsl`, preventing early-life trapping on noisy small-sample turn_bias estimates
- Widen `fatigue_floor` evolvable bounds from `[0.05, 0.15]` back to `[0.05, 0.4]` so evolution can discover less punishing floor values
- Update test assertions to match the new upper bound

Closes #42

## Test plan
- [x] `cargo check -p xagent-sandbox` passes
- [x] `cargo test -p xagent-sandbox` — all 99 tests pass (including `mutate_config_respects_fatigue_bounds`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)