### PR TITLE
diag: investigate terrain-height agent Y — add diagnostics and regression tests

### DIFF
--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1668,17 +1668,19 @@ impl ApplicationHandler for App {
 
                                 // Diagnostic: log first readback Y vs terrain height
                                 if !self.readback_logged {
-                                    self.readback_logged = true;
                                     if let Some(world) = &self.world {
                                         let n = self.agents.len().min(5);
-                                        for i in 0..n {
-                                            let a = &self.agents[i];
-                                            let p = a.body.body.position;
-                                            let terrain_y = world.terrain.height_at(p.x, p.z);
-                                            log::info!(
-                                                "[TERRAIN-DIAG] Agent {} pos=({:.2}, {:.2}, {:.2}) terrain_y={:.2} diff={:.2}",
-                                                i, p.x, p.y, p.z, terrain_y, p.y - terrain_y,
-                                            );
+                                        if n > 0 {
+                                            for i in 0..n {
+                                                let a = &self.agents[i];
+                                                let p = a.body.body.position;
+                                                let terrain_y = world.terrain.height_at(p.x, p.z);
+                                                log::info!(
+                                                    "[TERRAIN-DIAG] Agent {} pos=({:.2}, {:.2}, {:.2}) terrain_y={:.2} diff={:.2}",
+                                                    i, p.x, p.y, p.z, terrain_y, p.y - terrain_y,
+                                                );
+                                            }
+                                            self.readback_logged = true;
                                         }
                                     }
                                 }

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -364,6 +364,9 @@ struct App {
     // Adaptive GPU tick budget — keeps dispatch under ~8ms wall time
     gpu_tick_budget: u32,
 
+    // Diagnostic: log first readback Y vs terrain height
+    readback_logged: bool,
+
     // Sidebar sort mode
     sort_mode: SortMode,
 
@@ -463,6 +466,7 @@ impl App {
             viewport_hovered: false,
             chart_window: 120,
             orbit_mode: false,
+            readback_logged: false,
             logger,
             agent_instance_buffer: None,
             agent_instance_count: 0,
@@ -1660,6 +1664,23 @@ impl ApplicationHandler for App {
                                     a.cached_motor.turn = state[base + P_MOTOR_TURN_OUT];
                                     a.cached_gradient = state[base + P_GRADIENT_OUT];
                                     a.cached_urgency = state[base + P_URGENCY_OUT];
+                                }
+
+                                // Diagnostic: log first readback Y vs terrain height
+                                if !self.readback_logged {
+                                    self.readback_logged = true;
+                                    if let Some(world) = &self.world {
+                                        let n = self.agents.len().min(5);
+                                        for i in 0..n {
+                                            let a = &self.agents[i];
+                                            let p = a.body.body.position;
+                                            let terrain_y = world.terrain.height_at(p.x, p.z);
+                                            println!(
+                                                "[TERRAIN-DIAG] Agent {} pos=({:.2}, {:.2}, {:.2}) terrain_y={:.2} diff={:.2}",
+                                                i, p.x, p.y, p.z, terrain_y, p.y - terrain_y,
+                                            );
+                                        }
+                                    }
                                 }
                             }
 

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1675,7 +1675,7 @@ impl ApplicationHandler for App {
                                             let a = &self.agents[i];
                                             let p = a.body.body.position;
                                             let terrain_y = world.terrain.height_at(p.x, p.z);
-                                            println!(
+                                            log::info!(
                                                 "[TERRAIN-DIAG] Agent {} pos=({:.2}, {:.2}, {:.2}) terrain_y={:.2} diff={:.2}",
                                                 i, p.x, p.y, p.z, terrain_y, p.y - terrain_y,
                                             );

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1466,14 +1466,14 @@ fn gpu_agents_follow_terrain_height() {
     }
 
     let brain = BrainConfig::default();
-    let wc = WorldConfig {
+    let world_config = WorldConfig {
         seed: 42,
         ..Default::default()
     };
     let agent_count = 10;
 
-    let result = bench::run_bench(brain, wc.clone(), agent_count, 200);
-    let world = WorldState::new(wc);
+    let result = bench::run_bench(brain, world_config.clone(), agent_count, 200);
+    let world = WorldState::new(world_config);
 
     for (i, pos) in result.final_positions.iter().enumerate() {
         let x = pos[0];
@@ -1496,7 +1496,7 @@ fn gpu_agents_follow_terrain_height() {
         // allow small float tolerance (0.99) but reject agents sunk into the ground.
         assert!(
             diff >= 0.99 && diff < 5.0,
-            "Agent {} at ({:.2}, {:.2}, {:.2}): Y should be near terrain height {:.2}, but diff={:.2}",
+            "Agent {} at ({:.2}, {:.2}, {:.2}): expected Y to be 0.99..5.0 above terrain height {:.2}, but y - terrain_y = {:.2}",
             i, x, y, z, terrain_y, diff
         );
     }
@@ -1513,15 +1513,15 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
     }
 
     let brain = BrainConfig::default();
-    let wc = WorldConfig {
+    let world_config = WorldConfig {
         seed: 42,
         ..Default::default()
     };
     let agent_count = 10;
-    let world = WorldState::new(wc.clone());
+    let world = WorldState::new(world_config.clone());
     let food_count = world.food_items.len();
 
-    let mut mk = GpuKernel::new(agent_count as u32, food_count, &brain, &wc);
+    let mut kernel = GpuKernel::new(agent_count as u32, food_count, &brain, &world_config);
 
     let heights = world.terrain.heights.clone();
     let biomes = world.biome_map.grid_as_u32();
@@ -1532,7 +1532,7 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
         .collect();
     let food_consumed: Vec<bool> = world.food_items.iter().map(|f| f.consumed).collect();
     let food_timers: Vec<f32> = world.food_items.iter().map(|f| f.respawn_timer).collect();
-    mk.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
+    kernel.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
 
     let spawn_positions: Vec<glam::Vec3> = (0..agent_count)
         .map(|_| world.safe_spawn_position())
@@ -1549,10 +1549,10 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
             )
         })
         .collect();
-    mk.upload_agents(&agent_data);
+    kernel.upload_agents(&agent_data);
 
     // Read state before any ticks (should match uploaded positions)
-    let state_before = mk.read_full_state_blocking();
+    let state_before = kernel.read_full_state_blocking();
     for i in 0..agent_count {
         let base = i * PHYS_STRIDE;
         let y = state_before[base + P_POS_Y];
@@ -1567,13 +1567,13 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
     }
 
     // Run 1 tick on the same kernel and verify agents stay near terrain.
-    // Using `mk` directly (not bench::run_bench) so the pre- and post-tick
+    // Using `kernel` directly (not bench::run_bench) so the pre- and post-tick
     // states come from the same kernel instance.
     assert!(
-        mk.dispatch_batch(0, 1),
+        kernel.dispatch_batch(0, 1),
         "dispatch_batch should return true indicating ticks were submitted"
     );
-    let state_after = mk.read_full_state_blocking();
+    let state_after = kernel.read_full_state_blocking();
     for i in 0..agent_count {
         let base = i * PHYS_STRIDE;
         let x = state_after[base + P_POS_X];

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1531,7 +1531,13 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
         .collect();
     let food_consumed: Vec<bool> = world.food_items.iter().map(|f| f.consumed).collect();
     let food_timers: Vec<f32> = world.food_items.iter().map(|f| f.respawn_timer).collect();
-    kernel.upload_world(&world.terrain.heights, &biomes, &food_pos, &food_consumed, &food_timers);
+    kernel.upload_world(
+        &world.terrain.heights,
+        &biomes,
+        &food_pos,
+        &food_consumed,
+        &food_timers,
+    );
 
     let spawn_positions: Vec<glam::Vec3> = (0..agent_count)
         .map(|_| world.safe_spawn_position())

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1565,7 +1565,10 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
     // Run 1 tick on the same kernel and verify agents stay near terrain.
     // Using `mk` directly (not bench::run_bench) so the pre- and post-tick
     // states come from the same kernel instance.
-    mk.dispatch_batch(0, 1);
+    assert!(
+        mk.dispatch_batch(0, 1),
+        "dispatch_batch should return true indicating ticks were submitted"
+    );
     let state_after = mk.read_full_state_blocking();
     for i in 0..agent_count {
         let base = i * PHYS_STRIDE;

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1455,3 +1455,128 @@ fn gpu_non_multiple_ticks_matching_strides_no_crash() {
         assert!(pos[2].is_finite(), "NaN/inf z after non-multiple ticks");
     }
 }
+
+// ── GPU Terrain Height Tests ────────────────────────────────────────
+
+#[test]
+fn gpu_agents_follow_terrain_height() {
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    let brain = BrainConfig::default();
+    let wc = WorldConfig {
+        seed: 42,
+        ..Default::default()
+    };
+    let agent_count = 10;
+
+    let result = bench::run_bench(brain, wc.clone(), agent_count, 200);
+    let world = WorldState::new(wc);
+
+    for (i, pos) in result.final_positions.iter().enumerate() {
+        let x = pos[0];
+        let y = pos[1];
+        let z = pos[2];
+
+        // Skip NaN positions (shouldn't happen but guard)
+        if !x.is_finite() || !y.is_finite() || !z.is_finite() {
+            continue;
+        }
+
+        let terrain_y = world.terrain.height_at(x, z);
+        let diff = y - terrain_y;
+
+        // Agents should be above terrain (within AGENT_HALF_HEIGHT = 1.0,
+        // plus tolerance for gravity/movement dynamics)
+        assert!(
+            diff >= 0.5 && diff < 5.0,
+            "Agent {} at ({:.2}, {:.2}, {:.2}): Y should be near terrain height {:.2}, but diff={:.2}",
+            i, x, y, z, terrain_y, diff
+        );
+    }
+}
+
+#[test]
+fn gpu_agents_y_matches_terrain_after_single_tick() {
+    use xagent_brain::buffers::{PHYS_STRIDE, P_POS_Y};
+    use xagent_brain::GpuKernel;
+
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    let brain = BrainConfig::default();
+    let wc = WorldConfig {
+        seed: 42,
+        ..Default::default()
+    };
+    let agent_count = 10;
+    let world = WorldState::new(wc.clone());
+    let food_count = world.food_items.len();
+
+    let mut mk = GpuKernel::new(agent_count as u32, food_count, &brain, &wc);
+
+    let heights = world.terrain.heights.clone();
+    let biomes = world.biome_map.grid_as_u32();
+    let food_pos: Vec<(f32, f32, f32)> = world
+        .food_items
+        .iter()
+        .map(|f| (f.position.x, f.position.y, f.position.z))
+        .collect();
+    let food_consumed: Vec<bool> = world.food_items.iter().map(|f| f.consumed).collect();
+    let food_timers: Vec<f32> = world.food_items.iter().map(|f| f.respawn_timer).collect();
+    mk.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
+
+    let spawn_positions: Vec<glam::Vec3> = (0..agent_count)
+        .map(|_| world.safe_spawn_position())
+        .collect();
+    let agent_data: Vec<(glam::Vec3, f32, f32, usize, usize)> = spawn_positions
+        .iter()
+        .map(|&pos| {
+            (
+                pos,
+                100.0,
+                100.0,
+                brain.memory_capacity,
+                brain.processing_slots,
+            )
+        })
+        .collect();
+    mk.upload_agents(&agent_data);
+
+    // Read state before any ticks (should match uploaded positions)
+    let state_before = mk.read_full_state_blocking();
+    for i in 0..agent_count {
+        let base = i * PHYS_STRIDE;
+        let y = state_before[base + P_POS_Y];
+        let expected_y = spawn_positions[i].y;
+        assert!(
+            (y - expected_y).abs() < 0.01,
+            "Agent {} pre-tick Y={:.3} should match spawn Y={:.3}",
+            i,
+            y,
+            expected_y
+        );
+    }
+
+    // Run 1 tick and verify agents stay near terrain
+    let result = bench::run_bench(brain, wc.clone(), agent_count, 1);
+    let world2 = WorldState::new(wc);
+    for (i, pos) in result.final_positions.iter().enumerate() {
+        let terrain_y = world2.terrain.height_at(pos[0], pos[2]);
+        let diff = pos[1] - terrain_y;
+        assert!(
+            diff >= 0.5 && diff < 5.0,
+            "Agent {} after 1 tick at ({:.2}, {:.2}, {:.2}): terrain_y={:.2}, diff={:.2}",
+            i,
+            pos[0],
+            pos[1],
+            pos[2],
+            terrain_y,
+            diff
+        );
+    }
+}

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1500,7 +1500,7 @@ fn gpu_agents_follow_terrain_height() {
 
 #[test]
 fn gpu_agents_y_matches_terrain_after_single_tick() {
-    use xagent_brain::buffers::{PHYS_STRIDE, P_POS_Y};
+    use xagent_brain::buffers::{PHYS_STRIDE, P_POS_X, P_POS_Y, P_POS_Z};
     use xagent_brain::GpuKernel;
 
     if !xagent_brain::GpuKernel::is_available() {
@@ -1562,19 +1562,25 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
         );
     }
 
-    // Run 1 tick and verify agents stay near terrain
-    let result = bench::run_bench(brain, wc.clone(), agent_count, 1);
-    let world2 = WorldState::new(wc);
-    for (i, pos) in result.final_positions.iter().enumerate() {
-        let terrain_y = world2.terrain.height_at(pos[0], pos[2]);
-        let diff = pos[1] - terrain_y;
+    // Run 1 tick on the same kernel and verify agents stay near terrain.
+    // Using `mk` directly (not bench::run_bench) so the pre- and post-tick
+    // states come from the same kernel instance.
+    mk.dispatch_batch(0, 1);
+    let state_after = mk.read_full_state_blocking();
+    for i in 0..agent_count {
+        let base = i * PHYS_STRIDE;
+        let x = state_after[base + P_POS_X];
+        let y = state_after[base + P_POS_Y];
+        let z = state_after[base + P_POS_Z];
+        let terrain_y = world.terrain.height_at(x, z);
+        let diff = y - terrain_y;
         assert!(
             diff >= 0.5 && diff < 5.0,
             "Agent {} after 1 tick at ({:.2}, {:.2}, {:.2}): terrain_y={:.2}, diff={:.2}",
             i,
-            pos[0],
-            pos[1],
-            pos[2],
+            x,
+            y,
+            z,
             terrain_y,
             diff
         );

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1523,7 +1523,6 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
 
     let mut kernel = GpuKernel::new(agent_count as u32, food_count, &brain, &world_config);
 
-    let heights = world.terrain.heights.clone();
     let biomes = world.biome_map.grid_as_u32();
     let food_pos: Vec<(f32, f32, f32)> = world
         .food_items
@@ -1532,7 +1531,7 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
         .collect();
     let food_consumed: Vec<bool> = world.food_items.iter().map(|f| f.consumed).collect();
     let food_timers: Vec<f32> = world.food_items.iter().map(|f| f.respawn_timer).collect();
-    kernel.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
+    kernel.upload_world(&world.terrain.heights, &biomes, &food_pos, &food_consumed, &food_timers);
 
     let spawn_positions: Vec<glam::Vec3> = (0..agent_count)
         .map(|_| world.safe_spawn_position())

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1480,10 +1480,14 @@ fn gpu_agents_follow_terrain_height() {
         let y = pos[1];
         let z = pos[2];
 
-        // Skip NaN positions (shouldn't happen but guard)
-        if !x.is_finite() || !y.is_finite() || !z.is_finite() {
-            continue;
-        }
+        assert!(
+            x.is_finite() && y.is_finite() && z.is_finite(),
+            "Agent {} has non-finite final position: ({:?}, {:?}, {:?})",
+            i,
+            x,
+            y,
+            z
+        );
 
         let terrain_y = world.terrain.height_at(x, z);
         let diff = y - terrain_y;

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1488,10 +1488,10 @@ fn gpu_agents_follow_terrain_height() {
         let terrain_y = world.terrain.height_at(x, z);
         let diff = y - terrain_y;
 
-        // Agents should be above terrain (within AGENT_HALF_HEIGHT = 1.0,
-        // plus tolerance for gravity/movement dynamics)
+        // Agents should be at least AGENT_HALF_HEIGHT (1.0) above terrain;
+        // allow small float tolerance (0.99) but reject agents sunk into the ground.
         assert!(
-            diff >= 0.5 && diff < 5.0,
+            diff >= 0.99 && diff < 5.0,
             "Agent {} at ({:.2}, {:.2}, {:.2}): Y should be near terrain height {:.2}, but diff={:.2}",
             i, x, y, z, terrain_y, diff
         );
@@ -1574,8 +1574,10 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
         let z = state_after[base + P_POS_Z];
         let terrain_y = world.terrain.height_at(x, z);
         let diff = y - terrain_y;
+        // Agents should be at least AGENT_HALF_HEIGHT (1.0) above terrain;
+        // allow small float tolerance (0.99) but reject agents sunk into the ground.
         assert!(
-            diff >= 0.5 && diff < 5.0,
+            diff >= 0.99 && diff < 5.0,
             "Agent {} after 1 tick at ({:.2}, {:.2}, {:.2}): terrain_y={:.2}, diff={:.2}",
             i,
             x,


### PR DESCRIPTION
## Summary

This is an investigation/diagnostic PR, not a fix. The physics code is unchanged.

- Added `log::info!` diagnostic on first GPU readback to compare agent Y positions against CPU-sampled terrain height, gated behind a `readback_logged` one-shot flag so it fires exactly once
- Added two integration tests that verify GPU-computed agent Y positions stay within expected range above terrain height:
  - `gpu_agents_follow_terrain_height` — runs 200 ticks via `bench::run_bench`, asserts all positions land above terrain
  - `gpu_agents_y_matches_terrain_after_single_tick` — creates a single `GpuKernel`, verifies pre-tick Y matches spawn positions, dispatches 1 tick on the same kernel, verifies post-tick Y is near terrain
- Fixed `GpuBrain::is_available()` compile error → `GpuKernel::is_available()` (no `GpuBrain` type exists)

Tests currently pass, suggesting the GPU terrain-height pipeline (heightmap upload → `sample_height` in WGSL → physics integration → readback) is working correctly. A follow-up PR will investigate whether any real-world regression exists before applying a code fix.

## Test plan
- [ ] `cargo check -p xagent-sandbox` passes
- [ ] `cargo test -p xagent-sandbox` — all 37 tests pass including the two new GPU terrain tests
- [ ] Diagnostic log line visible on first frame when running with `RUST_LOG=info`

Closes #24