### PR TITLE
refactor: expand abbreviated identifiers to full words

### DIFF
--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -1452,7 +1452,7 @@ impl GpuKernel {
         ];
         let byte_offset = ((i * bs + tail_base + first_delta) * 4) as u64;
         self.queue.write_buffer(
-            &self.brain_state_buf,
+            &self.brain_state_buffer,
             byte_offset,
             bytemuck::cast_slice(&values),
         );

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -72,24 +72,24 @@ pub struct GpuKernel {
     food_count: usize,
 
     // ── Shared buffers (14 storage + 2 uniform + 1 indirect) ──
-    agent_phys_buf: wgpu::Buffer,
-    decision_buf: wgpu::Buffer,
-    heightmap_buf: wgpu::Buffer,
-    biome_buf: wgpu::Buffer,
+    agent_phys_buffer: wgpu::Buffer,
+    decision_buffer: wgpu::Buffer,
+    heightmap_buffer: wgpu::Buffer,
+    biome_buffer: wgpu::Buffer,
     world_config_bufs: [wgpu::Buffer; 2],
-    food_state_buf: wgpu::Buffer,
-    food_flags_buf: wgpu::Buffer,
-    food_grid_buf: wgpu::Buffer,
-    agent_grid_buf: wgpu::Buffer,
-    collision_scratch_buf: wgpu::Buffer,
-    sensory_buf: wgpu::Buffer,
-    brain_state_buf: wgpu::Buffer,
-    pattern_buf: wgpu::Buffer,
-    history_buf: wgpu::Buffer,
-    brain_config_buf: wgpu::Buffer,
+    food_state_buffer: wgpu::Buffer,
+    food_flags_buffer: wgpu::Buffer,
+    food_grid_buffer: wgpu::Buffer,
+    agent_grid_buffer: wgpu::Buffer,
+    collision_scratch_buffer: wgpu::Buffer,
+    sensory_buffer: wgpu::Buffer,
+    brain_state_buffer: wgpu::Buffer,
+    pattern_buffer: wgpu::Buffer,
+    history_buffer: wgpu::Buffer,
+    brain_config_buffer: wgpu::Buffer,
 
     // ── Indirect dispatch ──
-    dispatch_args_buf: wgpu::Buffer,
+    dispatch_args_buffer: wgpu::Buffer,
 
     // ── Pipelines ──
     prepare_pipeline: wgpu::ComputePipeline,
@@ -100,11 +100,11 @@ pub struct GpuKernel {
     global_pipeline: wgpu::ComputePipeline,
     vision_stride: u32,
     bind_groups: [wgpu::BindGroup; 2],
-    active_config_idx: usize,
+    active_config_index: usize,
 
     // ── Async state readback (double-buffered, non-blocking) ──
     state_staging: [wgpu::Buffer; 2],
-    staging_idx: usize,                  // which buffer to write NEXT
+    staging_index: usize,                  // which buffer to write NEXT
     staging_in_flight: [bool; 2],        // submitted, not yet collected
     staging_ready: [Arc<AtomicBool>; 2], // map_async callback fired
     state_cache: Vec<f32>,
@@ -180,7 +180,7 @@ impl GpuKernel {
             }
             self.staging_ready[i].store(false, Ordering::Release);
         }
-        self.staging_idx = 0;
+        self.staging_index = 0;
 
         // Clear async telemetry state so stale readbacks from the
         // previous generation don't leak into the new one.
@@ -205,13 +205,13 @@ impl GpuKernel {
             history_data.extend_from_slice(&init_action_history());
         }
         self.queue
-            .write_buffer(&self.brain_state_buf, 0, bytemuck::cast_slice(&brain_data));
+            .write_buffer(&self.brain_state_buffer, 0, bytemuck::cast_slice(&brain_data));
         self.queue
-            .write_buffer(&self.pattern_buf, 0, bytemuck::cast_slice(&pattern_data));
+            .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
         self.queue
-            .write_buffer(&self.history_buf, 0, bytemuck::cast_slice(&history_data));
+            .write_buffer(&self.history_buffer, 0, bytemuck::cast_slice(&history_data));
         self.queue.write_buffer(
-            &self.brain_config_buf,
+            &self.brain_config_buffer,
             0,
             bytemuck::cast_slice(&build_config_for(brain_config, &self.layout)),
         );
@@ -294,25 +294,25 @@ impl GpuKernel {
 
         // ── Storage buffers (13 read-write + 2 read-only) ──
 
-        let agent_phys_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let agent_phys_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_agent_phys"),
             size: (n * PHYS_STRIDE * 4) as u64,
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let decision_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let decision_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_decision"),
             size: (n * DECISION_STRIDE * 4) as u64,
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let heightmap_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let heightmap_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_heightmap"),
             size: (TERRAIN_VPS * TERRAIN_VPS * 4) as u64,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let biome_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let biome_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_biome"),
             size: (BIOME_GRID_RES * BIOME_GRID_RES * 4) as u64,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
@@ -332,67 +332,67 @@ impl GpuKernel {
                 mapped_at_creation: false,
             }),
         ];
-        let food_state_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let food_state_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_food_state"),
             size: ((f * FOOD_STATE_STRIDE * 4) as u64).max(4),
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let food_flags_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let food_flags_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_food_flags"),
             size: ((f * 4) as u64).max(4),
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let food_grid_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let food_grid_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_food_grid"),
             size: ((grid_cells * FOOD_GRID_CELL_STRIDE * 4) as u64).max(4),
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let agent_grid_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let agent_grid_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_agent_grid"),
             size: (grid_cells * AGENT_GRID_CELL_STRIDE * 4) as u64,
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let collision_scratch_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let collision_scratch_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_collision_scratch"),
             size: (n * 3 * 4) as u64,
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let sensory_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let sensory_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_sensory"),
             size: (n * layout.sensory_stride * 4) as u64,
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let brain_state_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let brain_state_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_brain_state"),
             size: (n * layout.brain_stride * 4) as u64,
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let pattern_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let pattern_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_pattern"),
             size: (n * PATTERN_STRIDE * 4) as u64,
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let history_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let history_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_history"),
             size: (n * HISTORY_STRIDE * 4) as u64,
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let brain_config_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let brain_config_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_brain_config"),
             size: (CONFIG_SIZE * 4) as u64,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let dispatch_args_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        let dispatch_args_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_dispatch_args"),
             size: 6 * 4, // 2 × (x, y, z) u32 triplets
             usage: wgpu::BufferUsages::INDIRECT
