### PR TITLE
docs: add contributing guidelines from PR review analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@
 ## GPU & Buffer Rules
 - All buffer offsets must derive from `BrainLayout` / kernel config, never hardcoded constants
 - Validate index/count inputs against kernel state before computing buffer offsets
-- Constants shared between Rust and WGSL must have a single canonical source (either `wgsl_physics_constants()` template or `wconfig` uniform buffer)
-- Never introduce a second copy of a constant — import or reference the canonical one
+- Constants shared between Rust and WGSL must have a single canonical source for each constant in each shader/pipeline; use whichever source that shader already treats as authoritative (e.g., `wgsl_physics_constants()` or `wconfig`)
+- Never define the same constant in multiple headers that get concatenated — import or reference the canonical one for that shader/pipeline
 
 ## Async Readback Rules
 - Track in-flight state explicitly: never overwrite pending async operations without cleanup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,34 @@
 - The CPU main loop submits GPU dispatches (batched) and collects async readback results (non-blocking)
 - Recording/telemetry/history functions run once per frame, sampling the latest state
 - No CPU-side work should scale with `ticks_to_run` — up to 64,000 ticks may be scheduled per frame/batch call, with GPU work dispatched in chunks
+- Never clone large collections (`Vec`, `HashMap`) in per-frame hot paths — use `clone_from()` or borrow
+- Use squared-distance comparisons to avoid `sqrt()` in loops
+
+## GPU & Buffer Rules
+- All buffer offsets must derive from `BrainLayout` / kernel config, never hardcoded constants
+- Validate index/count inputs against kernel state before computing buffer offsets
+- Constants shared between Rust and WGSL must have a single canonical source (either `wgsl_physics_constants()` template or `wconfig` uniform buffer)
+- Never introduce a second copy of a constant — import or reference the canonical one
+
+## Async Readback Rules
+- Track in-flight state explicitly: never overwrite pending async operations without cleanup
+- Always handle both success and failure paths for `map_async` — stuck-forever states are bugs
+- When multiple sources provide the same field (e.g., phys readback vs telemetry), document which is authoritative and never overwrite fresher data with stale
+- Unmap staging buffers on all paths: success, error, agent switch, and generation reset
+
+## Concurrency Rules
+- All SQLite connections must set `busy_timeout` — default is 0 (instant fail)
+- Background threads must have a shutdown path: drop sender → recv returns Disconnected → thread exits
+- `Drop` impls must join threads and log panics, never silently discard
+- Never use `.expect()` for fallible I/O/GPU/thread operations — return `Result` or `Option`
+
+## Testing Rules
+- New concurrency-sensitive code paths require end-to-end tests exercising failure modes
+- Cache invalidation logic must be tested: populate → invalidate → verify fresh
+- Non-trivial algorithms (color generation, distance checks) need unit tests with boundary cases
 
 ## Code Style
 - Specs: `docs/superpowers/specs/`, Plans: `docs/superpowers/plans/`
 - Commit prefixes: `feat:`, `fix:`, `perf:`
+- Docstrings must match implementation — "non-blocking" means non-blocking, "pre-allocates" means pre-allocates
+- Distinguish "start operation" from "poll/collect operation" in API naming

--- a/README.md
+++ b/README.md
@@ -518,12 +518,12 @@ The simulation's throughput depends on keeping per-tick work on the GPU. These r
 
 ## 12. Contributing Guidelines
 
-These rules are distilled from 88 review comments across PRs #33-49. They represent the project's hard-won invariants.
+These rules are distilled from 88 review comments across PRs #33–#49. They represent the project's hard-won invariants.
 
 ### GPU & Buffer Safety
 - **All buffer offsets must derive from `BrainLayout` / kernel config, never hardcoded constants.** Hardcoded strides like `SENSORY_STRIDE` break when `BrainLayout` uses non-default vision dimensions.
 - **Validate index and count inputs against kernel state before computing buffer offsets.** Out-of-bounds offsets trigger wgpu validation errors or silent corruption.
-- **Constants shared between Rust and WGSL must have a single canonical source.** Either the `wgsl_physics_constants()` template or the `wconfig` uniform buffer — never both. Use named constants, not magic indices (e.g., `WC_FOOD_RADIUS`, not `wc(7u)`).
+- **Constants shared between Rust and WGSL must have a single canonical source within a given shader pipeline / concatenated header set.** A pipeline may use either the `wgsl_physics_constants()` template or the `wconfig` uniform buffer for a given constant, but do not define the same constant from both sources when headers are combined. Use named constants, not magic indices (e.g., `WC_FOOD_RADIUS`, not `wc(7u)`).
 
 ### Async Readback
 - **Track in-flight state explicitly.** Never overwrite a pending `map_async` operation without unmapping/cleaning up the previous one first.

