### PR TITLE
feat: distinct agent colors via golden-angle HSV

### DIFF
--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -86,8 +86,12 @@ const GOLDEN_ANGLE_DEG: f32 = 137.508;
 /// Gray color applied to dead agent cubes.
 const DEAD_COLOR: [f32; 3] = [0.3, 0.3, 0.3];
 
-/// Convert an HSV color (h in 0..360, s/v in 0..1) to sRGB [r, g, b] in 0..1.
+/// Convert an HSV color (h in degrees, s/v in 0..1) to sRGB [r, g, b] in 0..1.
+/// Inputs are normalized: h is wrapped to 0..360, s and v are clamped to 0..1.
 fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [f32; 3] {
+    let h = h.rem_euclid(360.0);
+    let s = s.clamp(0.0, 1.0);
+    let v = v.clamp(0.0, 1.0);
     let c = v * s;
     let h_prime = h / 60.0;
     let x = c * (1.0 - (h_prime % 2.0 - 1.0).abs());
@@ -696,5 +700,58 @@ mod tests {
     fn mutate_brain_state_rejects_short_buffer() {
         let state = AgentBrainState::new_for(10); // way too small
         let _ = mutate_brain_state(&state, 0.1);
+    }
+
+    #[test]
+    fn hsv_to_rgb_outputs_in_unit_range() {
+        let hues = [0.0, 30.0, 60.0, 120.0, 180.0, 240.0, 300.0, 359.999];
+        for &h in &hues {
+            let [r, g, b] = hsv_to_rgb(h, 0.8, 0.9);
+            assert!(
+                (0.0..=1.0).contains(&r) && (0.0..=1.0).contains(&g) && (0.0..=1.0).contains(&b),
+                "RGB out of range for hue {h}: [{r}, {g}, {b}]",
+            );
+        }
+    }
+
+    #[test]
+    fn hsv_to_rgb_normalizes_inputs() {
+        // Negative hue wraps into 0..360
+        let neg = hsv_to_rgb(-90.0, 0.5, 0.5);
+        let pos = hsv_to_rgb(270.0, 0.5, 0.5);
+        assert_eq!(neg, pos, "negative hue should wrap to equivalent positive");
+
+        // Hue > 360 wraps
+        let over = hsv_to_rgb(420.0, 0.5, 0.5);
+        let wrapped = hsv_to_rgb(60.0, 0.5, 0.5);
+        assert_eq!(over, wrapped, "hue > 360 should wrap");
+
+        // Out-of-range s/v are clamped — result must still be in 0..1
+        let [r, g, b] = hsv_to_rgb(180.0, 2.0, -0.5);
+        assert!(
+            (0.0..=1.0).contains(&r) && (0.0..=1.0).contains(&g) && (0.0..=1.0).contains(&b),
+            "clamped s/v should produce valid RGB: [{r}, {g}, {b}]",
+        );
+    }
+
+    #[test]
+    fn first_16_agent_colors_are_distinct() {
+        let colors: Vec<[f32; 3]> = (0..16).map(agent_color).collect();
+        let eps = 1e-4;
+        for i in 0..colors.len() {
+            for j in (i + 1)..colors.len() {
+                let diff = colors[i]
+                    .iter()
+                    .zip(colors[j].iter())
+                    .map(|(a, b)| (a - b).abs())
+                    .fold(0.0f32, f32::max);
+                assert!(
+                    diff > eps,
+                    "agent_color({i}) and agent_color({j}) are too similar: {:?} vs {:?}",
+                    colors[i],
+                    colors[j],
+                );
+            }
+        }
     }
 }

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -76,27 +76,38 @@ impl AgentBody {
     }
 }
 
-// ── Color palette for multi-agent rendering ────────────────────────────
+// ── Color generation for multi-agent rendering ──────────────────────────
 
-/// Eight-color palette for distinguishing agents in multi-agent mode.
-/// Colors are chosen for maximum visual contrast on the terrain.
-const AGENT_COLORS: [[f32; 3]; 8] = [
-    [0.85, 0.20, 0.20], // red
-    [0.20, 0.40, 0.90], // blue
-    [0.20, 0.80, 0.25], // green
-    [0.90, 0.85, 0.15], // yellow
-    [0.70, 0.25, 0.85], // purple
-    [0.95, 0.55, 0.10], // orange
-    [0.10, 0.80, 0.80], // cyan
-    [0.90, 0.40, 0.70], // pink
-];
+/// Golden angle in degrees (~137.508°). Successive multiples of this angle
+/// produce maximally spread hues for any population size, avoiding the
+/// clustering that a fixed-size palette causes when `agent_count > palette_len`.
+const GOLDEN_ANGLE_DEG: f32 = 137.508;
 
 /// Gray color applied to dead agent cubes.
 const DEAD_COLOR: [f32; 3] = [0.3, 0.3, 0.3];
 
-/// Get the display color for agent at the given index (wraps around the 8-color palette).
+/// Convert an HSV color (h in 0..360, s/v in 0..1) to sRGB [r, g, b] in 0..1.
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [f32; 3] {
+    let c = v * s;
+    let h_prime = h / 60.0;
+    let x = c * (1.0 - (h_prime % 2.0 - 1.0).abs());
+    let (r1, g1, b1) = match h_prime as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    let m = v - c;
+    [r1 + m, g1 + m, b1 + m]
+}
+
+/// Deterministic, visually distinct color for the agent at `index`.
+/// Uses golden-angle hue stepping so any population size gets well-separated colors.
 pub fn agent_color(index: usize) -> [f32; 3] {
-    AGENT_COLORS[index % AGENT_COLORS.len()]
+    let hue = (index as f32 * GOLDEN_ANGLE_DEG) % 360.0;
+    hsv_to_rgb(hue, 0.8, 0.9)
 }
 
 /// Maximum number of agents for performance.


### PR DESCRIPTION
## Summary
- Replace the fixed 8-color palette in `agent_color()` with golden-angle HSV hue stepping (`hue = index * 137.508° mod 360°`, saturation 0.8, value 0.9)
- Every agent now gets a deterministic, visually distinct color regardless of population size — no more duplicate colors when `agent_count > 8`
- Added `hsv_to_rgb` helper for the conversion

## Test plan
- [x] `cargo check -p xagent-sandbox` passes
- [x] All 99 tests pass (`cargo test -p xagent-sandbox`)
- [ ] Visual inspection: run simulation with 20+ agents, verify no duplicate-looking colors

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)