@@ -448,11 +448,11 @@ impl GpuKernel {
             pattern_data.extend_from_slice(&init_pattern_memory());
             history_data.extend_from_slice(&init_action_history());
         }
-        queue.write_buffer(&brain_state_buf, 0, bytemuck::cast_slice(&brain_data));
-        queue.write_buffer(&pattern_buf, 0, bytemuck::cast_slice(&pattern_data));
-        queue.write_buffer(&history_buf, 0, bytemuck::cast_slice(&history_data));
+        queue.write_buffer(&brain_state_buffer, 0, bytemuck::cast_slice(&brain_data));
+        queue.write_buffer(&pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
+        queue.write_buffer(&history_buffer, 0, bytemuck::cast_slice(&history_data));
         queue.write_buffer(
-            &brain_config_buf,
+            &brain_config_buffer,
             0,
             bytemuck::cast_slice(&build_config_for(brain_config, &layout)),
         );
@@ -504,10 +504,10 @@ impl GpuKernel {
     // Each of 128 threads holds one element in registers.
     // subgroupShuffle exchanges values within 32-wide subgroups.
     var my_val: f32 = -3.0;
-    var my_idx: u32 = 0u;
+    var my_index: u32 = 0u;
     if (tid < MEMORY_CAP) {
         my_val = s_similarities[tid];
-        my_idx = s_sort_idx[tid];
+        my_index = shared_sort_indices[tid];
     }
 
     for (var stage: u32 = 0u; stage < 5u; stage = stage + 1u) {
@@ -516,7 +516,7 @@ impl GpuKernel {
                 let half = 1u << (stage - step);
                 let partner_tid = tid ^ half;
                 let partner_val = subgroupShuffle(my_val, sgid ^ half);
-                let partner_idx = subgroupShuffle(my_idx, sgid ^ half);
+                let partner_idx = subgroupShuffle(my_index, sgid ^ half);
 
                 let i = min(tid, partner_tid);
                 let descending = ((i >> (stage + 1u)) & 1u) == 0u;
@@ -524,7 +524,7 @@ impl GpuKernel {
                 let want_max = i_am_low == descending;
                 if ((my_val < partner_val) == want_max) {
                     my_val = partner_val;
-                    my_idx = partner_idx;
+                    my_index = partner_idx;
                 }
             }
             // No barrier needed — subgroup ops are synchronous within subgroup
@@ -534,7 +534,7 @@ impl GpuKernel {
     // Write back to shared memory for stages 5–6
     if (tid < MEMORY_CAP) {
         s_similarities[tid] = my_val;
-        s_sort_idx[tid] = my_idx;
+        shared_sort_indices[tid] = my_index;
     }
     workgroupBarrier();
 
@@ -552,15 +552,15 @@ impl GpuKernel {
 
                 let val_i = s_similarities[i];
                 let val_j = s_similarities[j];
-                let idx_i = s_sort_idx[i];
-                let idx_j = s_sort_idx[j];
+                let idx_i = shared_sort_indices[i];
+                let idx_j = shared_sort_indices[j];
 
                 let should_swap = (descending && val_i < val_j) || (!descending && val_i > val_j);
                 if (should_swap) {
                     s_similarities[i] = val_j;
                     s_similarities[j] = val_i;
-                    s_sort_idx[i] = idx_j;
-                    s_sort_idx[j] = idx_i;
+                    shared_sort_indices[i] = idx_j;
+                    shared_sort_indices[j] = idx_i;
                 }
             }
             workgroupBarrier();
@@ -844,19 +844,19 @@ impl GpuKernel {
                 entries: &[
                     wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: agent_phys_buf.as_entire_binding(),
+                        resource: agent_phys_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 1,
-                        resource: decision_buf.as_entire_binding(),
+                        resource: decision_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: heightmap_buf.as_entire_binding(),
+                        resource: heightmap_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 3,
-                        resource: biome_buf.as_entire_binding(),
+                        resource: biome_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 4,
@@ -864,47 +864,47 @@ impl GpuKernel {
                     },
                     wgpu::BindGroupEntry {
                         binding: 5,
-                        resource: food_state_buf.as_entire_binding(),
+                        resource: food_state_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 6,
-                        resource: food_flags_buf.as_entire_binding(),
+                        resource: food_flags_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 7,
-                        resource: food_grid_buf.as_entire_binding(),
+                        resource: food_grid_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 8,
-                        resource: agent_grid_buf.as_entire_binding(),
+                        resource: agent_grid_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 9,
-                        resource: collision_scratch_buf.as_entire_binding(),
+                        resource: collision_scratch_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 10,
-                        resource: sensory_buf.as_entire_binding(),
+                        resource: sensory_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 11,
-                        resource: brain_state_buf.as_entire_binding(),
+                        resource: brain_state_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 12,
-                        resource: pattern_buf.as_entire_binding(),
+                        resource: pattern_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 13,
-                        resource: history_buf.as_entire_binding(),
+                        resource: history_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 14,
-                        resource: brain_config_buf.as_entire_binding(),
+                        resource: brain_config_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
                         binding: 15,
-                        resource: dispatch_args_buf.as_entire_binding(),
+                        resource: dispatch_args_buffer.as_entire_binding(),
                     },
                 ],
             })
@@ -919,22 +919,22 @@ impl GpuKernel {
             queue,
             agent_count,
             food_count,
-            agent_phys_buf,
-            decision_buf,
-            heightmap_buf,
-            biome_buf,
+            agent_phys_buffer,
+            decision_buffer,
+            heightmap_buffer,
+            biome_buffer,
             world_config_bufs,
-            food_state_buf,
-            food_flags_buf,
-            food_grid_buf,
-            agent_grid_buf,
-            collision_scratch_buf,
-            sensory_buf,
-            brain_state_buf,
-            pattern_buf,
-            history_buf,
-            brain_config_buf,
-            dispatch_args_buf,
+            food_state_buffer,
+            food_flags_buffer,
+            food_grid_buffer,
+            agent_grid_buffer,
+            collision_scratch_buffer,
+            sensory_buffer,
+            brain_state_buffer,
+            pattern_buffer,
+            history_buffer,
+            brain_config_buffer,
+            dispatch_args_buffer,
             prepare_pipeline,
             physics_pipeline,
             vision_pipeline,
@@ -943,9 +943,9 @@ impl GpuKernel {
             global_pipeline,
             vision_stride: brain_config.vision_stride,
             bind_groups,
-            active_config_idx: 0,
+            active_config_index: 0,
             state_staging,
-            staging_idx: 0,
+            staging_index: 0,
             staging_in_flight: [false, false],
             staging_ready: [
                 Arc::new(AtomicBool::new(false)),
@@ -973,12 +973,12 @@ impl GpuKernel {
         food_timers: &[f32],
     ) {
         self.queue.write_buffer(
-            &self.heightmap_buf,
+            &self.heightmap_buffer,
             0,
             bytemuck::cast_slice(terrain_heights),
         );
         self.queue
-            .write_buffer(&self.biome_buf, 0, bytemuck::cast_slice(biome_grid));
+            .write_buffer(&self.biome_buffer, 0, bytemuck::cast_slice(biome_grid));
 
         let mut food_data = Vec::with_capacity(food_positions.len() * FOOD_STATE_STRIDE);
         for (i, &(x, y, z)) in food_positions.iter().enumerate() {
@@ -988,14 +988,14 @@ impl GpuKernel {
             food_data.push(food_timers[i]);
         }
         self.queue
-            .write_buffer(&self.food_state_buf, 0, bytemuck::cast_slice(&food_data));
+            .write_buffer(&self.food_state_buffer, 0, bytemuck::cast_slice(&food_data));
 
         let flags: Vec<u32> = food_consumed
             .iter()
             .map(|&c| if c { 1 } else { 0 })
             .collect();
         self.queue
-            .write_buffer(&self.food_flags_buf, 0, bytemuck::cast_slice(&flags));
+            .write_buffer(&self.food_flags_buffer, 0, bytemuck::cast_slice(&flags));
     }
 
     /// Upload initial agent physics state.
@@ -1021,7 +1021,7 @@ impl GpuKernel {
             data[base + P_PROCESSING_SLOTS] = proc_slots as f32;
         }
         self.queue
-            .write_buffer(&self.agent_phys_buf, 0, bytemuck::cast_slice(&data));
+            .write_buffer(&self.agent_phys_buffer, 0, bytemuck::cast_slice(&data));
     }
 
     /// Write world config uniform with batch parameters.
@@ -1043,7 +1043,7 @@ impl GpuKernel {
         );
         wc[WC_PHASE_MASK] = phase_mask as f32;
         self.queue.write_buffer(
-            &self.world_config_bufs[self.active_config_idx],
+            &self.world_config_bufs[self.active_config_index],
             0,
             bytemuck::cast_slice(&wc),
         );
@@ -1069,7 +1069,7 @@ impl GpuKernel {
         );
         wc[WC_PHASE_MASK] = phase_mask as f32;
         self.queue.write_buffer(
-            &self.world_config_bufs[self.active_config_idx],
+            &self.world_config_bufs[self.active_config_index],
             0,
             bytemuck::cast_slice(&wc),
         );
@@ -1104,7 +1104,7 @@ impl GpuKernel {
             if run_vision || run_brain {
                 let mut pass = encoder.begin_compute_pass(&Default::default());
                 pass.set_pipeline(&self.prepare_pipeline);
-                pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
+                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
                 pass.dispatch_workgroups(1, 1, 1);
             }
             for c in cycle..chunk_end {
@@ -1113,21 +1113,21 @@ impl GpuKernel {
                 {
                     let mut pass = encoder.begin_compute_pass(&Default::default());
                     pass.set_pipeline(&self.physics_pipeline);
-                    pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
+                    pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
                     pass.set_push_constants(0, bytemuck::cast_slice(&pc));
                     pass.dispatch_workgroups(1, 1, 1);
                 }
                 if run_vision {
                     let mut pass = encoder.begin_compute_pass(&Default::default());
                     pass.set_pipeline(&self.vision_pipeline);
-                    pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
-                    pass.dispatch_workgroups_indirect(&self.dispatch_args_buf, 0);
+                    pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
+                    pass.dispatch_workgroups_indirect(&self.dispatch_args_buffer, 0);
                 }
                 if run_brain {
                     let mut pass = encoder.begin_compute_pass(&Default::default());
                     pass.set_pipeline(&self.brain_pipeline);
-                    pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
-                    pass.dispatch_workgroups_indirect(&self.dispatch_args_buf, 12);
+                    pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
+                    pass.dispatch_workgroups_indirect(&self.dispatch_args_buffer, 12);
                 }
             }
             self.queue.submit(std::iter::once(encoder.finish()));
@@ -1146,22 +1146,22 @@ impl GpuKernel {
             {
                 let mut pass = encoder.begin_compute_pass(&Default::default());
                 pass.set_pipeline(&self.physics_pipeline);
-                pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
+                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
                 pass.set_push_constants(0, bytemuck::cast_slice(&pc));
                 pass.dispatch_workgroups(1, 1, 1);
             }
         }
         encoder.copy_buffer_to_buffer(
-            &self.agent_phys_buf,
+            &self.agent_phys_buffer,
             0,
-            &self.state_staging[self.staging_idx],
+            &self.state_staging[self.staging_index],
             0,
             buf_size,
         );
         self.queue.submit(std::iter::once(encoder.finish()));
         self.device.poll(wgpu::Maintain::Wait).panic_on_timeout();
 
-        self.active_config_idx = 1 - self.active_config_idx;
+        self.active_config_index = 1 - self.active_config_index;
     }
 
     /// Non-blocking: collect any ready staging buffers into state_cache.
@@ -1193,7 +1193,7 @@ impl GpuKernel {
     /// Returns true if dispatched, false if skipped.
     pub fn dispatch_batch(&mut self, start_tick: u64, ticks_to_run: u32) -> bool {
         // Check if the write-target staging buffer is free.
-        let widx = self.staging_idx;
+        let widx = self.staging_index;
         if self.staging_in_flight[widx] {
             return false;
         }
@@ -1239,7 +1239,7 @@ impl GpuKernel {
             {
                 let mut pass = encoder.begin_compute_pass(&Default::default());
                 pass.set_pipeline(&self.prepare_pipeline);
-                pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
+                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
                 pass.dispatch_workgroups(1, 1, 1);
             }
 
@@ -1247,7 +1247,7 @@ impl GpuKernel {
             {
                 let mut pass = encoder.begin_compute_pass(&Default::default());
                 pass.set_pipeline(&self.kernel_pipeline);
-                pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
+                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
                 pass.dispatch_workgroups(self.agent_count, 1, 1);
             }
 
@@ -1257,7 +1257,7 @@ impl GpuKernel {
                 let gpc: [u32; 2] = [tick_for_global as u32, 0];
                 let mut pass = encoder.begin_compute_pass(&Default::default());
                 pass.set_pipeline(&self.global_pipeline);
-                pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
+                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
                 pass.set_push_constants(0, bytemuck::cast_slice(&gpc));
                 pass.dispatch_workgroups(1, 1, 1);
             }
@@ -1266,8 +1266,8 @@ impl GpuKernel {
             {
                 let mut pass = encoder.begin_compute_pass(&Default::default());
                 pass.set_pipeline(&self.vision_pipeline);
-                pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
-                pass.dispatch_workgroups_indirect(&self.dispatch_args_buf, 0);
+                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
+                pass.dispatch_workgroups_indirect(&self.dispatch_args_buffer, 0);
             }
 
             self.queue.submit(std::iter::once(encoder.finish()));
@@ -1289,7 +1289,7 @@ impl GpuKernel {
             {
                 let mut pass = encoder.begin_compute_pass(&Default::default());
                 pass.set_pipeline(&self.physics_pipeline);
-                pass.set_bind_group(0, &self.bind_groups[self.active_config_idx], &[]);
+                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
                 pass.set_push_constants(0, bytemuck::cast_slice(&pc));
                 pass.dispatch_workgroups(1, 1, 1);
             }
@@ -1297,7 +1297,7 @@ impl GpuKernel {
 
         // Async state readback into staging[widx]
         encoder.copy_buffer_to_buffer(
-            &self.agent_phys_buf,
+            &self.agent_phys_buffer,
             0,
             &self.state_staging[widx],
             0,
@@ -1315,8 +1315,8 @@ impl GpuKernel {
                 }
             });
         self.staging_in_flight[widx] = true;
-        self.staging_idx = 1 - self.staging_idx;
-        self.active_config_idx = 1 - self.active_config_idx;
+        self.staging_index = 1 - self.staging_index;
+        self.active_config_index = 1 - self.active_config_index;
         true
     }
 
@@ -1343,7 +1343,7 @@ impl GpuKernel {
         });
 
         let mut encoder = self.device.create_command_encoder(&Default::default());
-        encoder.copy_buffer_to_buffer(&self.agent_phys_buf, 0, &staging, 0, buf_size);
+        encoder.copy_buffer_to_buffer(&self.agent_phys_buffer, 0, &staging, 0, buf_size);
         self.queue.submit(std::iter::once(encoder.finish()));
 
         let slice = staging.slice(..);
@@ -1368,7 +1368,7 @@ impl GpuKernel {
         let brain_offset = (i * bs * 4) as u64;
         let brain_size = (bs * 4) as u64;
         self.read_buffer_range(
-            &self.brain_state_buf,
+            &self.brain_state_buffer,
             brain_offset,
             brain_size,
             &mut state.brain_state,
@@ -1376,12 +1376,12 @@ impl GpuKernel {
 
         let pat_offset = (i * PATTERN_STRIDE * 4) as u64;
         let pat_size = (PATTERN_STRIDE * 4) as u64;
-        self.read_buffer_range(&self.pattern_buf, pat_offset, pat_size, &mut state.patterns);
+        self.read_buffer_range(&self.pattern_buffer, pat_offset, pat_size, &mut state.patterns);
 
         let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
         let hist_size = (HISTORY_STRIDE * 4) as u64;
         self.read_buffer_range(
-            &self.history_buf,
+            &self.history_buffer,
             hist_offset,
             hist_size,
             &mut state.history,
@@ -1397,21 +1397,21 @@ impl GpuKernel {
 
         let brain_offset = (i * bs * 4) as u64;
         self.queue.write_buffer(
-            &self.brain_state_buf,
+            &self.brain_state_buffer,
             brain_offset,
             bytemuck::cast_slice(&state.brain_state),
         );
 
         let pat_offset = (i * PATTERN_STRIDE * 4) as u64;
         self.queue.write_buffer(
-            &self.pattern_buf,
+            &self.pattern_buffer,
             pat_offset,
             bytemuck::cast_slice(&state.patterns),
         );
 
         let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
         self.queue.write_buffer(
-            &self.history_buf,
+            &self.history_buffer,
             hist_offset,
             bytemuck::cast_slice(&state.history),
         );
@@ -1492,17 +1492,17 @@ impl GpuKernel {
 
         let brain_offset = (i * bs * 4) as u64;
         encoder.copy_buffer_to_buffer(
-            &self.brain_state_buf,
+            &self.brain_state_buffer,
             brain_offset,
             &brain_staging,
             0,
             brain_size,
         );
         let pat_offset = (i * PATTERN_STRIDE * 4) as u64;
-        encoder.copy_buffer_to_buffer(&self.pattern_buf, pat_offset, &pattern_staging, 0, pat_size);
+        encoder.copy_buffer_to_buffer(&self.pattern_buffer, pat_offset, &pattern_staging, 0, pat_size);
         let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
         encoder.copy_buffer_to_buffer(
-            &self.history_buf,
+            &self.history_buffer,
             hist_offset,
             &history_staging,
             0,
@@ -1667,11 +1667,11 @@ impl GpuKernel {
         debug_assert_eq!(history_data.len(), count * HISTORY_STRIDE);
 
         self.queue
-            .write_buffer(&self.brain_state_buf, 0, bytemuck::cast_slice(&brain_data));
+            .write_buffer(&self.brain_state_buffer, 0, bytemuck::cast_slice(&brain_data));
         self.queue
-            .write_buffer(&self.pattern_buf, 0, bytemuck::cast_slice(&pattern_data));
+            .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
         self.queue
-            .write_buffer(&self.history_buf, 0, bytemuck::cast_slice(&history_data));
+            .write_buffer(&self.history_buffer, 0, bytemuck::cast_slice(&history_data));
     }
 
     /// Non-blocking version of `reset_agents`. Returns false if async staging
@@ -1693,7 +1693,7 @@ impl GpuKernel {
             }
             self.staging_ready[i].store(false, Ordering::Release);
         }
-        self.staging_idx = 0;
+        self.staging_index = 0;
 
         let n = self.agent_count as usize;
 
@@ -1712,13 +1712,13 @@ impl GpuKernel {
             history_data.extend_from_slice(&init_action_history());
         }
         self.queue
-            .write_buffer(&self.brain_state_buf, 0, bytemuck::cast_slice(&brain_data));
+            .write_buffer(&self.brain_state_buffer, 0, bytemuck::cast_slice(&brain_data));
         self.queue
-            .write_buffer(&self.pattern_buf, 0, bytemuck::cast_slice(&pattern_data));
+            .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
         self.queue
-            .write_buffer(&self.history_buf, 0, bytemuck::cast_slice(&history_data));
+            .write_buffer(&self.history_buffer, 0, bytemuck::cast_slice(&history_data));
         self.queue.write_buffer(
-            &self.brain_config_buf,
+            &self.brain_config_buffer,
             0,
             bytemuck::cast_slice(&build_config_for(brain_config, &self.layout)),
         );
@@ -1765,7 +1765,7 @@ impl GpuKernel {
         let sensory_size = (ss * 4) as u64;
         let mut sensory = Vec::with_capacity(ss);
         self.read_buffer_range(
-            &self.sensory_buf,
+            &self.sensory_buffer,
             sensory_offset,
             sensory_size,
             &mut sensory,
@@ -1776,7 +1776,7 @@ impl GpuKernel {
         let dec_offset = (i * DECISION_STRIDE * 4) as u64;
         let dec_size = (DECISION_STRIDE * 4) as u64;
         let mut decision = Vec::with_capacity(DECISION_STRIDE);
-        self.read_buffer_range(&self.decision_buf, dec_offset, dec_size, &mut decision);
+        self.read_buffer_range(&self.decision_buffer, dec_offset, dec_size, &mut decision);
         let motor_base = DIM + DIM; // prediction(32) + credit(32)
         let motor_fwd = decision[motor_base];
         let motor_turn = decision[motor_base + 1];
@@ -1786,7 +1786,7 @@ impl GpuKernel {
         let brain_offset = (i * bs * 4) as u64;
         let brain_size = (bs * 4) as u64;
         let mut brain = Vec::with_capacity(bs);
-        self.read_buffer_range(&self.brain_state_buf, brain_offset, brain_size, &mut brain);
+        self.read_buffer_range(&self.brain_state_buffer, brain_offset, brain_size, &mut brain);
 
         // Compute dynamic brain-state offsets from layout's feature_count
         let dyn_pred_ctx_wt = fc * DIM + DIM + DIM * DIM;
@@ -1823,7 +1823,7 @@ impl GpuKernel {
         let phys_offset = (i * PHYS_STRIDE * 4) as u64;
         let phys_size = (PHYS_STRIDE * 4) as u64;
         let mut phys = Vec::with_capacity(PHYS_STRIDE);
-        self.read_buffer_range(&self.agent_phys_buf, phys_offset, phys_size, &mut phys);
+        self.read_buffer_range(&self.agent_phys_buffer, phys_offset, phys_size, &mut phys);
         let gradient = phys[P_GRADIENT_OUT];
         let urgency = phys[P_URGENCY_OUT];
         let prediction_error = phys[P_PREDICTION_ERROR];
@@ -1886,7 +1886,7 @@ impl GpuKernel {
 
         let sensory_offset = (i * ss * 4) as u64;
         encoder.copy_buffer_to_buffer(
-            &self.sensory_buf,
+            &self.sensory_buffer,
             sensory_offset,
             &self.telemetry_staging.sensory,
             0,
@@ -1895,7 +1895,7 @@ impl GpuKernel {
 
         let dec_offset = (i * DECISION_STRIDE * 4) as u64;
         encoder.copy_buffer_to_buffer(
-            &self.decision_buf,
+            &self.decision_buffer,
             dec_offset,
             &self.telemetry_staging.decision,
             0,
@@ -1904,7 +1904,7 @@ impl GpuKernel {
 
         let brain_offset = (i * bs * 4) as u64;
         encoder.copy_buffer_to_buffer(
-            &self.brain_state_buf,
+            &self.brain_state_buffer,
             brain_offset,
             &self.telemetry_staging.brain,
             0,
@@ -1913,7 +1913,7 @@ impl GpuKernel {
 
         let phys_offset = (i * PHYS_STRIDE * 4) as u64;
         encoder.copy_buffer_to_buffer(
-            &self.agent_phys_buf,
+            &self.agent_phys_buffer,
             phys_offset,
             &self.telemetry_staging.phys,
             0,

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -104,7 +104,7 @@ pub struct GpuKernel {
 
     // ── Async state readback (double-buffered, non-blocking) ──
     state_staging: [wgpu::Buffer; 2],
-    staging_index: usize,                  // which buffer to write NEXT
+    staging_index: usize,                // which buffer to write NEXT
     staging_in_flight: [bool; 2],        // submitted, not yet collected
     staging_ready: [Arc<AtomicBool>; 2], // map_async callback fired
     state_cache: Vec<f32>,
@@ -204,8 +204,11 @@ impl GpuKernel {
             pattern_data.extend_from_slice(&init_pattern_memory());
             history_data.extend_from_slice(&init_action_history());
         }
-        self.queue
-            .write_buffer(&self.brain_state_buffer, 0, bytemuck::cast_slice(&brain_data));
+        self.queue.write_buffer(
+            &self.brain_state_buffer,
+            0,
+            bytemuck::cast_slice(&brain_data),
+        );
         self.queue
             .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
         self.queue
@@ -1376,7 +1379,12 @@ impl GpuKernel {
 
         let pat_offset = (i * PATTERN_STRIDE * 4) as u64;
         let pat_size = (PATTERN_STRIDE * 4) as u64;
-        self.read_buffer_range(&self.pattern_buffer, pat_offset, pat_size, &mut state.patterns);
+        self.read_buffer_range(
+            &self.pattern_buffer,
+            pat_offset,
+            pat_size,
+            &mut state.patterns,
+        );
 
         let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
         let hist_size = (HISTORY_STRIDE * 4) as u64;
@@ -1499,7 +1507,13 @@ impl GpuKernel {
             brain_size,
         );
         let pat_offset = (i * PATTERN_STRIDE * 4) as u64;
-        encoder.copy_buffer_to_buffer(&self.pattern_buffer, pat_offset, &pattern_staging, 0, pat_size);
+        encoder.copy_buffer_to_buffer(
+            &self.pattern_buffer,
+            pat_offset,
+            &pattern_staging,
+            0,
+            pat_size,
+        );
         let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
         encoder.copy_buffer_to_buffer(
             &self.history_buffer,
@@ -1666,8 +1680,11 @@ impl GpuKernel {
         debug_assert_eq!(pattern_data.len(), count * PATTERN_STRIDE);
         debug_assert_eq!(history_data.len(), count * HISTORY_STRIDE);
 
-        self.queue
-            .write_buffer(&self.brain_state_buffer, 0, bytemuck::cast_slice(&brain_data));
+        self.queue.write_buffer(
+            &self.brain_state_buffer,
+            0,
+            bytemuck::cast_slice(&brain_data),
+        );
         self.queue
             .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
         self.queue
@@ -1711,8 +1728,11 @@ impl GpuKernel {
             pattern_data.extend_from_slice(&init_pattern_memory());
             history_data.extend_from_slice(&init_action_history());
         }
-        self.queue
-            .write_buffer(&self.brain_state_buffer, 0, bytemuck::cast_slice(&brain_data));
+        self.queue.write_buffer(
+            &self.brain_state_buffer,
+            0,
+            bytemuck::cast_slice(&brain_data),
+        );
         self.queue
             .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
         self.queue
@@ -1786,7 +1806,12 @@ impl GpuKernel {
         let brain_offset = (i * bs * 4) as u64;
         let brain_size = (bs * 4) as u64;
         let mut brain = Vec::with_capacity(bs);
-        self.read_buffer_range(&self.brain_state_buffer, brain_offset, brain_size, &mut brain);
+        self.read_buffer_range(
+            &self.brain_state_buffer,
+            brain_offset,
+            brain_size,
+            &mut brain,
+        );
 
         // Compute dynamic brain-state offsets from layout's feature_count
         let dyn_pred_ctx_wt = fc * DIM + DIM + DIM * DIM;

--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -9,7 +9,7 @@ var<workgroup> s_encoded: array<f32, 32>;
 var<workgroup> s_habituated: array<f32, 32>;
 var<workgroup> s_homeo: array<f32, 6>;
 var<workgroup> s_similarities: array<f32, 128>;  // reused for decay tracking in pass 7
-var<workgroup> s_sort_idx: array<u32, 128>;   // tracks pattern index through bitonic sort
+var<workgroup> shared_sort_indices: array<u32, 128>;   // tracks pattern index through bitonic sort
 var<workgroup> s_recall: array<f32, 17>;
 var<workgroup> s_prediction: array<f32, 32>;
 var<workgroup> s_credit: array<f32, 32>;
@@ -201,7 +201,7 @@ fn coop_recall_topk(agent_id: u32, tid: u32 /* SUBGROUP_TOPK_PARAMS */) {
 
     // Initialize sort index: threads 0..127
     if (tid < MEMORY_CAP) {
-        s_sort_idx[tid] = tid;
+        shared_sort_indices[tid] = tid;
     }
     workgroupBarrier();
 
@@ -221,15 +221,15 @@ fn coop_recall_topk(agent_id: u32, tid: u32 /* SUBGROUP_TOPK_PARAMS */) {
 
                 let val_i = s_similarities[i];
                 let val_j = s_similarities[j];
-                let idx_i = s_sort_idx[i];
-                let idx_j = s_sort_idx[j];
+                let idx_i = shared_sort_indices[i];
+                let idx_j = shared_sort_indices[j];
 
                 let should_swap = (descending && val_i < val_j) || (!descending && val_i > val_j);
                 if (should_swap) {
                     s_similarities[i] = val_j;
                     s_similarities[j] = val_i;
-                    s_sort_idx[i] = idx_j;
-                    s_sort_idx[j] = idx_i;
+                    shared_sort_indices[i] = idx_j;
+                    shared_sort_indices[j] = idx_i;
                 }
             }
             workgroupBarrier();
@@ -242,7 +242,7 @@ fn coop_recall_topk(agent_id: u32, tid: u32 /* SUBGROUP_TOPK_PARAMS */) {
         var count: u32 = 0u;
         for (var k: u32 = 0u; k < RECALL_K; k = k + 1u) {
             if (s_similarities[k] <= -1.5) { break; }
-            let idx = s_sort_idx[k];
+            let idx = shared_sort_indices[k];
             s_recall[k] = f32(idx);
             count = count + 1u;
             pattern_buf[p_base + O_PAT_META + idx * 3u + 1u] = tick;

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -169,11 +169,11 @@ fn agent_food_detect(agent_id: u32, tid: u32) {
         }
     }
 
-    // Two-phase shared-memory reduction (s_similarities/s_sort_idx are 128 elements)
+    // Two-phase shared-memory reduction (s_similarities/shared_sort_indices are 128 elements)
     // Phase 1: first 128 threads write directly
     if (tid < 128u) {
         s_similarities[tid] = local_best_dist_sq;
-        s_sort_idx[tid] = local_best_idx;
+        shared_sort_indices[tid] = local_best_idx;
     }
     workgroupBarrier();
 
@@ -182,7 +182,7 @@ fn agent_food_detect(agent_id: u32, tid: u32) {
         let slot = tid - 128u;
         if (local_best_dist_sq < s_similarities[slot]) {
             s_similarities[slot] = local_best_dist_sq;
-            s_sort_idx[slot] = local_best_idx;
+            shared_sort_indices[slot] = local_best_idx;
         }
     }
     workgroupBarrier();
@@ -193,7 +193,7 @@ fn agent_food_detect(agent_id: u32, tid: u32) {
         for (var i = 0u; i < 128u; i++) {
             if (s_similarities[i] < best_dist_sq) {
                 best_dist_sq = s_similarities[i];
-                best_idx = s_sort_idx[i];
+                best_idx = shared_sort_indices[i];
             }
         }
         if (best_idx != 0xFFFFFFFFu) {

--- a/crates/xagent-sandbox/src/agent/senses.rs
+++ b/crates/xagent-sandbox/src/agent/senses.rs
@@ -168,7 +168,7 @@ enum AgentSlice<'a> {
 
 /// Fixed-step ray marching for terrain, food, and agent intersection.
 ///
-/// Advances a ray from `origin` in direction `dir` in increments of `step` units,
+/// Advances a ray from `origin` in direction `direction` in increments of `step` units,
 /// checking for food items, other agents, and terrain at each step. Returns the
 /// hit color and distance traveled. If no hit within `max_dist`, returns sky color.
 ///

--- a/crates/xagent-sandbox/src/agent/senses.rs
+++ b/crates/xagent-sandbox/src/agent/senses.rs
@@ -178,7 +178,7 @@ enum AgentSlice<'a> {
 /// zero directional signal for food.
 fn march_ray_unified(
     origin: Vec3,
-    dir: Vec3,
+    direction: Vec3,
     world: &WorldState,
     max_dist: f32,
     step: f32,
@@ -191,7 +191,7 @@ fn march_ray_unified(
     let food_radius_sq: f32 = 1.0 * 1.0;
 
     // Early-out: upward-pointing rays above terrain are almost certainly sky.
-    if dir.y > 0.3 {
+    if direction.y > 0.3 {
         let origin_h = world.terrain.height_at(origin.x, origin.z);
         if origin.y > origin_h {
             return (sky, max_dist);
@@ -199,7 +199,7 @@ fn march_ray_unified(
     }
 
     let num_steps = (max_dist / step) as u32;
-    let dir_step = dir * step;
+    let dir_step = direction * step;
     let mut p = origin;
     for s in 0..num_steps {
         // Check food items via spatial grid (O(1) per step)

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1049,9 +1049,9 @@ impl App {
         (true, spawned)
     }
 
-    fn log_msg(&mut self, msg: String) {
-        println!("{}", msg);
-        self.console_log.push_back(msg);
+    fn log_msg(&mut self, message: String) {
+        println!("{}", message);
+        self.console_log.push_back(message);
         if self.console_log.len() > 200 {
             self.console_log.pop_front();
         }
@@ -2120,7 +2120,7 @@ impl ApplicationHandler for App {
                                                 };
                                             AgentSnapshot {
                                                 id: a.id,
-                                                gen: a.generation,
+                                                generation: a.generation,
                                                 energy: a.body.body.internal.energy,
                                                 max_energy: a.body.body.internal.max_energy,
                                                 integrity: a.body.body.internal.integrity,
@@ -2523,7 +2523,7 @@ impl ApplicationHandler for App {
                                                                 let status = if !snap.alive { "💀" } else { "" };
                                                                 ui.label(format!(
                                                                     "Agent {} (g{}) {}",
-                                                                    snap.id, snap.gen, status
+                                                                    snap.id, snap.generation, status
                                                                 ));
                                                             });
                                                             ui.horizontal(|ui| {

--- a/crates/xagent-sandbox/src/renderer/mod.rs
+++ b/crates/xagent-sandbox/src/renderer/mod.rs
@@ -882,10 +882,10 @@ impl Renderer {
     }
 
     /// Submit the command buffer and present the surface.
-    /// Call this after appending any additional render passes (e.g. egui) to `ctx.encoder`.
-    pub fn finish_frame(&self, ctx: FrameContext) {
-        self.queue.submit(std::iter::once(ctx.encoder.finish()));
-        ctx.surface_output.present();
+    /// Call this after appending any additional render passes (e.g. egui) to `context.encoder`.
+    pub fn finish_frame(&self, context: FrameContext) {
+        self.queue.submit(std::iter::once(context.encoder.finish()));
+        context.surface_output.present();
     }
 }
 

--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -55,7 +55,7 @@ impl SortMode {
 #[derive(Clone)]
 pub struct AgentSnapshot {
     pub id: u32,
-    pub gen: u32,
+    pub generation: u32,
     pub energy: f32,
     pub max_energy: f32,
     pub integrity: f32,
@@ -259,7 +259,7 @@ pub struct TabContext<'a> {
 /// Holds egui state needed across frames: context, winit integration, wgpu renderer,
 /// and the offscreen texture used to embed the 3D viewport inside an egui panel.
 pub struct EguiIntegration {
-    pub ctx: egui::Context,
+    pub context: egui::Context,
     winit_state: egui_winit::State,
     wgpu_renderer: egui_wgpu::Renderer,
 
@@ -282,10 +282,10 @@ impl EguiIntegration {
         viewport_width: u32,
         viewport_height: u32,
     ) -> Self {
-        let ctx = egui::Context::default();
+        let context = egui::Context::default();
 
         let winit_state = egui_winit::State::new(
-            ctx.clone(),
+            context.clone(),
             egui::ViewportId::ROOT,
             window,
             None, // native_pixels_per_point — let egui auto-detect
@@ -312,7 +312,7 @@ impl EguiIntegration {
             wgpu_renderer.register_native_texture(device, &color_view, wgpu::FilterMode::Linear);
 
         Self {
-            ctx,
+            context,
             winit_state,
             wgpu_renderer,
             viewport_color_format: surface_format,
@@ -419,13 +419,13 @@ impl EguiIntegration {
         ui_fn: impl FnMut(&egui::Context),
     ) {
         let raw_input = self.winit_state.take_egui_input(window);
-        let full_output = self.ctx.run(raw_input, ui_fn);
+        let full_output = self.context.run(raw_input, ui_fn);
 
         self.winit_state
             .handle_platform_output(window, full_output.platform_output);
 
         let tris = self
-            .ctx
+            .context
             .tessellate(full_output.shapes, full_output.pixels_per_point);
 
         // Upload changed textures (font atlas on first frame, etc.)
@@ -493,7 +493,7 @@ impl<'a> egui_dock::TabViewer for TabContext<'a> {
                     .agents
                     .iter()
                     .find(|a| a.id == *id)
-                    .map(|a| format!("Agent {} (g{})", a.id, a.gen))
+                    .map(|a| format!("Agent {} (g{})", a.id, a.generation))
                     .unwrap_or_else(|| format!("Agent {} (?)", id));
                 format!("🧠 {}", name).into()
             }
@@ -578,7 +578,7 @@ impl<'a> TabContext<'a> {
         ui.horizontal(|ui| {
             let (rect, _) = ui.allocate_exact_size(egui::vec2(14.0, 14.0), egui::Sense::hover());
             ui.painter().circle_filled(rect.center(), 7.0, color);
-            ui.heading(format!("Agent {} (Gen {})", snap.id, snap.gen));
+            ui.heading(format!("Agent {} (Gen {})", snap.id, snap.generation));
             if !snap.alive {
                 ui.label(egui::RichText::new("DEAD").color(egui::Color32::RED));
             }
@@ -680,7 +680,7 @@ impl<'a> TabContext<'a> {
                     let (id, color) = rec.agent_info[replay.selected_agent_idx];
                     replay_snap = AgentSnapshot {
                         id,
-                        gen: rec.generation,
+                        generation: rec.generation,
                         energy: record.energy,
                         max_energy: 1.0,
                         integrity: record.integrity,
@@ -761,7 +761,7 @@ impl<'a> TabContext<'a> {
                             let (id, color) = rec.agent_info[i];
                             AgentSnapshot {
                                 id,
-                                gen: rec.generation,
+                                generation: rec.generation,
                                 energy: r.energy,
                                 max_energy: 1.0,
                                 integrity: r.integrity,

--- a/crates/xagent-sandbox/src/world/entity.rs
+++ b/crates/xagent-sandbox/src/world/entity.rs
@@ -137,7 +137,7 @@ pub fn update_food(
 fn append_cube(
     vertices: &mut Vec<Vertex>,
     indices: &mut Vec<u32>,
-    pos: Vec3,
+    position: Vec3,
     size: f32,
     color: [f32; 3],
 ) {
@@ -146,14 +146,14 @@ fn append_cube(
 
     #[rustfmt::skip]
     let p: [[f32; 3]; 8] = [
-        [pos.x - h, pos.y - h, pos.z + h],
-        [pos.x + h, pos.y - h, pos.z + h],
-        [pos.x + h, pos.y + h, pos.z + h],
-        [pos.x - h, pos.y + h, pos.z + h],
-        [pos.x - h, pos.y - h, pos.z - h],
-        [pos.x + h, pos.y - h, pos.z - h],
-        [pos.x + h, pos.y + h, pos.z - h],
-        [pos.x - h, pos.y + h, pos.z - h],
+        [position.x - h, position.y - h, position.z + h],
+        [position.x + h, position.y - h, position.z + h],
+        [position.x + h, position.y + h, position.z + h],
+        [position.x - h, position.y + h, position.z + h],
+        [position.x - h, position.y - h, position.z - h],
+        [position.x + h, position.y - h, position.z - h],
+        [position.x + h, position.y + h, position.z - h],
+        [position.x - h, position.y + h, position.z - h],
     ];
 
     let shades = [1.0_f32, 0.9, 0.85, 0.7, 0.8, 0.75];

--- a/crates/xagent-sandbox/src/world/spatial.rs
+++ b/crates/xagent-sandbox/src/world/spatial.rs
@@ -80,16 +80,16 @@ impl FoodGrid {
     }
 
     /// Mark a food item as consumed (remove from its cell).
-    pub fn remove(&mut self, idx: usize, x: f32, z: f32) {
+    pub fn remove(&mut self, index: usize, x: f32, z: f32) {
         if let Some(flat) = self.flat_index(x, z) {
-            self.cells[flat].retain(|&i| i != idx);
+            self.cells[flat].retain(|&i| i != index);
         }
     }
 
     /// Insert a food item into the grid at position (x, z).
-    pub fn insert(&mut self, idx: usize, x: f32, z: f32) {
+    pub fn insert(&mut self, index: usize, x: f32, z: f32) {
         if let Some(flat) = self.flat_index(x, z) {
-            self.cells[flat].push(idx);
+            self.cells[flat].push(index);
         }
     }
 

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -21,8 +21,8 @@ fn test_world_with_seed(seed: u64) -> WorldState {
     })
 }
 
-fn agent_at(pos: Vec3) -> AgentBody {
-    AgentBody::new(pos)
+fn agent_at(position: Vec3) -> AgentBody {
+    AgentBody::new(position)
 }
 
 /// Create a blank sensory frame using the default brain config's vision dimensions.


### PR DESCRIPTION
## Summary
- Renames all `_buf` struct fields to `_buffer` in `gpu_kernel.rs` (14 fields)
- Renames `active_config_idx` → `active_config_index` and `staging_idx` → `staging_index` in `gpu_kernel.rs`
- Renames `gen: u32` → `generation: u32` in `AgentSnapshot` (ui.rs + all call sites)
- Renames `ctx: egui::Context` → `context: egui::Context` in `EguiIntegration` (ui.rs)
- Renames `idx` → `index` in `FoodGrid::insert`/`remove` (spatial.rs)
- Renames `pos` → `position` in `append_cube` (entity.rs)
- Renames `dir` → `direction` in `march_ray_unified` (senses.rs)
- Renames `msg` → `message` in `log_msg` (main.rs)
- Renames `ctx` → `context` in `finish_frame` (renderer/mod.rs)
- Renames `pos` → `position` in `agent_at` (integration.rs)
- Renames `my_idx` → `my_index` and `s_sort_idx` → `shared_sort_indices` in WGSL shaders (brain_tick.wgsl, kernel_tick.wgsl, embedded string in gpu_kernel.rs)

## Test plan
- [x] `cargo check -p xagent-sandbox` passes
- [x] `cargo test -p xagent-sandbox` passes (103 tests: 65 lib + 3 bin + 35 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)