--- a/README.md
+++ b/README.md
@@ -516,7 +516,44 @@ The simulation's throughput depends on keeping per-tick work on the GPU. These r
 
 ---
 
-## 12. Testing
+## 12. Contributing Guidelines
+
+These rules are distilled from 88 review comments across PRs #33-49. They represent the project's hard-won invariants.
+
+### GPU & Buffer Safety
+- **All buffer offsets must derive from `BrainLayout` / kernel config, never hardcoded constants.** Hardcoded strides like `SENSORY_STRIDE` break when `BrainLayout` uses non-default vision dimensions.
+- **Validate index and count inputs against kernel state before computing buffer offsets.** Out-of-bounds offsets trigger wgpu validation errors or silent corruption.
+- **Constants shared between Rust and WGSL must have a single canonical source.** Either the `wgsl_physics_constants()` template or the `wconfig` uniform buffer — never both. Use named constants, not magic indices (e.g., `WC_FOOD_RADIUS`, not `wc(7u)`).
+
+### Async Readback
+- **Track in-flight state explicitly.** Never overwrite a pending `map_async` operation without unmapping/cleaning up the previous one first.
+- **Always handle both success and failure paths.** If any `map_async` callback fails, the system must clean up and allow retry — "stuck forever" states are bugs.
+- **Establish data authority.** When physics readback and telemetry readback both provide the same field, document which is authoritative and never overwrite fresher data with stale async results.
+- **Unmap staging buffers on all paths:** success, error, agent switch, and generation reset.
+
+### Concurrency
+- **All SQLite connections must set `busy_timeout`.** The default is 0 (instant `SQLITE_BUSY` failure). Both main and background connections need matching timeout policies.
+- **Background threads must have a deterministic shutdown path.** Drop sender → `recv` returns `Disconnected` → thread exits. `Drop` impls must join threads and log any panics.
+- **Return `Result` or `Option` from fallible operations.** Never use `.expect()` for I/O, GPU, or thread operations. Silent failures are worse than explicit errors.
+
+### Performance
+- **Never clone large collections in per-frame hot paths.** Use `clone_from()` for in-place updates or borrow patterns. A throttled rebuild is useless if you deep-clone every frame.
+- **Use squared-distance comparisons to avoid `sqrt()` in loops.** Both CPU and GPU code should use `_SQ` variants for radius checks.
+- **Only mark throttle windows as consumed when work actually happens.** Updating `last_rebuild` without rebuilding silently wastes the throttle budget.
+
+### Documentation & Naming
+- **Docstrings must match implementation.** "Non-blocking" means non-blocking, "pre-allocates" means pre-allocates. Rename functions when behavior changes (e.g., `read_agent_telemetry` → `read_agent_telemetry_blocking`).
+- **Distinguish "start operation" from "poll/collect operation" in API naming.** A function that both starts and polls should document that clearly.
+- **Keep PR descriptions synchronized with code.** Constant values, radius sizes, and architectural claims must reflect what the code actually does.
+
+### Testing
+- **New concurrency-sensitive code paths require end-to-end tests** exercising the async lifecycle: request → complete → consume, and request → fail → cleanup.
+- **Cache invalidation must be tested:** populate → invalidate → verify fresh data returned.
+- **Non-trivial algorithms need unit tests** with representative inputs and boundary conditions.
+
+---
+
+## 13. Testing
 
 ```bash
 # Run all tests across the workspace
@@ -544,7 +581,7 @@ cargo test -p xagent-brain -- brain_prediction_error_decreases_with_repeated_inp
 
 ---
 
-## 13. Future Directions
+## 14. Future Directions
 
 - **Multi-agent communication** — Agents could emit and perceive signals (sound, visual markers), enabling emergent social behaviors, cooperation, or competition.
 - **Dynamic memory growth** — Allow memory capacity to expand based on environmental complexity, simulating neuroplasticity.


### PR DESCRIPTION
## Summary
- Analyzed 88 review comments across PRs #33–49 and distilled them into concrete contributing rules
- Added 6 new sections to CLAUDE.md: GPU & Buffer Rules, Async Readback Rules, Concurrency Rules, Testing Rules, expanded Performance Invariants, expanded Code Style
- Added "Contributing Guidelines" section to README.md with 6 categories

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify README.md section 12 renders correctly and numbering is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)