### PR TITLE
feat: make agent movement speed configurable and evolvable

### DIFF
--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -672,6 +672,9 @@ pub fn init_brain_state_for(
     state[o_pred_ctx_wt + delta_fatigue_factor] = 1.0;
 
     // Heritable config values (stored per-agent for GPU access)
+    // TODO: once PR #52 merges, update `write_agent_heritable_config()` in
+    // gpu_kernel.rs to also write movement_speed so mid-generation config
+    // changes propagate to the GPU.
     state[o_pred_ctx_wt + delta_hab_sens] = config.habituation_sensitivity;
     state[o_pred_ctx_wt + delta_hab_curiosity] = config.max_curiosity_bonus;
     state[o_pred_ctx_wt + delta_fatigue_floor] = config.fatigue_floor;

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -671,10 +671,8 @@ pub fn init_brain_state_for(
     // Fatigue factor: 1.0 (no fatigue)
     state[o_pred_ctx_wt + delta_fatigue_factor] = 1.0;
 
-    // Heritable config values (stored per-agent for GPU access)
-    // TODO: once PR #52 merges, update `write_agent_heritable_config()` in
-    // gpu_kernel.rs to also write movement_speed so mid-generation config
-    // changes propagate to the GPU.
+    // Heritable config values (stored per-agent for GPU access and kept in
+    // sync by `write_agent_heritable_config()`, including `movement_speed`).
     state[o_pred_ctx_wt + delta_hab_sens] = config.habituation_sensitivity;
     state[o_pred_ctx_wt + delta_hab_curiosity] = config.max_curiosity_bonus;
     state[o_pred_ctx_wt + delta_fatigue_floor] = config.fatigue_floor;

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -65,12 +65,13 @@ pub const O_TICK_COUNT: usize = O_PREV_PREDICTION + DIM; // 9904
 pub const O_HAB_SENSITIVITY: usize = O_TICK_COUNT + 1; // 9905
 pub const O_HAB_MAX_CURIOSITY: usize = O_HAB_SENSITIVITY + 1; // 9906
 pub const O_FATIGUE_FLOOR: usize = O_HAB_MAX_CURIOSITY + 1; // 9907
-pub const BRAIN_STRIDE: usize = O_FATIGUE_FLOOR + 1; // 9908
+pub const O_MOVEMENT_SPEED: usize = O_FATIGUE_FLOOR + 1; // 9908
+pub const BRAIN_STRIDE: usize = O_MOVEMENT_SPEED + 1; // 9909
 
 /// Number of elements in `brain_state` from `O_PRED_CTX_WT` (inclusive)
 /// to `BRAIN_STRIDE` (exclusive). This tail is layout-independent: it
 /// doesn't change with feature_count / vision dimensions.
-pub const FIXED_TAIL_SIZE: usize = BRAIN_STRIDE - O_PRED_CTX_WT; // 372
+pub const FIXED_TAIL_SIZE: usize = BRAIN_STRIDE - O_PRED_CTX_WT; // 373
 
 // ── Pattern memory buffer offsets (per agent) ─────────────────────────
 
@@ -419,6 +420,7 @@ const O_TICK_COUNT: u32 = {O_TICK_COUNT}u;
 const O_HAB_SENSITIVITY: u32 = {O_HAB_SENSITIVITY}u;
 const O_HAB_MAX_CURIOSITY: u32 = {O_HAB_MAX_CURIOSITY}u;
 const O_FATIGUE_FLOOR: u32 = {O_FATIGUE_FLOOR}u;
+const O_MOVEMENT_SPEED: u32 = {O_MOVEMENT_SPEED}u;
 
 // Pattern memory offsets
 const O_PAT_STATES: u32 = {O_PAT_STATES}u;
@@ -656,6 +658,7 @@ pub fn init_brain_state_for(
     let delta_hab_sens = O_HAB_SENSITIVITY - O_PRED_CTX_WT;
     let delta_hab_curiosity = O_HAB_MAX_CURIOSITY - O_PRED_CTX_WT;
     let delta_fatigue_floor = O_FATIGUE_FLOOR - O_PRED_CTX_WT;
+    let delta_movement_speed = O_MOVEMENT_SPEED - O_PRED_CTX_WT;
 
     // Habituation attenuation: 1.0 (no attenuation initially)
     for i in 0..DIM {
@@ -672,6 +675,7 @@ pub fn init_brain_state_for(
     state[o_pred_ctx_wt + delta_hab_sens] = config.habituation_sensitivity;
     state[o_pred_ctx_wt + delta_hab_curiosity] = config.max_curiosity_bonus;
     state[o_pred_ctx_wt + delta_fatigue_floor] = config.fatigue_floor;
+    state[o_pred_ctx_wt + delta_movement_speed] = config.movement_speed;
 
     state
 }
@@ -720,7 +724,7 @@ mod tests {
 
     #[test]
     fn brain_stride_is_consistent() {
-        assert_eq!(BRAIN_STRIDE, O_FATIGUE_FLOOR + 1);
+        assert_eq!(BRAIN_STRIDE, O_MOVEMENT_SPEED + 1);
     }
 
     #[test]

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -167,7 +167,7 @@ impl BrainLayout {
             .and_then(|v| v.checked_add(NON_VISUAL_COUNT))
             .expect("vision dimensions overflow sensory stride");
         // brain_stride = feature_count * DIM + DIM + DIM*DIM + FIXED_TAIL_SIZE
-        // (FIXED_TAIL_SIZE = fixed fields starting at O_PRED_CTX_WT through O_FATIGUE_FLOOR, incl. position ring)
+        // (FIXED_TAIL_SIZE = fixed fields starting at O_PRED_CTX_WT through O_MOVEMENT_SPEED, incl. position ring)
         let brain_stride = feature_count
             .checked_mul(DIM)
             .and_then(|v| v.checked_add(DIM))

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -1453,8 +1453,8 @@ impl GpuKernel {
 
     /// Patch per-agent heritable config values in brain_state buffer.
     ///
-    /// Writes habituation_sensitivity, max_curiosity_bonus, and
-    /// fatigue_floor from the given BrainConfig into the agent's
+    /// Writes habituation_sensitivity, max_curiosity_bonus, fatigue_floor,
+    /// and movement_speed from the given BrainConfig into the agent's
     /// brain_state slots. Use this after `reset_agents()` to apply
     /// per-agent config variation.
     pub fn write_agent_heritable_config(&self, index: u32, config: &BrainConfig) {
@@ -1468,11 +1468,13 @@ impl GpuKernel {
         let first_delta = O_HAB_SENSITIVITY - O_PRED_CTX_WT;
         debug_assert_eq!(O_HAB_MAX_CURIOSITY - O_PRED_CTX_WT, first_delta + 1);
         debug_assert_eq!(O_FATIGUE_FLOOR - O_PRED_CTX_WT, first_delta + 2);
+        debug_assert_eq!(O_MOVEMENT_SPEED - O_PRED_CTX_WT, first_delta + 3);
 
         let values = [
             config.habituation_sensitivity,
             config.max_curiosity_bonus,
             config.fatigue_floor,
+            config.movement_speed,
         ];
         let byte_offset = ((i * bs + tail_base + first_delta) * 4) as u64;
         self.queue.write_buffer(

--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -493,9 +493,10 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
             let dz = cur_z - old_z;
             let displacement = sqrt(dx * dx + dz * dz);
 
-            // Expected displacement: accumulated forward * MOVE_SPEED * DT * stride
-            // Each brain tick, the agent moves fwd * MOVE_SPEED * DT * stride units
-            let expected = new_accum * MOVE_SPEED * wc_f32(WC_DT) * f32(wc_u32(WC_BRAIN_TICK_STRIDE));
+            // Expected displacement: accumulated forward * move_speed * DT * stride
+            // Each brain tick, the agent moves fwd * move_speed * DT * stride units
+            let move_speed = brain_state[b + O_MOVEMENT_SPEED];
+            let expected = new_accum * move_speed * wc_f32(WC_DT) * f32(wc_u32(WC_BRAIN_TICK_STRIDE));
             // Only penalize when the agent is actually trying to move;
             // idle agents (expected ≈ 0) keep fatigue_factor = 1.0.
             let expected_epsilon = 0.001;

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -143,7 +143,6 @@ const F_RESPAWN_TIMER: u32 = 3u;
 // ── Physics constants ───────────────────────────────────────────────────────
 
 const GRAVITY: f32 = 20.0;
-const MOVE_SPEED: f32 = 8.0;
 const TURN_SPEED: f32 = 3.0;
 const AGENT_HALF_HEIGHT: f32 = 1.0;
 const METABOLIC_BASE_COST: f32 = 0.0001;

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -54,10 +54,11 @@ const O_TICK_COUNT: u32 = O_PREV_PREDICTION + DIM;
 const O_HAB_SENSITIVITY: u32 = O_TICK_COUNT + 1u;
 const O_HAB_MAX_CURIOSITY: u32 = O_HAB_SENSITIVITY + 1u;
 const O_FATIGUE_FLOOR: u32 = O_HAB_MAX_CURIOSITY + 1u;
+const O_MOVEMENT_SPEED: u32 = O_FATIGUE_FLOOR + 1u;
 
 // ── Per-agent buffer strides ────────────────────────────────────────────────
 
-const BRAIN_STRIDE: u32 = O_FATIGUE_FLOOR + 1u;
+const BRAIN_STRIDE: u32 = O_MOVEMENT_SPEED + 1u;
 const PATTERN_STRIDE: u32 = 5251u;
 const HISTORY_STRIDE: u32 = 2370u;
 const FEATURES_STRIDE: u32 = FEATURE_COUNT;

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -98,7 +98,7 @@ fn agent_physics(agent_id: u32, tick: u32) {
 
     // Energy depletion
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414);
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * move_speed;
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -98,7 +98,8 @@ fn agent_physics(agent_id: u32, tick: u32) {
 
     // Energy depletion
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * move_speed * dt;
+    // Normalize by default speed (8.0) so baseline energy drain is unchanged.
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 8.0) * dt;
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -98,7 +98,7 @@ fn agent_physics(agent_id: u32, tick: u32) {
 
     // Energy depletion
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * move_speed;
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * move_speed * dt;
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -99,7 +99,7 @@ fn agent_physics(agent_id: u32, tick: u32) {
     // Energy depletion
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
     // Normalize by default speed (8.0) so baseline energy drain is unchanged.
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 8.0) * dt;
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 8.0);
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -59,8 +59,9 @@ fn agent_physics(agent_id: u32, tick: u32) {
     if desired_sq > 1.0 {
         desired = desired / sqrt(desired_sq);
     }
-    agent_phys[b + P_VEL_X] = desired.x * MOVE_SPEED;
-    agent_phys[b + P_VEL_Z] = desired.z * MOVE_SPEED;
+    let move_speed = brain_state[agent_id * BRAIN_STRIDE + O_MOVEMENT_SPEED];
+    agent_phys[b + P_VEL_X] = desired.x * move_speed;
+    agent_phys[b + P_VEL_Z] = desired.z * move_speed;
 
     // Gravity
     agent_phys[b + P_VEL_Y] = agent_phys[b + P_VEL_Y] - GRAVITY * dt;

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -96,7 +96,7 @@ fn phase_physics(tid: u32, tick: u32) {
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
     // Normalize by default speed (8.0) so baseline energy drain is unchanged;
     // faster agents pay proportionally more, slower agents pay less.
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 8.0) * dt;
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 8.0);
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -94,7 +94,7 @@ fn phase_physics(tid: u32, tick: u32) {
 
     // Energy depletion (scaled by metabolic_rate from brain config)
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414);
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * move_speed;
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -94,7 +94,9 @@ fn phase_physics(tid: u32, tick: u32) {
 
     // Energy depletion (scaled by metabolic_rate from brain config)
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * move_speed * dt;
+    // Normalize by default speed (8.0) so baseline energy drain is unchanged;
+    // faster agents pay proportionally more, slower agents pay less.
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 8.0) * dt;
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -55,8 +55,9 @@ fn phase_physics(tid: u32, tick: u32) {
     if desired_sq > 1.0 {
         desired = desired / sqrt(desired_sq);
     }
-    agent_phys[b + P_VEL_X] = desired.x * MOVE_SPEED;
-    agent_phys[b + P_VEL_Z] = desired.z * MOVE_SPEED;
+    let move_speed = brain_state[agent * BRAIN_STRIDE + O_MOVEMENT_SPEED];
+    agent_phys[b + P_VEL_X] = desired.x * move_speed;
+    agent_phys[b + P_VEL_Z] = desired.z * move_speed;
 
     // Gravity
     agent_phys[b + P_VEL_Y] = agent_phys[b + P_VEL_Y] - GRAVITY * dt;

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -94,7 +94,7 @@ fn phase_physics(tid: u32, tick: u32) {
 
     // Energy depletion (scaled by metabolic_rate from brain config)
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * move_speed;
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * move_speed * dt;
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -362,6 +362,9 @@ pub fn mutate_config_with_strength(
         vision_stride: parent.vision_stride,
         metabolic_rate: parent.metabolic_rate,
         integrity_scale: parent.integrity_scale,
+        movement_speed: momentum
+            .biased_perturb_f(&mut rng, parent.movement_speed, "movement_speed", strength)
+            .clamp(2.0, 20.0),
     }
 }
 
@@ -478,6 +481,11 @@ pub fn crossover_config(a: &BrainConfig, b: &BrainConfig) -> BrainConfig {
         vision_stride: a.vision_stride,
         metabolic_rate: a.metabolic_rate,
         integrity_scale: a.integrity_scale,
+        movement_speed: if rng.random::<f32>() < 0.5 {
+            a.movement_speed
+        } else {
+            b.movement_speed
+        },
     }
 }
 

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -686,6 +686,45 @@ mod tests {
     }
 
     #[test]
+    fn mutate_config_respects_movement_speed_bounds() {
+        let momentum = MutationMomentum::new(0.9);
+        // Push initial config to extreme values to verify clamps.
+        let too_fast = BrainConfig {
+            movement_speed: 100.0,
+            ..BrainConfig::default()
+        };
+        let too_slow = BrainConfig {
+            movement_speed: 0.1,
+            ..BrainConfig::default()
+        };
+        for _ in 0..50 {
+            let child = mutate_config_with_strength(&too_fast, 0.3, &momentum);
+            assert!(
+                child.movement_speed <= 20.0,
+                "movement_speed must be <= 20.0, got {}",
+                child.movement_speed,
+            );
+            assert!(
+                child.movement_speed >= 2.0,
+                "movement_speed must be >= 2.0, got {}",
+                child.movement_speed,
+            );
+
+            let child = mutate_config_with_strength(&too_slow, 0.3, &momentum);
+            assert!(
+                child.movement_speed <= 20.0,
+                "movement_speed must be <= 20.0, got {}",
+                child.movement_speed,
+            );
+            assert!(
+                child.movement_speed >= 2.0,
+                "movement_speed must be >= 2.0, got {}",
+                child.movement_speed,
+            );
+        }
+    }
+
+    #[test]
     fn hsv_to_rgb_outputs_in_unit_range() {
         let hues = [0.0, 30.0, 60.0, 120.0, 180.0, 240.0, 300.0, 359.999];
         for &h in &hues {

--- a/crates/xagent-sandbox/src/momentum.rs
+++ b/crates/xagent-sandbox/src/momentum.rs
@@ -128,6 +128,7 @@ impl MutationMomentum {
             ("habituation_sensitivity", parent.habituation_sensitivity),
             ("max_curiosity_bonus", parent.max_curiosity_bonus),
             ("fatigue_floor", parent.fatigue_floor),
+            ("movement_speed", parent.movement_speed),
         ];
 
         for (name, parent_val) in &params {
@@ -144,6 +145,7 @@ impl MutationMomentum {
                         "habituation_sensitivity" => w.habituation_sensitivity,
                         "max_curiosity_bonus" => w.max_curiosity_bonus,
                         "fatigue_floor" => w.fatigue_floor,
+                        "movement_speed" => w.movement_speed,
                         _ => *parent_val,
                     };
                     w_val - parent_val

--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1932,6 +1932,9 @@ impl<'a> TabContext<'a> {
                         ui.label("fatigue_floor");
                         ui.monospace(format!("{:.2}", cfg.fatigue_floor));
                         ui.end_row();
+                        ui.label("movement_speed");
+                        ui.monospace(format!("{:.1}", cfg.movement_speed));
+                        ui.end_row();
                     });
             });
         }

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -374,6 +374,7 @@ mod tests {
         assert_eq!(config.vision_height, 6);
         assert!((config.metabolic_rate - 0.01).abs() < 1e-6);
         assert!((config.integrity_scale - 0.01).abs() < 1e-6);
+        assert!((config.movement_speed - 8.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -60,6 +60,10 @@ pub struct BrainConfig {
     /// Lower = agents take less damage. Higher = hazard zones are deadlier.
     #[serde(default = "default_integrity_scale")]
     pub integrity_scale: f32,
+    /// Base movement speed (units per second). Default 8.0.
+    /// Heritable: mutated during breeding, clamped to [2.0, 20.0].
+    #[serde(default = "default_movement_speed")]
+    pub movement_speed: f32,
 }
 
 /// Configuration for the world simulation.
@@ -128,6 +132,10 @@ fn default_metabolic_rate() -> f32 {
 
 fn default_integrity_scale() -> f32 {
     0.01
+}
+
+fn default_movement_speed() -> f32 {
+    8.0
 }
 
 /// Describes an agent to be spawned into the world.
@@ -245,6 +253,7 @@ impl Default for BrainConfig {
             vision_stride: default_vision_stride(),
             metabolic_rate: default_metabolic_rate(),
             integrity_scale: default_integrity_scale(),
+            movement_speed: default_movement_speed(),
         }
     }
 }
@@ -269,6 +278,7 @@ impl BrainConfig {
             vision_stride: default_vision_stride(),
             metabolic_rate: default_metabolic_rate(),
             integrity_scale: default_integrity_scale(),
+            movement_speed: default_movement_speed(),
         }
     }
 
@@ -291,6 +301,7 @@ impl BrainConfig {
             vision_stride: default_vision_stride(),
             metabolic_rate: default_metabolic_rate(),
             integrity_scale: default_integrity_scale(),
+            movement_speed: default_movement_speed(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `movement_speed` as a heritable `BrainConfig` field (default 8.0, matching the former hardcoded `MOVE_SPEED` constant)
- Store per-agent in brain_state GPU buffer at new `O_MOVEMENT_SPEED` offset; both `kernel_tick.wgsl` and `phase_physics.wgsl` read from brain_state instead of the hardcoded constant
- Evolutionary mutation clamps to [2.0, 20.0]; crossover picks from either parent
- UI config panel displays the value

## Test plan
- [x] `cargo check -p xagent-sandbox` passes
- [x] All 103 tests pass (`cargo test -p xagent-sandbox`: 65 lib + 3 bin + 35 integration)
- [ ] Verify agents move at expected speed in sandbox (visual check)
- [ ] Verify evolution produces speed variation across generations

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)