### PR TITLE
refactor: rename vision_w/vision_h to vision_width/vision_height

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,4 @@
 - Commit prefixes: `feat:`, `fix:`, `perf:`
 - Docstrings must match implementation — "non-blocking" means non-blocking, "pre-allocates" means pre-allocates
 - Distinguish "start operation" from "poll/collect operation" in API naming
+- Avoid abbreviations in identifiers — use full words (e.g. `vision_width` not `vision_w`, `position` not `pos`). Exceptions: buffer layout constants (O_*, P_*, CFG_*), loop variables, external API types.

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -134,12 +134,12 @@ pub const BRAIN_TICK_STRIDE: u32 = 4;
 
 // ── Runtime layout for configurable vision dimensions ─────────────────
 
-/// Runtime-computed buffer layout that depends on vision_w × vision_h.
+/// Runtime-computed buffer layout that depends on vision_width × vision_height.
 /// All strides and offsets cascade from the pixel count.
 #[derive(Clone, Debug)]
 pub struct BrainLayout {
-    pub vision_w: u32,
-    pub vision_h: u32,
+    pub vision_width: u32,
+    pub vision_height: u32,
     pub vision_color_count: usize,
     pub vision_depth_count: usize,
     pub feature_count: usize,
@@ -148,9 +148,9 @@ pub struct BrainLayout {
 }
 
 impl BrainLayout {
-    pub fn new(vision_w: u32, vision_h: u32) -> Self {
-        let pixel_count = (vision_w as usize)
-            .checked_mul(vision_h as usize)
+    pub fn new(vision_width: u32, vision_height: u32) -> Self {
+        let pixel_count = (vision_width as usize)
+            .checked_mul(vision_height as usize)
             .expect("vision dimensions overflow pixel count");
         let color_count = pixel_count
             .checked_mul(4)
@@ -173,8 +173,8 @@ impl BrainLayout {
             .and_then(|v| v.checked_add(FIXED_TAIL_SIZE))
             .expect("vision dimensions overflow brain stride");
         Self {
-            vision_w,
-            vision_h,
+            vision_width,
+            vision_height,
             vision_color_count: color_count,
             vision_depth_count: depth_count,
             feature_count,
@@ -752,8 +752,8 @@ mod tests {
     #[test]
     fn brain_layout_default_matches_constants() {
         let layout = BrainLayout::default();
-        assert_eq!(layout.vision_w, 8);
-        assert_eq!(layout.vision_h, 6);
+        assert_eq!(layout.vision_width, 8);
+        assert_eq!(layout.vision_height, 6);
         assert_eq!(layout.feature_count, FEATURE_COUNT);
         assert_eq!(layout.sensory_stride, SENSORY_STRIDE);
         assert_eq!(layout.brain_stride, BRAIN_STRIDE);
@@ -763,8 +763,8 @@ mod tests {
     fn brain_layout_dynamic_is_consistent() {
         for (w, h) in [(4, 4), (6, 4), (8, 4), (8, 6), (8, 8), (12, 8)] {
             let layout = BrainLayout::new(w, h);
-            assert_eq!(layout.vision_w, w);
-            assert_eq!(layout.vision_h, h);
+            assert_eq!(layout.vision_width, w);
+            assert_eq!(layout.vision_height, h);
             let pixels = (w * h) as usize;
             assert_eq!(layout.vision_color_count, pixels * 4);
             assert_eq!(

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -285,7 +285,7 @@ impl GpuKernel {
         ))
         .expect("Failed to create GPU device");
 
-        let layout = BrainLayout::new(brain_config.vision_w, brain_config.vision_h);
+        let layout = BrainLayout::new(brain_config.vision_width, brain_config.vision_height);
         let brain_tick_stride = brain_config.brain_tick_stride;
 
         let storage_rw = wgpu::BufferUsages::STORAGE
@@ -461,11 +461,11 @@ impl GpuKernel {
         let common_src = include_str!("shaders/kernel/common.wgsl")
             .replace(
                 "const VISION_W: u32 = 8u;",
-                &format!("const VISION_W: u32 = {}u;", layout.vision_w),
+                &format!("const VISION_W: u32 = {}u;", layout.vision_width),
             )
             .replace(
                 "const VISION_H: u32 = 6u;",
-                &format!("const VISION_H: u32 = {}u;", layout.vision_h),
+                &format!("const VISION_H: u32 = {}u;", layout.vision_height),
             );
 
         // ── Compose physics shader ──

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -174,8 +174,8 @@ pub struct Agent {
 impl Agent {
     /// Create a new agent with an assigned GPU brain index, color, and zero death count.
     pub fn new(id: u32, position: Vec3, brain_idx: u32, config: BrainConfig, tick: u64) -> Self {
-        let vw = config.vision_w;
-        let vh = config.vision_h;
+        let vw = config.vision_width;
+        let vh = config.vision_height;
         Self {
             id,
             body: AgentBody::new(position),
@@ -364,8 +364,8 @@ pub fn mutate_config_with_strength(
         fatigue_floor: momentum
             .biased_perturb_f(&mut rng, parent.fatigue_floor, "fatigue_floor", strength)
             .clamp(0.05, 0.4),
-        vision_w: parent.vision_w,
-        vision_h: parent.vision_h,
+        vision_width: parent.vision_width,
+        vision_height: parent.vision_height,
         brain_tick_stride: parent.brain_tick_stride,
         vision_stride: parent.vision_stride,
         metabolic_rate: parent.metabolic_rate,
@@ -381,7 +381,7 @@ pub fn mutate_brain_state(state: &AgentBrainState, strength: f32) -> AgentBrainS
     let mut rng = rand::rng();
     let mut mutated = state.clone();
 
-    // Derive layout from actual state length (supports dynamic vision_w × vision_h).
+    // Derive layout from actual state length (supports dynamic vision_width × vision_height).
     // brain_stride = fc * DIM + DIM + DIM*DIM + FIXED_TAIL_SIZE
     let variable_part = state
         .brain_state
@@ -485,8 +485,8 @@ pub fn crossover_config(a: &BrainConfig, b: &BrainConfig) -> BrainConfig {
         } else {
             b.fatigue_floor
         },
-        vision_w: a.vision_w,
-        vision_h: a.vision_h,
+        vision_width: a.vision_width,
+        vision_height: a.vision_height,
         brain_tick_stride: a.brain_tick_stride,
         vision_stride: a.vision_stride,
         metabolic_rate: a.metabolic_rate,

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -174,8 +174,8 @@ pub struct Agent {
 impl Agent {
     /// Create a new agent with an assigned GPU brain index, color, and zero death count.
     pub fn new(id: u32, position: Vec3, brain_idx: u32, config: BrainConfig, tick: u64) -> Self {
-        let vw = config.vision_width;
-        let vh = config.vision_height;
+        let vision_width = config.vision_width;
+        let vision_height = config.vision_height;
         Self {
             id,
             body: AgentBody::new(position),
@@ -203,7 +203,7 @@ impl Agent {
             energy_history: std::collections::VecDeque::with_capacity(128),
             integrity_history: std::collections::VecDeque::with_capacity(128),
             fatigue_history: std::collections::VecDeque::with_capacity(128),
-            cached_frame: SensoryFrame::new_blank(vw, vh),
+            cached_frame: SensoryFrame::new_blank(vision_width, vision_height),
             cached_urgency: 0.0,
             cached_gradient: 0.0,
             cached_mean_attenuation: 0.0,

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -774,8 +774,8 @@ impl App {
                 &agent_info,
                 &initial_food,
                 self.governor_config.tick_budget as usize,
-                self.brain_config.vision_w,
-                self.brain_config.vision_h,
+                self.brain_config.vision_width,
+                self.brain_config.vision_height,
             ));
         }
     }
@@ -803,8 +803,8 @@ impl App {
                 &agent_info,
                 &initial_food,
                 self.governor_config.tick_budget as usize,
-                self.brain_config.vision_w,
-                self.brain_config.vision_h,
+                self.brain_config.vision_width,
+                self.brain_config.vision_height,
             ));
         }
     }

--- a/crates/xagent-sandbox/src/replay.rs
+++ b/crates/xagent-sandbox/src/replay.rs
@@ -30,7 +30,7 @@ pub struct TickRecord {
     pub fatigue_factor: f32,
     /// Motor output variance.
     pub motor_variance: f32,
-    /// Vision color data (vision_w * vision_h * 4 f32 values). Only stored at keyframes
+    /// Vision color data (vision_width * vision_height * 4 f32 values). Only stored at keyframes
     /// (every VISION_KEYFRAME_INTERVAL ticks) to save memory.
     pub vision_color: Option<Vec<f32>>,
 }
@@ -55,10 +55,10 @@ pub struct GenerationRecording {
     pub agent_count: usize,
     /// (agent_id, color) for each agent slot.
     pub agent_info: Vec<(u32, [f32; 3])>,
-    /// Visual field dimensions used during this generation.
-    pub vision_w: u32,
+    /// Visual field width used during this generation.
+    pub vision_width: u32,
     /// Visual field height used during this generation.
-    pub vision_h: u32,
+    pub vision_height: u32,
     /// Flat array indexed as `tick_records[tick * agent_count + agent_idx]`.
     pub tick_records: Vec<TickRecord>,
     /// Sparse food events (consumption + respawn).
@@ -74,8 +74,8 @@ impl GenerationRecording {
         agents: &[(u32, [f32; 3])],
         initial_food: &[[f32; 3]],
         estimated_ticks: usize,
-        vision_w: u32,
-        vision_h: u32,
+        vision_width: u32,
+        vision_height: u32,
     ) -> Self {
         let agent_count = agents.len();
         Self {
@@ -83,8 +83,8 @@ impl GenerationRecording {
             total_ticks: 0,
             agent_count,
             agent_info: agents.to_vec(),
-            vision_w,
-            vision_h,
+            vision_width,
+            vision_height,
             tick_records: Vec::with_capacity(estimated_ticks * agent_count),
             food_events: Vec::new(),
             initial_food_positions: initial_food.to_vec(),

--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1389,15 +1389,15 @@ impl<'a> TabContext<'a> {
                     ui.end_row();
 
                     ui.label("vision_width");
-                    let mut vw = b.vision_width as i32;
-                    ui.add(egui::DragValue::new(&mut vw).range(2..=32).speed(1));
-                    b.vision_width = vw.max(2) as u32;
+                    let mut vision_width = b.vision_width as i32;
+                    ui.add(egui::DragValue::new(&mut vision_width).range(2..=32).speed(1));
+                    b.vision_width = vision_width.max(2) as u32;
                     ui.end_row();
 
                     ui.label("vision_height");
-                    let mut vh = b.vision_height as i32;
-                    ui.add(egui::DragValue::new(&mut vh).range(2..=32).speed(1));
-                    b.vision_height = vh.max(2) as u32;
+                    let mut vision_height = b.vision_height as i32;
+                    ui.add(egui::DragValue::new(&mut vision_height).range(2..=32).speed(1));
+                    b.vision_height = vision_height.max(2) as u32;
                     ui.end_row();
 
                     ui.label("brain_tick_stride");

--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1390,13 +1390,21 @@ impl<'a> TabContext<'a> {
 
                     ui.label("vision_width");
                     let mut vision_width = b.vision_width as i32;
-                    ui.add(egui::DragValue::new(&mut vision_width).range(2..=32).speed(1));
+                    ui.add(
+                        egui::DragValue::new(&mut vision_width)
+                            .range(2..=32)
+                            .speed(1),
+                    );
                     b.vision_width = vision_width.max(2) as u32;
                     ui.end_row();
 
                     ui.label("vision_height");
                     let mut vision_height = b.vision_height as i32;
-                    ui.add(egui::DragValue::new(&mut vision_height).range(2..=32).speed(1));
+                    ui.add(
+                        egui::DragValue::new(&mut vision_height)
+                            .range(2..=32)
+                            .speed(1),
+                    );
                     b.vision_height = vision_height.max(2) as u32;
                     ui.end_row();
 

--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -88,7 +88,7 @@ pub struct AgentSnapshot {
     pub motor_turn: f32,
     /// Current behavior phase label.
     pub phase: &'static str,
-    /// Agent's visual field as RGBA floats (vision_w * vision_h * 4 values).
+    /// Agent's visual field as RGBA floats (vision_width * vision_height * 4 values).
     pub vision_color: Vec<f32>,
     /// Visual field dimensions.
     pub vision_width: u32,
@@ -706,8 +706,8 @@ impl<'a> TabContext<'a> {
                         motor_turn: record.motor_turn,
                         phase: crate::replay::GenerationRecording::phase_label(record.phase),
                         vision_color: record.vision_color.clone().unwrap_or_default(),
-                        vision_width: rec.vision_w,
-                        vision_height: rec.vision_h,
+                        vision_width: rec.vision_width,
+                        vision_height: rec.vision_height,
                         position: record.position,
                         yaw: record.yaw,
                         mean_attenuation: record.mean_attenuation,
@@ -787,8 +787,8 @@ impl<'a> TabContext<'a> {
                                 motor_turn: r.motor_turn,
                                 phase: crate::replay::GenerationRecording::phase_label(r.phase),
                                 vision_color: Vec::new(),
-                                vision_width: rec.vision_w,
-                                vision_height: rec.vision_h,
+                                vision_width: rec.vision_width,
+                                vision_height: rec.vision_height,
                                 position: r.position,
                                 yaw: r.yaw,
                                 mean_attenuation: r.mean_attenuation,
@@ -1388,16 +1388,16 @@ impl<'a> TabContext<'a> {
                     );
                     ui.end_row();
 
-                    ui.label("vision_w");
-                    let mut vw = b.vision_w as i32;
+                    ui.label("vision_width");
+                    let mut vw = b.vision_width as i32;
                     ui.add(egui::DragValue::new(&mut vw).range(2..=32).speed(1));
-                    b.vision_w = vw.max(2) as u32;
+                    b.vision_width = vw.max(2) as u32;
                     ui.end_row();
 
-                    ui.label("vision_h");
-                    let mut vh = b.vision_h as i32;
+                    ui.label("vision_height");
+                    let mut vh = b.vision_height as i32;
                     ui.add(egui::DragValue::new(&mut vh).range(2..=32).speed(1));
-                    b.vision_h = vh.max(2) as u32;
+                    b.vision_height = vh.max(2) as u32;
                     ui.end_row();
 
                     ui.label("brain_tick_stride");

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -28,7 +28,7 @@ fn agent_at(pos: Vec3) -> AgentBody {
 /// Create a blank sensory frame using the default brain config's vision dimensions.
 fn default_frame() -> xagent_shared::SensoryFrame {
     let cfg = xagent_shared::BrainConfig::default();
-    xagent_shared::SensoryFrame::new_blank(cfg.vision_w, cfg.vision_h)
+    xagent_shared::SensoryFrame::new_blank(cfg.vision_width, cfg.vision_height)
 }
 
 // ── Physics Tests ──────────────────────────────────────────────────────
@@ -331,8 +331,8 @@ fn sensory_frame_has_correct_dimensions() {
     let agent = agent_at(Vec3::new(0.0, spawn_y, 0.0));
 
     let cfg = xagent_shared::BrainConfig::default();
-    let vw = cfg.vision_w;
-    let vh = cfg.vision_h;
+    let vw = cfg.vision_width;
+    let vh = cfg.vision_height;
     let mut frame = xagent_shared::SensoryFrame::new_blank(vw, vh);
     xagent_sandbox::agent::senses::extract_senses(&agent, &world, 0, &mut frame);
 
@@ -1054,8 +1054,8 @@ fn cpu_vision_produces_correct_buffer_shape() {
     ];
 
     let cfg = BrainConfig::default();
-    let vw = cfg.vision_w;
-    let vh = cfg.vision_h;
+    let vw = cfg.vision_width;
+    let vh = cfg.vision_height;
     let mut frame = xagent_shared::SensoryFrame::new_blank(vw, vh);
     let agent_grid = xagent_sandbox::world::spatial::AgentGrid::from_positions(&positions, 256.0);
     xagent_sandbox::agent::senses::extract_senses_with_positions(

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1068,8 +1068,14 @@ fn cpu_vision_produces_correct_buffer_shape() {
         &mut frame,
     );
 
-    assert_eq!(frame.vision.color.len(), (vision_width * vision_height * 4) as usize);
-    assert_eq!(frame.vision.depth.len(), (vision_width * vision_height) as usize);
+    assert_eq!(
+        frame.vision.color.len(),
+        (vision_width * vision_height * 4) as usize
+    );
+    assert_eq!(
+        frame.vision.depth.len(),
+        (vision_width * vision_height) as usize
+    );
 }
 
 // ── Async Recording Persistence ───────────────────────────────────────

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -331,27 +331,27 @@ fn sensory_frame_has_correct_dimensions() {
     let agent = agent_at(Vec3::new(0.0, spawn_y, 0.0));
 
     let cfg = xagent_shared::BrainConfig::default();
-    let vw = cfg.vision_width;
-    let vh = cfg.vision_height;
-    let mut frame = xagent_shared::SensoryFrame::new_blank(vw, vh);
+    let vision_width = cfg.vision_width;
+    let vision_height = cfg.vision_height;
+    let mut frame = xagent_shared::SensoryFrame::new_blank(vision_width, vision_height);
     xagent_sandbox::agent::senses::extract_senses(&agent, &world, 0, &mut frame);
 
     assert_eq!(
-        frame.vision.width, vw,
+        frame.vision.width, vision_width,
         "Visual field width should match config"
     );
     assert_eq!(
-        frame.vision.height, vh,
+        frame.vision.height, vision_height,
         "Visual field height should match config"
     );
     assert_eq!(
         frame.vision.color.len(),
-        (vw * vh * 4) as usize,
+        (vision_width * vision_height * 4) as usize,
         "Color buffer should have width*height*4 elements"
     );
     assert_eq!(
         frame.vision.depth.len(),
-        (vw * vh) as usize,
+        (vision_width * vision_height) as usize,
         "Depth buffer should have width*height elements"
     );
 }
@@ -1054,9 +1054,9 @@ fn cpu_vision_produces_correct_buffer_shape() {
     ];
 
     let cfg = BrainConfig::default();
-    let vw = cfg.vision_width;
-    let vh = cfg.vision_height;
-    let mut frame = xagent_shared::SensoryFrame::new_blank(vw, vh);
+    let vision_width = cfg.vision_width;
+    let vision_height = cfg.vision_height;
+    let mut frame = xagent_shared::SensoryFrame::new_blank(vision_width, vision_height);
     let agent_grid = xagent_sandbox::world::spatial::AgentGrid::from_positions(&positions, 256.0);
     xagent_sandbox::agent::senses::extract_senses_with_positions(
         &agent,
@@ -1068,8 +1068,8 @@ fn cpu_vision_produces_correct_buffer_shape() {
         &mut frame,
     );
 
-    assert_eq!(frame.vision.color.len(), (vw * vh * 4) as usize);
-    assert_eq!(frame.vision.depth.len(), (vw * vh) as usize);
+    assert_eq!(frame.vision.color.len(), (vision_width * vision_height * 4) as usize);
+    assert_eq!(frame.vision.depth.len(), (vision_width * vision_height) as usize);
 }
 
 // ── Async Recording Persistence ───────────────────────────────────────

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -42,11 +42,11 @@ pub struct BrainConfig {
     #[serde(default = "default_fatigue_floor")]
     pub fatigue_floor: f32,
     /// Visual field width in pixels. Default 8.
-    #[serde(default = "default_vision_w")]
-    pub vision_w: u32,
+    #[serde(default = "default_vision_width")]
+    pub vision_width: u32,
     /// Visual field height in pixels. Default 6.
-    #[serde(default = "default_vision_h")]
-    pub vision_h: u32,
+    #[serde(default = "default_vision_height")]
+    pub vision_height: u32,
     /// Physics ticks per brain+vision cycle. Higher = faster but less responsive.
     /// Default 4.
     #[serde(default = "default_brain_tick_stride")]
@@ -110,11 +110,11 @@ fn default_fatigue_floor() -> f32 {
     0.1
 }
 
-fn default_vision_w() -> u32 {
+fn default_vision_width() -> u32 {
     8
 }
 
-fn default_vision_h() -> u32 {
+fn default_vision_height() -> u32 {
     6
 }
 
@@ -248,8 +248,8 @@ impl Default for BrainConfig {
             max_curiosity_bonus: 0.6,
             fatigue_recovery_sensitivity: 8.0,
             fatigue_floor: 0.1,
-            vision_w: 8,
-            vision_h: 6,
+            vision_width: 8,
+            vision_height: 6,
             brain_tick_stride: 4,
             vision_stride: 10,
             metabolic_rate: 1.0,
@@ -273,8 +273,8 @@ impl BrainConfig {
             max_curiosity_bonus: 0.6,
             fatigue_recovery_sensitivity: 8.0,
             fatigue_floor: 0.1,
-            vision_w: 6,
-            vision_h: 4,
+            vision_width: 6,
+            vision_height: 4,
             brain_tick_stride: 4,
             vision_stride: 10,
             metabolic_rate: 1.0,
@@ -296,8 +296,8 @@ impl BrainConfig {
             max_curiosity_bonus: 0.6,
             fatigue_recovery_sensitivity: 8.0,
             fatigue_floor: 0.1,
-            vision_w: 12,
-            vision_h: 8,
+            vision_width: 12,
+            vision_height: 8,
             brain_tick_stride: 4,
             vision_stride: 10,
             metabolic_rate: 1.0,

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -42,10 +42,10 @@ pub struct BrainConfig {
     #[serde(default = "default_fatigue_floor")]
     pub fatigue_floor: f32,
     /// Visual field width in pixels. Default 8.
-    #[serde(default = "default_vision_width")]
+    #[serde(default = "default_vision_width", alias = "vision_w")]
     pub vision_width: u32,
     /// Visual field height in pixels. Default 6.
-    #[serde(default = "default_vision_height")]
+    #[serde(default = "default_vision_height", alias = "vision_h")]
     pub vision_height: u32,
     /// Physics ticks per brain+vision cycle. Higher = faster but less responsive.
     /// Default 4.

--- a/crates/xagent-shared/src/sensory.rs
+++ b/crates/xagent-shared/src/sensory.rs
@@ -70,9 +70,9 @@ pub struct SensoryFrame {
 
 impl SensoryFrame {
     /// Create a blank sensory frame with pre-allocated vision buffers.
-    pub fn new_blank(vision_w: u32, vision_h: u32) -> Self {
+    pub fn new_blank(vision_width: u32, vision_height: u32) -> Self {
         Self {
-            vision: VisualField::new(vision_w, vision_h),
+            vision: VisualField::new(vision_width, vision_height),
             velocity: Vec3::ZERO,
             facing: Vec3::Z,
             angular_velocity: 0.0,


### PR DESCRIPTION
## Summary
- Renamed `vision_w`/`vision_h` to `vision_width`/`vision_height` across all Rust files and WGSL-adjacent Rust code (structs, fields, function parameters, constructor calls, doc comments)
- Added naming convention to `CLAUDE.md` under Code Style: avoid abbreviations in identifiers; use full words (with exceptions for buffer layout constants, loop variables, and external API types)

## Files changed
- `crates/xagent-shared/src/config.rs` — `BrainConfig` struct fields + default fns + preset constructors
- `crates/xagent-shared/src/sensory.rs` — `SensoryFrame::new_blank` parameters
- `crates/xagent-brain/src/buffers.rs` — `BrainLayout` struct fields + `new()` parameters + test assertions
- `crates/xagent-brain/src/gpu_kernel.rs` — `BrainLayout::new()` call + WGSL constant injection
- `crates/xagent-brain/src/gpu_brain.rs` — all `config.vision_w/h` call sites
- `crates/xagent-sandbox/src/replay.rs` — `GenerationRecording` fields + constructor
- `crates/xagent-sandbox/src/main.rs` — recording creation calls
- `crates/xagent-sandbox/src/ui.rs` — UI labels + field access + doc comment
- `crates/xagent-sandbox/src/agent/mod.rs` — `Agent::new`, `breed_from_parent`, crossover helpers
- `crates/xagent-sandbox/tests/integration.rs` — test helper function
- `CLAUDE.md` — naming convention rule added

## Test plan
- [x] `cargo check -p xagent-sandbox` passes
- [x] `cargo test -p xagent-sandbox` passes (65 unit + 3 bin + 35 integration = 103 tests)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)