### PR TITLE
fix: tune simulation defaults (metabolic_rate, integrity_scale, tick_budget, brain_tick_stride)

### DIFF
--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -167,7 +167,7 @@ impl Default for EvolutionSnapshot {
             state: EvolutionState::Idle,
             generation: 0,
             gen_tick: 0,
-            tick_budget: 50_000,
+            tick_budget: xagent_shared::GovernorConfig::default().tick_budget,
             population_size: 10,
             elitism_count: 3,
             patience: 5,

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -123,7 +123,7 @@ fn default_seed() -> u64 {
 }
 
 fn default_brain_tick_stride() -> u32 {
-    4
+    10
 }
 
 fn default_vision_stride() -> u32 {
@@ -131,11 +131,11 @@ fn default_vision_stride() -> u32 {
 }
 
 fn default_metabolic_rate() -> f32 {
-    1.0
+    0.01
 }
 
 fn default_integrity_scale() -> f32 {
-    1.0
+    0.01
 }
 
 /// Describes an agent to be spawned into the world.
@@ -221,7 +221,7 @@ impl Default for GovernorConfig {
     fn default() -> Self {
         Self {
             population_size: 10,
-            tick_budget: 50_000,
+            tick_budget: 1_000_000,
             elitism_count: 3,
             max_generations: 0,
             patience: 5,
@@ -250,10 +250,10 @@ impl Default for BrainConfig {
             fatigue_floor: 0.1,
             vision_width: 8,
             vision_height: 6,
-            brain_tick_stride: 4,
+            brain_tick_stride: default_brain_tick_stride(),
             vision_stride: 10,
-            metabolic_rate: 1.0,
-            integrity_scale: 1.0,
+            metabolic_rate: default_metabolic_rate(),
+            integrity_scale: default_integrity_scale(),
         }
     }
 }
@@ -275,10 +275,10 @@ impl BrainConfig {
             fatigue_floor: 0.1,
             vision_width: 6,
             vision_height: 4,
-            brain_tick_stride: 4,
+            brain_tick_stride: default_brain_tick_stride(),
             vision_stride: 10,
-            metabolic_rate: 1.0,
-            integrity_scale: 1.0,
+            metabolic_rate: 0.01,
+            integrity_scale: 0.01,
         }
     }
 
@@ -298,10 +298,10 @@ impl BrainConfig {
             fatigue_floor: 0.1,
             vision_width: 12,
             vision_height: 8,
-            brain_tick_stride: 4,
+            brain_tick_stride: default_brain_tick_stride(),
             vision_stride: 10,
-            metabolic_rate: 1.0,
-            integrity_scale: 1.0,
+            metabolic_rate: 0.01,
+            integrity_scale: 0.01,
         }
     }
 }

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -248,10 +248,10 @@ impl Default for BrainConfig {
             max_curiosity_bonus: 0.6,
             fatigue_recovery_sensitivity: 8.0,
             fatigue_floor: 0.1,
-            vision_width: 8,
-            vision_height: 6,
+            vision_width: default_vision_width(),
+            vision_height: default_vision_height(),
             brain_tick_stride: default_brain_tick_stride(),
-            vision_stride: 10,
+            vision_stride: default_vision_stride(),
             metabolic_rate: default_metabolic_rate(),
             integrity_scale: default_integrity_scale(),
         }
@@ -276,7 +276,7 @@ impl BrainConfig {
             vision_width: 6,
             vision_height: 4,
             brain_tick_stride: default_brain_tick_stride(),
-            vision_stride: 10,
+            vision_stride: default_vision_stride(),
             metabolic_rate: default_metabolic_rate(),
             integrity_scale: default_integrity_scale(),
         }
@@ -299,7 +299,7 @@ impl BrainConfig {
             vision_width: 12,
             vision_height: 8,
             brain_tick_stride: default_brain_tick_stride(),
-            vision_stride: 10,
+            vision_stride: default_vision_stride(),
             metabolic_rate: default_metabolic_rate(),
             integrity_scale: default_integrity_scale(),
         }
@@ -366,8 +366,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vision_stride_defaults_to_10() {
+    fn brain_config_tuned_defaults() {
         let config = BrainConfig::default();
+        assert_eq!(config.brain_tick_stride, 10);
         assert_eq!(config.vision_stride, 10);
+        assert_eq!(config.vision_width, 8);
+        assert_eq!(config.vision_height, 6);
+        assert!((config.metabolic_rate - 0.01).abs() < 1e-6);
+        assert!((config.integrity_scale - 0.01).abs() < 1e-6);
+    }
+
+    #[test]
+    fn governor_config_tuned_defaults() {
+        let config = GovernorConfig::default();
+        assert_eq!(config.tick_budget, 1_000_000);
     }
 }

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -48,7 +48,7 @@ pub struct BrainConfig {
     #[serde(default = "default_vision_height", alias = "vision_h")]
     pub vision_height: u32,
     /// Physics ticks per brain+vision cycle. Higher = faster but less responsive.
-    /// Default 4.
+    /// Default 10.
     #[serde(default = "default_brain_tick_stride")]
     pub brain_tick_stride: u32,
     /// Brain cycles between global passes (grid rebuild, collisions, vision).
@@ -56,11 +56,11 @@ pub struct BrainConfig {
     /// Default 10.
     #[serde(default = "default_vision_stride")]
     pub vision_stride: u32,
-    /// Multiplier for all energy costs (metabolic + movement). Default 1.0.
+    /// Multiplier for all energy costs (metabolic + movement). Default 0.01.
     /// Lower = agents survive longer. Higher = harsher energy pressure.
     #[serde(default = "default_metabolic_rate")]
     pub metabolic_rate: f32,
-    /// Multiplier for integrity damage and regen. Default 1.0.
+    /// Multiplier for integrity damage and regen. Default 0.01.
     /// Lower = agents take less damage. Higher = hazard zones are deadlier.
     #[serde(default = "default_integrity_scale")]
     pub integrity_scale: f32,

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -277,8 +277,8 @@ impl BrainConfig {
             vision_height: 4,
             brain_tick_stride: default_brain_tick_stride(),
             vision_stride: 10,
-            metabolic_rate: 0.01,
-            integrity_scale: 0.01,
+            metabolic_rate: default_metabolic_rate(),
+            integrity_scale: default_integrity_scale(),
         }
     }
 
@@ -300,8 +300,8 @@ impl BrainConfig {
             vision_height: 8,
             brain_tick_stride: default_brain_tick_stride(),
             vision_stride: 10,
-            metabolic_rate: 0.01,
-            integrity_scale: 0.01,
+            metabolic_rate: default_metabolic_rate(),
+            integrity_scale: default_integrity_scale(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- `metabolic_rate` default: `1.0` → `0.01`
- `integrity_scale` default: `1.0` → `0.01`
- `tick_budget` default: `50_000` → `1_000_000`
- `brain_tick_stride` default: `4` → `10`

Applied to `BrainConfig::default()`, `BrainConfig::tiny()`, `BrainConfig::large()`, the serde default fns, `GovernorConfig::default()`, and `EvolutionSnapshot::default()` in ui.rs.

## Test plan
- [x] `cargo check -p xagent-sandbox` passes
- [x] `cargo test -p xagent-sandbox` passes (103 tests)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)