### PR TITLE
fix: make vision dimensions fully dynamic

### DIFF
--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -14,7 +14,8 @@ use xagent_shared::{BrainConfig, SensoryFrame, TouchContact};
 
 pub const DIM: usize = 32;
 /// Feature count for the default 8×6 vision layout.
-/// Used only to compute default brain state offsets and `FIXED_TAIL_SIZE`.
+/// Used to compute default brain state offsets (`O_ENC_BIASES`),
+/// `FEATURES_STRIDE`, and `FIXED_TAIL_SIZE`.
 /// For other vision dimensions, use `BrainLayout::feature_count`.
 const FEATURE_COUNT: usize = 8 * 6 * 4 + 8 * 6 + 25; // 265
 pub const MEMORY_CAP: usize = 128;

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -10,10 +10,13 @@
 
 use xagent_shared::{BrainConfig, SensoryFrame, TouchContact};
 
-// ── Dimensions (fixed for default config) ─────────────────────────────
+// ── Dimensions ───────────────────────────────────────────────────────
 
 pub const DIM: usize = 32;
-pub const FEATURE_COUNT: usize = 265;
+/// Feature count for the default 8×6 vision layout.
+/// Used only to compute default brain state offsets and `FIXED_TAIL_SIZE`.
+/// For other vision dimensions, use `BrainLayout::feature_count`.
+const FEATURE_COUNT: usize = 8 * 6 * 4 + 8 * 6 + 25; // 265
 pub const MEMORY_CAP: usize = 128;
 pub const RECALL_K: usize = 16;
 pub const ACTION_HISTORY_LEN: usize = 64;
@@ -23,16 +26,15 @@ pub const TOUCH_FEATURES: usize = 4; // dir_x, dir_z, intensity, tag/4
 
 // ── Sensory input layout (CPU → GPU upload) ───────────────────────────
 
-pub const VISION_W: usize = 8;
-pub const VISION_H: usize = 6;
-pub const VISION_COLOR_COUNT: usize = VISION_W * VISION_H * 4; // 192 RGBA
-pub const VISION_DEPTH_COUNT: usize = VISION_W * VISION_H; // 48
+/// Non-visual sensory channels (vision-independent).
+/// velocity(3) + facing(3) + angular_vel(1) + energy(1) + integrity(1) + e_delta(1) + i_delta(1) + touch(16)
 pub const NON_VISUAL_COUNT: usize = 3 + 3 + 1 + 1 + 1 + 1 + 1 + MAX_TOUCH_CONTACTS * TOUCH_FEATURES;
-// velocity(3) + facing(3) + angular_vel(1) + energy(1) + integrity(1) + e_delta(1) + i_delta(1) + touch(16)
-pub const SENSORY_STRIDE: usize = VISION_COLOR_COUNT + VISION_DEPTH_COUNT + NON_VISUAL_COUNT;
-// 192 + 48 + 27 = 267
 
-// ── Brain state buffer offsets (per agent) ────────────────────────────
+// ── Brain state buffer offsets (default 8×6 layout) ──────────────────
+// These constants are valid for the default vision dimensions (8×6).
+// For other dimensions, use `BrainLayout` to compute dynamic offsets.
+// The *tail* offsets (from `O_PRED_CTX_WT` onward) are vision-independent:
+// `O_FOO - O_PRED_CTX_WT` is the same regardless of vision size.
 
 pub const O_ENC_WEIGHTS: usize = 0;
 pub const O_ENC_BIASES: usize = O_ENC_WEIGHTS + FEATURE_COUNT * DIM; // 8480
@@ -293,26 +295,26 @@ impl AgentBrainState {
 
 /// Pack a SensoryFrame into a flat f32 slice for GPU upload.
 /// Selects up to 4 highest-intensity touch contacts, zero-pads the rest.
-pub fn pack_sensory_frame(frame: &SensoryFrame, out: &mut [f32]) {
-    debug_assert!(out.len() >= SENSORY_STRIDE);
+pub fn pack_sensory_frame(frame: &SensoryFrame, layout: &BrainLayout, out: &mut [f32]) {
+    debug_assert!(out.len() >= layout.sensory_stride);
 
     let mut offset = 0;
 
-    // Vision color (192 f32)
-    let color_len = frame.vision.color.len().min(VISION_COLOR_COUNT);
+    // Vision color (RGBA per pixel)
+    let color_len = frame.vision.color.len().min(layout.vision_color_count);
     out[offset..offset + color_len].copy_from_slice(&frame.vision.color[..color_len]);
-    for i in color_len..VISION_COLOR_COUNT {
+    for i in color_len..layout.vision_color_count {
         out[offset + i] = 0.0;
     }
-    offset += VISION_COLOR_COUNT;
+    offset += layout.vision_color_count;
 
-    // Vision depth (48 f32)
-    let depth_len = frame.vision.depth.len().min(VISION_DEPTH_COUNT);
+    // Vision depth (one per pixel)
+    let depth_len = frame.vision.depth.len().min(layout.vision_depth_count);
     out[offset..offset + depth_len].copy_from_slice(&frame.vision.depth[..depth_len]);
-    for i in depth_len..VISION_DEPTH_COUNT {
+    for i in depth_len..layout.vision_depth_count {
         out[offset + i] = 0.0;
     }
-    offset += VISION_DEPTH_COUNT;
+    offset += layout.vision_depth_count;
 
     // Velocity (3)
     out[offset] = frame.velocity.x;
@@ -371,213 +373,6 @@ pub fn pack_sensory_frame(frame: &SensoryFrame, out: &mut [f32]) {
     }
 }
 
-/// Generate WGSL constants header shared by all shaders.
-pub fn wgsl_constants() -> String {
-    format!(
-        "// Auto-generated constants — do not edit manually
-const DIM: u32 = {DIM}u;
-const FEATURE_COUNT: u32 = {FEATURE_COUNT}u;
-const VISION_COLOR_COUNT: u32 = {VISION_COLOR_COUNT}u;
-const VISION_DEPTH_COUNT: u32 = {VISION_DEPTH_COUNT}u;
-const MEMORY_CAP: u32 = {MEMORY_CAP}u;
-const RECALL_K: u32 = {RECALL_K}u;
-const ACTION_HISTORY_LEN: u32 = {ACTION_HISTORY_LEN}u;
-const ERROR_HISTORY_LEN: u32 = {ERROR_HISTORY_LEN}u;
-const SENSORY_STRIDE: u32 = {SENSORY_STRIDE}u;
-const BRAIN_STRIDE: u32 = {BRAIN_STRIDE}u;
-const PATTERN_STRIDE: u32 = {PATTERN_STRIDE}u;
-const HISTORY_STRIDE: u32 = {HISTORY_STRIDE}u;
-const FEATURES_STRIDE: u32 = {FEATURES_STRIDE}u;
-const DECISION_STRIDE: u32 = {DECISION_STRIDE}u;
-const HOMEO_OUT_STRIDE: u32 = {HOMEO_OUT_STRIDE}u;
-const RECALL_IDX_STRIDE: u32 = {RECALL_IDX_STRIDE}u;
-
-// Brain state offsets
-const O_ENC_WEIGHTS: u32 = {O_ENC_WEIGHTS}u;
-const O_ENC_BIASES: u32 = {O_ENC_BIASES}u;
-const O_PRED_WEIGHTS: u32 = {O_PRED_WEIGHTS}u;
-const O_PRED_CTX_WT: u32 = {O_PRED_CTX_WT}u;
-const O_PRED_ERR_RING: u32 = {O_PRED_ERR_RING}u;
-const O_PRED_ERR_CURSOR: u32 = {O_PRED_ERR_CURSOR}u;
-const O_PRED_ERR_COUNT: u32 = {O_PRED_ERR_COUNT}u;
-const O_HAB_EMA: u32 = {O_HAB_EMA}u;
-const O_HAB_ATTEN: u32 = {O_HAB_ATTEN}u;
-const O_PREV_ENCODED: u32 = {O_PREV_ENCODED}u;
-const O_HOMEO: u32 = {O_HOMEO}u;
-const O_ACT_FWD_WTS: u32 = {O_ACT_FWD_WTS}u;
-const O_ACT_TURN_WTS: u32 = {O_ACT_TURN_WTS}u;
-const O_ACT_BIASES: u32 = {O_ACT_BIASES}u;
-const O_EXPLORATION_RATE: u32 = {O_EXPLORATION_RATE}u;
-const POS_RING_LEN: u32 = {POS_RING_LEN}u;
-const O_POS_RING_X: u32 = {O_POS_RING_X}u;
-const O_POS_RING_Z: u32 = {O_POS_RING_Z}u;
-const O_POS_RING_CURSOR: u32 = {O_POS_RING_CURSOR}u;
-const O_POS_RING_LEN: u32 = {O_POS_RING_LEN}u;
-const O_ACCUM_FWD: u32 = {O_ACCUM_FWD}u;
-const O_FATIGUE_FACTOR: u32 = {O_FATIGUE_FACTOR}u;
-const O_PREV_PREDICTION: u32 = {O_PREV_PREDICTION}u;
-const O_TICK_COUNT: u32 = {O_TICK_COUNT}u;
-const O_HAB_SENSITIVITY: u32 = {O_HAB_SENSITIVITY}u;
-const O_HAB_MAX_CURIOSITY: u32 = {O_HAB_MAX_CURIOSITY}u;
-const O_FATIGUE_FLOOR: u32 = {O_FATIGUE_FLOOR}u;
-const O_MOVEMENT_SPEED: u32 = {O_MOVEMENT_SPEED}u;
-
-// Pattern memory offsets
-const O_PAT_STATES: u32 = {O_PAT_STATES}u;
-const O_PAT_NORMS: u32 = {O_PAT_NORMS}u;
-const O_PAT_REINF: u32 = {O_PAT_REINF}u;
-const O_PAT_MOTOR: u32 = {O_PAT_MOTOR}u;
-const O_PAT_META: u32 = {O_PAT_META}u;
-const O_PAT_ACTIVE: u32 = {O_PAT_ACTIVE}u;
-const O_ACTIVE_COUNT: u32 = {O_ACTIVE_COUNT}u;
-const O_MIN_REINF_IDX: u32 = {O_MIN_REINF_IDX}u;
-const O_LAST_STORED_IDX: u32 = {O_LAST_STORED_IDX}u;
-
-// Action history offsets
-const O_MOTOR_RING: u32 = {O_MOTOR_RING}u;
-const O_STATE_RING: u32 = {O_STATE_RING}u;
-const O_HIST_CURSOR: u32 = {O_HIST_CURSOR}u;
-const O_HIST_LEN: u32 = {O_HIST_LEN}u;
-
-// Config offsets
-const CFG_LEARNING_RATE: u32 = {CFG_LEARNING_RATE}u;
-const CFG_DECAY_RATE: u32 = {CFG_DECAY_RATE}u;
-const CFG_DISTRESS_EXP: u32 = {CFG_DISTRESS_EXP}u;
-
-fn fast_tanh(x: f32) -> f32 {{
-    if (abs(x) > 4.5) {{ return sign(x); }}
-    let x2 = x * x;
-    return x * (27.0 + x2) / (27.0 + 9.0 * x2);
-}}
-
-fn pcg_hash(input: u32) -> u32 {{
-    let state = input * 747796405u + 2891336453u;
-    let word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
-    return (word >> 22u) ^ word;
-}}
-
-fn rand_f32(seed: u32) -> f32 {{
-    return f32(pcg_hash(seed)) / 4294967295.0;
-}}
-
-fn rand_normal(seed1: u32, seed2: u32) -> f32 {{
-    let u1 = max(rand_f32(seed1), 0.0001);
-    let u2 = rand_f32(seed2);
-    return sqrt(-2.0 * log(u1)) * cos(6.2831853 * u2);
-}}
-",
-    )
-}
-
-/// Generate WGSL constants for physics/vision shaders.
-/// These are separate from brain constants to avoid name collisions.
-pub fn wgsl_physics_constants(world_size: f32, food_count: usize, agent_count: usize) -> String {
-    let gw = grid_width(world_size);
-    let go = gw / 2;
-    let terrain_vps: u32 = 129;
-    let terrain_step = world_size / 128.0;
-    format!(
-        r#"// Auto-generated physics constants — do not edit manually
-const PHYS_STRIDE: u32 = {PHYS_STRIDE}u;
-const P_POS_X: u32 = {P_POS_X}u;
-const P_POS_Y: u32 = {P_POS_Y}u;
-const P_POS_Z: u32 = {P_POS_Z}u;
-const P_VEL_X: u32 = {P_VEL_X}u;
-const P_VEL_Y: u32 = {P_VEL_Y}u;
-const P_VEL_Z: u32 = {P_VEL_Z}u;
-const P_FACING_X: u32 = {P_FACING_X}u;
-const P_FACING_Y: u32 = {P_FACING_Y}u;
-const P_FACING_Z: u32 = {P_FACING_Z}u;
-const P_YAW: u32 = {P_YAW}u;
-const P_ANGULAR_VEL: u32 = {P_ANGULAR_VEL}u;
-const P_ENERGY: u32 = {P_ENERGY}u;
-const P_MAX_ENERGY: u32 = {P_MAX_ENERGY}u;
-const P_INTEGRITY: u32 = {P_INTEGRITY}u;
-const P_MAX_INTEGRITY: u32 = {P_MAX_INTEGRITY}u;
-const P_PREV_ENERGY: u32 = {P_PREV_ENERGY}u;
-const P_PREV_INTEGRITY: u32 = {P_PREV_INTEGRITY}u;
-const P_ALIVE: u32 = {P_ALIVE}u;
-const P_FOOD_COUNT: u32 = {P_FOOD_COUNT}u;
-const P_TICKS_ALIVE: u32 = {P_TICKS_ALIVE}u;
-const P_DIED_FLAG: u32 = {P_DIED_FLAG}u;
-const P_MEMORY_CAP: u32 = {P_MEMORY_CAP}u;
-const P_PROCESSING_SLOTS: u32 = {P_PROCESSING_SLOTS}u;
-
-const FOOD_STATE_STRIDE: u32 = {FOOD_STATE_STRIDE}u;
-const F_POS_X: u32 = {F_POS_X}u;
-const F_POS_Y: u32 = {F_POS_Y}u;
-const F_POS_Z: u32 = {F_POS_Z}u;
-const F_RESPAWN_TIMER: u32 = {F_RESPAWN_TIMER}u;
-
-const GRAVITY: f32 = 20.0;
-const MOVE_SPEED: f32 = 8.0;
-const TURN_SPEED: f32 = 3.0;
-const AGENT_HALF_HEIGHT: f32 = 1.0;
-const METABOLIC_BASE_COST: f32 = 0.0001;
-const METABOLIC_MEMORY_COST: f32 = 0.00003;
-const METABOLIC_PROCESSING_COST: f32 = 0.0001;
-// FOOD_CONSUME_RADIUS_SQ removed — shaders read from wconfig[WC_FOOD_RADIUS]
-const JUMP_VELOCITY: f32 = 8.0;
-const COLLISION_MIN_DIST: f32 = 2.0;
-const COLLISION_MIN_DIST_SQ: f32 = 4.0;
-const COLLISION_FIXED_SCALE: f32 = 1024.0;
-
-const CELL_SIZE: f32 = {GRID_CELL_SIZE};
-const GRID_WIDTH: u32 = {gw}u;
-const GRID_OFFSET: i32 = {go};
-const FOOD_GRID_MAX_PER_CELL: u32 = {FOOD_GRID_MAX_PER_CELL}u;
-const FOOD_GRID_CELL_STRIDE: u32 = {FOOD_GRID_CELL_STRIDE}u;
-const AGENT_GRID_MAX_PER_CELL: u32 = {AGENT_GRID_MAX_PER_CELL}u;
-const AGENT_GRID_CELL_STRIDE: u32 = {AGENT_GRID_CELL_STRIDE}u;
-
-const TERRAIN_VPS: u32 = {terrain_vps}u;
-const TERRAIN_MAX_IDX: u32 = {max_idx}u;
-const TERRAIN_INV_STEP: f32 = {inv_step};
-const TERRAIN_HALF: f32 = {half};
-const TERRAIN_MAX_COORD: f32 = {max_coord};
-const BIOME_GRID_RES: u32 = 256u;
-
-const FOOD_COUNT_VAL: u32 = {food_count}u;
-const AGENT_COUNT_VAL: u32 = {agent_count}u;
-
-const WC_FOOD_RADIUS: u32 = {WC_FOOD_RADIUS}u;
-
-const FOOD_RESPAWN_TIME: f32 = 10.0;
-const FOOD_HEIGHT_OFFSET: f32 = 0.35;
-const FOOD_RESPAWN_ATTEMPTS: u32 = 64u;
-
-const VISION_FOV_HALF: f32 = 0.7853982;  // PI/4 = 45 degrees (half of 90)
-const VISION_MAX_DIST: f32 = 30.0;
-const VISION_STEP_SIZE: f32 = 1.2;
-const VISION_NUM_STEPS: u32 = 25u;
-const VISION_RAYS: u32 = 48u;
-const VISION_W: u32 = 8u;
-const VISION_H: u32 = 6u;
-const MAX_TOUCH_CONTACTS: u32 = 4u;
-const FOOD_RAY_RADIUS_SQ: f32 = 1.0;
-const AGENT_RAY_RADIUS_SQ: f32 = 2.25;
-
-const TOUCH_FOOD: u32 = 1u;
-const TOUCH_TERRAIN_EDGE: u32 = 2u;
-const TOUCH_HAZARD: u32 = 3u;
-const TOUCH_AGENT: u32 = 4u;
-const TOUCH_FOOD_RANGE: f32 = 3.0;
-const TOUCH_AGENT_RANGE: f32 = 5.0;
-const TOUCH_EDGE_RANGE: f32 = 3.0;
-
-fn cell_coord(v: f32) -> i32 {{
-    return i32(floor(v / CELL_SIZE));
-}}
-"#,
-        gw = gw,
-        go = go,
-        half = world_size / 2.0,
-        inv_step = 1.0 / terrain_step,
-        max_idx = terrain_vps - 2,
-        max_coord = (terrain_vps - 1) as f32,
-    )
-}
-
 /// Build the world config uniform data.
 pub fn build_world_config(
     config: &xagent_shared::WorldConfig,
@@ -620,8 +415,13 @@ pub fn build_world_config(
 
 /// Initialize brain_state buffer data for one agent from BrainConfig.
 /// Xavier init for encoder, small random for predictor, zero for rest.
+/// Layout is derived from config's `vision_width`/`vision_height`.
 pub fn init_brain_state(config: &BrainConfig, rng: &mut impl rand::Rng) -> Vec<f32> {
-    init_brain_state_for(config, &BrainLayout::default(), rng)
+    init_brain_state_for(
+        config,
+        &BrainLayout::new(config.vision_width, config.vision_height),
+        rng,
+    )
 }
 
 /// Layout-aware version for configurable vision dimensions.
@@ -691,9 +491,10 @@ pub fn init_action_history() -> Vec<f32> {
     vec![0.0_f32; HISTORY_STRIDE]
 }
 
-/// Build config buffer values from BrainConfig (default layout).
+/// Build config buffer values from BrainConfig.
+/// Layout is derived from config's `vision_width`/`vision_height`.
 pub fn build_config(config: &BrainConfig) -> Vec<f32> {
-    build_config_for(config, &BrainLayout::default())
+    build_config_for(config, &BrainLayout::new(config.vision_width, config.vision_height))
 }
 
 /// Build config buffer values with explicit layout.
@@ -717,10 +518,13 @@ mod tests {
     use xagent_shared::SensoryFrame;
 
     #[test]
-    fn sensory_stride_matches_feature_count() {
-        assert_eq!(SENSORY_STRIDE, 267);
-        assert_eq!(FEATURE_COUNT, 265);
-        assert!(SENSORY_STRIDE >= FEATURE_COUNT);
+    fn default_layout_sensory_and_feature_counts() {
+        let layout = BrainLayout::default();
+        // Default 8x6: 192 color + 48 depth + 27 non-visual = 267 sensory
+        assert_eq!(layout.sensory_stride, 267);
+        // Feature count excludes 2 non-visual fields (energy_delta, integrity_delta)
+        assert_eq!(layout.feature_count, 265);
+        assert!(layout.sensory_stride >= layout.feature_count);
     }
 
     #[test]
@@ -740,33 +544,46 @@ mod tests {
 
     #[test]
     fn pack_sensory_frame_fills_buffer() {
-        let frame = SensoryFrame::new_blank(VISION_W as u32, VISION_H as u32);
-        let mut buf = vec![0.0_f32; SENSORY_STRIDE];
-        pack_sensory_frame(&frame, &mut buf);
+        let layout = BrainLayout::default();
+        let frame = SensoryFrame::new_blank(layout.vision_width, layout.vision_height);
+        let mut buf = vec![0.0_f32; layout.sensory_stride];
+        pack_sensory_frame(&frame, &layout, &mut buf);
+        assert!(buf.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn pack_sensory_frame_dynamic_layout() {
+        let layout = BrainLayout::new(12, 8);
+        let frame = SensoryFrame::new_blank(layout.vision_width, layout.vision_height);
+        let mut buf = vec![0.0_f32; layout.sensory_stride];
+        pack_sensory_frame(&frame, &layout, &mut buf);
         assert!(buf.iter().all(|v| v.is_finite()));
     }
 
     #[test]
     fn init_brain_state_has_correct_length() {
         let config = BrainConfig::default();
+        let layout = BrainLayout::new(config.vision_width, config.vision_height);
         let mut rng = rand::rng();
         let state = init_brain_state(&config, &mut rng);
-        assert_eq!(state.len(), BRAIN_STRIDE);
+        assert_eq!(state.len(), layout.brain_stride);
     }
 
     #[test]
-    fn brain_layout_default_matches_constants() {
+    fn brain_layout_default_values() {
         let layout = BrainLayout::default();
         assert_eq!(layout.vision_width, 8);
         assert_eq!(layout.vision_height, 6);
-        assert_eq!(layout.feature_count, FEATURE_COUNT);
-        assert_eq!(layout.sensory_stride, SENSORY_STRIDE);
+        assert_eq!(layout.vision_color_count, 192);
+        assert_eq!(layout.vision_depth_count, 48);
+        assert_eq!(layout.sensory_stride, 267);
+        assert_eq!(layout.feature_count, 265);
         assert_eq!(layout.brain_stride, BRAIN_STRIDE);
     }
 
     #[test]
     fn brain_layout_dynamic_is_consistent() {
-        for (w, h) in [(4, 4), (6, 4), (8, 4), (8, 6), (8, 8), (12, 8)] {
+        for (w, h) in [(4, 4), (6, 4), (8, 4), (8, 6), (8, 8), (12, 8), (32, 24)] {
             let layout = BrainLayout::new(w, h);
             assert_eq!(layout.vision_width, w);
             assert_eq!(layout.vision_height, h);
@@ -781,6 +598,16 @@ mod tests {
             let o_pred_ctx_wt = fc * DIM + DIM + DIM * DIM;
             assert_eq!(layout.brain_stride, o_pred_ctx_wt + FIXED_TAIL_SIZE);
         }
+    }
+
+    #[test]
+    fn brain_layout_large_vision() {
+        let layout = BrainLayout::new(32, 24);
+        assert_eq!(layout.vision_color_count, 32 * 24 * 4);
+        assert_eq!(layout.vision_depth_count, 32 * 24);
+        assert_eq!(layout.sensory_stride, 32 * 24 * 5 + NON_VISUAL_COUNT);
+        let expected = layout.feature_count * DIM + DIM + DIM * DIM + FIXED_TAIL_SIZE;
+        assert_eq!(layout.brain_stride, expected);
     }
 
     #[test]

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -296,7 +296,12 @@ impl AgentBrainState {
 /// Pack a SensoryFrame into a flat f32 slice for GPU upload.
 /// Selects up to 4 highest-intensity touch contacts, zero-pads the rest.
 pub fn pack_sensory_frame(frame: &SensoryFrame, layout: &BrainLayout, out: &mut [f32]) {
-    debug_assert!(out.len() >= layout.sensory_stride);
+    assert!(
+        out.len() >= layout.sensory_stride,
+        "output buffer too short: {} < {}",
+        out.len(),
+        layout.sensory_stride,
+    );
 
     let mut offset = 0;
 
@@ -494,7 +499,10 @@ pub fn init_action_history() -> Vec<f32> {
 /// Build config buffer values from BrainConfig.
 /// Layout is derived from config's `vision_width`/`vision_height`.
 pub fn build_config(config: &BrainConfig) -> Vec<f32> {
-    build_config_for(config, &BrainLayout::new(config.vision_width, config.vision_height))
+    build_config_for(
+        config,
+        &BrainLayout::new(config.vision_width, config.vision_height),
+    )
 }
 
 /// Build config buffer values with explicit layout.

--- a/crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl
@@ -1,5 +1,6 @@
 // ── Vision dispatch: multi-workgroup, one workgroup per agent ───────────────
-// dispatch(agent_count, 1, 1) — threads 0..47 each cast one ray,
+// dispatch(agent_count, 1, 1) — each workgroup's 256 threads cooperatively
+// cast all VISION_RAYS rays (looping when VISION_RAYS > 256),
 // then thread 0 packs proprioception/interoception/touch into sensory_buf.
 
 @compute @workgroup_size(256)
@@ -12,9 +13,9 @@ fn vision_tick(
 
     if (agent_phys[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
 
-    // Each thread casts one ray (VISION_RAYS = 48, threads 0..47 active)
-    if (tid < VISION_RAYS) {
-        vision_single_ray(agent_id, tid);
+    // Each thread casts rays in a strided loop (handles VISION_RAYS > 256)
+    for (var ray = tid; ray < VISION_RAYS; ray += 256u) {
+        vision_single_ray(agent_id, ray);
     }
     storageBarrier(); workgroupBarrier();
 

--- a/crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl
@@ -1,7 +1,10 @@
 // ── Vision dispatch: multi-workgroup, one workgroup per agent ───────────────
-// dispatch(agent_count, 1, 1) — each workgroup's 256 threads cooperatively
-// cast all VISION_RAYS rays (looping when VISION_RAYS > 256),
-// then thread 0 packs proprioception/interoception/touch into sensory_buf.
+// dispatch(agent_count, 1, 1) — each workgroup's WORKGROUP_SIZE threads
+// cooperatively cast all VISION_RAYS rays (looping when VISION_RAYS >
+// WORKGROUP_SIZE), then thread 0 packs proprioception/interoception/touch
+// into sensory_buf.
+
+const WORKGROUP_SIZE: u32 = 256u;
 
 @compute @workgroup_size(256)
 fn vision_tick(
@@ -13,8 +16,8 @@ fn vision_tick(
 
     if (agent_phys[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
 
-    // Each thread casts rays in a strided loop (handles VISION_RAYS > 256)
-    for (var ray = tid; ray < VISION_RAYS; ray += 256u) {
+    // Each thread casts rays in a strided loop (handles VISION_RAYS > WORKGROUP_SIZE)
+    for (var ray = tid; ray < VISION_RAYS; ray += WORKGROUP_SIZE) {
         vision_single_ray(agent_id, ray);
     }
     storageBarrier(); workgroupBarrier();

--- a/docs/superpowers/plans/2026-04-12-dynamic-vision-dimensions.md
+++ b/docs/superpowers/plans/2026-04-12-dynamic-vision-dimensions.md
@@ -1,0 +1,360 @@
+# Dynamic Vision Dimensions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make vision dimensions fully dynamic so changing `vision_w`/`vision_h` in `BrainConfig` works end-to-end without breaking the vision display or simulation.
+
+**Architecture:** The WGSL shader side already derives all vision constants from `VISION_W`/`VISION_H` (string-replaced at compile time). The GPU readback and buffer sizing already use the dynamic `BrainLayout`. The fix targets two areas: (1) the vision dispatch shader's workgroup limit of 256 threads that caps ray count, and (2) dead/stale Rust code that hardcodes 8x6 constants.
+
+**Tech Stack:** Rust, WGSL (WebGPU shading language), wgpu
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl` | Modify | Fix ray loop to handle > 256 rays |
+| `crates/xagent-brain/src/buffers.rs` | Modify | Remove dead code, make `pack_sensory_frame` layout-aware, update tests |
+
+---
+
+### Task 1: Fix vision dispatch to support > 256 rays per agent
+
+The `vision_tick.wgsl` shader has `@workgroup_size(256)` and guards ray casting with `if (tid < VISION_RAYS)`. With 32×24 = 768 rays, only threads 0–255 cast rays, leaving 256–767 empty. Fix by having each thread loop over multiple rays.
+
+**Files:**
+- Modify: `crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl`
+
+- [ ] **Step 1: Update `vision_tick` to loop over rays**
+
+Replace the single-ray-per-thread guard with a strided loop so each of the 256 threads handles `ceil(VISION_RAYS / 256)` rays:
+
+```wgsl
+// ── Vision dispatch: multi-workgroup, one workgroup per agent ───────────────
+// dispatch(agent_count, 1, 1) — each workgroup's 256 threads cooperatively
+// cast all VISION_RAYS rays (looping when VISION_RAYS > 256),
+// then thread 0 packs proprioception/interoception/touch into sensory_buf.
+
+@compute @workgroup_size(256)
+fn vision_tick(
+    @builtin(local_invocation_id) lid: vec3u,
+    @builtin(workgroup_id) wgid: vec3u,
+) {
+    let agent_id = wgid.x;
+    let tid = lid.x;
+
+    if (agent_phys[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
+
+    // Each thread casts rays in a strided loop (handles VISION_RAYS > 256)
+    for (var ray = tid; ray < VISION_RAYS; ray += 256u) {
+        vision_single_ray(agent_id, ray);
+    }
+    storageBarrier(); workgroupBarrier();
+
+    // Thread 0 packs sensory data (proprioception, interoception, touch)
+    if (tid == 0u) {
+        phase_vision_senses(agent_id);
+    }
+}
+```
+
+- [ ] **Step 2: Verify shader compiles**
+
+Run: `cargo check -p xagent-brain`
+Expected: compiles clean (WGSL is validated at pipeline creation, but Rust compilation confirms no syntax issues in the include)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl
+git commit -m "fix: loop vision rays so workgroup handles > 256 rays per agent"
+```
+
+---
+
+### Task 2: Make `pack_sensory_frame` layout-aware
+
+`pack_sensory_frame` uses hardcoded `VISION_COLOR_COUNT` (192) and `VISION_DEPTH_COUNT` (48). It's currently only called from its own test, but it's a public API that should work correctly for any vision dimensions.
+
+**Files:**
+- Modify: `crates/xagent-brain/src/buffers.rs:290-370` (function)
+- Modify: `crates/xagent-brain/src/buffers.rs:737-742` (test)
+
+- [ ] **Step 1: Update the test to use a non-default layout**
+
+Add a test that packs a frame with non-default vision dimensions:
+
+```rust
+#[test]
+fn pack_sensory_frame_dynamic_layout() {
+    let layout = BrainLayout::new(12, 8);
+    let frame = SensoryFrame::new_blank(12, 8);
+    let mut buf = vec![0.0_f32; layout.sensory_stride];
+    pack_sensory_frame(&frame, &layout, &mut buf);
+    assert!(buf.iter().all(|v| v.is_finite()));
+}
+```
+
+Run: `cargo test -p xagent-brain pack_sensory_frame_dynamic_layout`
+Expected: FAIL — `pack_sensory_frame` doesn't accept a `&BrainLayout` parameter
+
+- [ ] **Step 2: Add `&BrainLayout` parameter to `pack_sensory_frame`**
+
+Change the signature and body to use layout-derived counts:
+
+```rust
+/// Pack a SensoryFrame into a flat f32 slice for GPU upload.
+/// Selects up to 4 highest-intensity touch contacts, zero-pads the rest.
+pub fn pack_sensory_frame(frame: &SensoryFrame, layout: &BrainLayout, out: &mut [f32]) {
+    debug_assert!(out.len() >= layout.sensory_stride);
+
+    let mut offset = 0;
+
+    // Vision color
+    let color_len = frame.vision.color.len().min(layout.vision_color_count);
+    out[offset..offset + color_len].copy_from_slice(&frame.vision.color[..color_len]);
+    for i in color_len..layout.vision_color_count {
+        out[offset + i] = 0.0;
+    }
+    offset += layout.vision_color_count;
+
+    // Vision depth
+    let depth_len = frame.vision.depth.len().min(layout.vision_depth_count);
+    out[offset..offset + depth_len].copy_from_slice(&frame.vision.depth[..depth_len]);
+    for i in depth_len..layout.vision_depth_count {
+        out[offset + i] = 0.0;
+    }
+    offset += layout.vision_depth_count;
+
+    // ... rest of function unchanged (velocity, facing, angular_vel, energy, etc.)
+```
+
+- [ ] **Step 3: Update existing test to pass layout**
+
+```rust
+#[test]
+fn pack_sensory_frame_fills_buffer() {
+    let layout = BrainLayout::default();
+    let frame = SensoryFrame::new_blank(layout.vision_w, layout.vision_h);
+    let mut buf = vec![0.0_f32; layout.sensory_stride];
+    pack_sensory_frame(&frame, &layout, &mut buf);
+    assert!(buf.iter().all(|v| v.is_finite()));
+}
+```
+
+- [ ] **Step 4: Run tests to verify both pass**
+
+Run: `cargo test -p xagent-brain pack_sensory_frame`
+Expected: 2 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/xagent-brain/src/buffers.rs
+git commit -m "fix: make pack_sensory_frame layout-aware for dynamic vision dimensions"
+```
+
+---
+
+### Task 3: Remove dead WGSL generator functions and clean up stale constants
+
+`wgsl_constants()` and `wgsl_physics_constants()` are never called — the fused kernel uses `common.wgsl` with string replacements instead. Remove them to eliminate confusion about which constants are authoritative. Also remove the hardcoded `VISION_W`, `VISION_H`, `VISION_COLOR_COUNT`, `VISION_DEPTH_COUNT` Rust constants (they exist only for the now-layout-aware `pack_sensory_frame` and dead code). Keep `NON_VISUAL_COUNT` (used by `BrainLayout::new`).
+
+**Files:**
+- Modify: `crates/xagent-brain/src/buffers.rs`
+
+- [ ] **Step 1: Remove `wgsl_constants()` function**
+
+Delete the function at lines 372–466. It's never called (verified via grep).
+
+- [ ] **Step 2: Remove `wgsl_physics_constants()` function**
+
+Delete the function at lines 468–575. It's never called (verified via grep).
+
+- [ ] **Step 3: Remove hardcoded vision constants**
+
+Remove these lines:
+```rust
+pub const VISION_W: usize = 8;
+pub const VISION_H: usize = 6;
+pub const VISION_COLOR_COUNT: usize = VISION_W * VISION_H * 4;
+pub const VISION_DEPTH_COUNT: usize = VISION_W * VISION_H;
+pub const SENSORY_STRIDE: usize = VISION_COLOR_COUNT + VISION_DEPTH_COUNT + NON_VISUAL_COUNT;
+```
+
+Keep `NON_VISUAL_COUNT` — it's used by `BrainLayout::new()` and is vision-independent.
+
+- [ ] **Step 4: Update convenience wrappers to derive layout from config**
+
+`init_brain_state()` and `build_config()` use `BrainLayout::default()`. Update them to derive layout from the config's `vision_w`/`vision_h`:
+
+```rust
+pub fn init_brain_state(config: &BrainConfig, rng: &mut impl rand::Rng) -> Vec<f32> {
+    init_brain_state_for(config, &BrainLayout::new(config.vision_w, config.vision_h), rng)
+}
+
+pub fn build_config(config: &BrainConfig) -> Vec<f32> {
+    build_config_for(config, &BrainLayout::new(config.vision_w, config.vision_h))
+}
+```
+
+- [ ] **Step 5: Update `AgentBrainState::new()` to accept brain_stride**
+
+`AgentBrainState::new()` uses hardcoded `BRAIN_STRIDE`. Since it's only used in tests, change it to require explicit size (it already has `new_for(brain_stride)` — just remove the default `new()`):
+
+```rust
+// Remove:
+// pub fn new() -> Self { Self::new_for(BRAIN_STRIDE) }
+```
+
+Or keep it using `BrainLayout::default()`:
+
+```rust
+pub fn new() -> Self {
+    Self::new_for(BrainLayout::default().brain_stride)
+}
+```
+
+- [ ] **Step 6: Fix all compilation errors from removed constants**
+
+Any remaining references to the removed constants need updating. These will be in tests (Task 4 handles those).
+
+- [ ] **Step 7: Verify compilation**
+
+Run: `cargo check -p xagent-brain`
+Expected: compiles clean
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/xagent-brain/src/buffers.rs
+git commit -m "fix: remove dead WGSL generators and hardcoded vision constants"
+```
+
+---
+
+### Task 4: Update tests for dynamic vision
+
+Tests currently assert against removed hardcoded constants. Update them to use `BrainLayout::default()` values or test dynamic layouts directly.
+
+**Files:**
+- Modify: `crates/xagent-brain/src/buffers.rs` (test module, lines 709+)
+
+- [ ] **Step 1: Update `sensory_stride_matches_feature_count`**
+
+```rust
+#[test]
+fn sensory_stride_matches_feature_count() {
+    let layout = BrainLayout::default();
+    // Default 8x6: 192 color + 48 depth + 27 non-visual = 267 sensory
+    assert_eq!(layout.sensory_stride, 267);
+    // Feature count excludes 2 non-visual fields (energy_delta, integrity_delta)
+    assert_eq!(layout.feature_count, 265);
+    assert!(layout.sensory_stride >= layout.feature_count);
+}
+```
+
+- [ ] **Step 2: Update `brain_stride_is_consistent`**
+
+```rust
+#[test]
+fn brain_stride_is_consistent() {
+    let layout = BrainLayout::default();
+    let expected_tail_end = layout.feature_count * DIM + DIM + DIM * DIM + FIXED_TAIL_SIZE;
+    assert_eq!(layout.brain_stride, expected_tail_end);
+}
+```
+
+- [ ] **Step 3: Update `brain_layout_default_matches_constants`**
+
+Remove assertions against deleted constants. The test already checks internal consistency:
+
+```rust
+#[test]
+fn brain_layout_default_matches_constants() {
+    let layout = BrainLayout::default();
+    assert_eq!(layout.vision_w, 8);
+    assert_eq!(layout.vision_h, 6);
+    // Verify default layout values for 8x6 vision
+    assert_eq!(layout.vision_color_count, 192);
+    assert_eq!(layout.vision_depth_count, 48);
+    assert_eq!(layout.sensory_stride, 267);
+    assert_eq!(layout.feature_count, 265);
+}
+```
+
+- [ ] **Step 4: Update `init_brain_state_has_correct_length`**
+
+```rust
+#[test]
+fn init_brain_state_has_correct_length() {
+    let config = BrainConfig::default();
+    let layout = BrainLayout::new(config.vision_w, config.vision_h);
+    let mut rng = rand::rng();
+    let state = init_brain_state(&config, &mut rng);
+    assert_eq!(state.len(), layout.brain_stride);
+}
+```
+
+- [ ] **Step 5: Update `pack_sensory_frame_fills_buffer` (if not done in Task 2)**
+
+Already handled in Task 2.
+
+- [ ] **Step 6: Update any remaining test references to removed constants**
+
+Check for `BRAIN_STRIDE`, `SENSORY_STRIDE`, `FEATURE_COUNT`, `VISION_W`, `VISION_H` in tests and replace with `BrainLayout` equivalents.
+
+- [ ] **Step 7: Add test for large vision dimensions**
+
+```rust
+#[test]
+fn brain_layout_large_vision() {
+    let layout = BrainLayout::new(32, 24);
+    assert_eq!(layout.vision_color_count, 32 * 24 * 4);
+    assert_eq!(layout.vision_depth_count, 32 * 24);
+    assert_eq!(layout.sensory_stride, 32 * 24 * 5 + NON_VISUAL_COUNT);
+    // Verify brain_stride is consistent
+    let expected = layout.feature_count * DIM + DIM + DIM * DIM + FIXED_TAIL_SIZE;
+    assert_eq!(layout.brain_stride, expected);
+}
+```
+
+- [ ] **Step 8: Run all tests**
+
+Run: `cargo test -p xagent-brain`
+Expected: all tests pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/xagent-brain/src/buffers.rs
+git commit -m "fix: update tests for dynamic vision layout, remove hardcoded constant assertions"
+```
+
+---
+
+### Task 5: Final validation — clippy, fmt, full test suite
+
+**Files:** All modified files
+
+- [ ] **Step 1: Run rustfmt**
+
+Run: `cargo fmt --all -- --check`
+Expected: no formatting issues
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+Expected: no warnings
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cargo test -p xagent-sandbox`
+Expected: all tests pass
+
+- [ ] **Step 4: Fix any issues and commit**
+
+```bash
+git commit -m "fix: address clippy/fmt issues"
+```

--- a/docs/superpowers/plans/2026-04-12-dynamic-vision-dimensions.md
+++ b/docs/superpowers/plans/2026-04-12-dynamic-vision-dimensions.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make vision dimensions fully dynamic so changing `vision_w`/`vision_h` in `BrainConfig` works end-to-end without breaking the vision display or simulation.
+**Goal:** Make vision dimensions fully dynamic so changing `vision_width`/`vision_height` in `BrainConfig` works end-to-end without breaking the vision display or simulation.
 
 **Architecture:** The WGSL shader side already derives all vision constants from `VISION_W`/`VISION_H` (string-replaced at compile time). The GPU readback and buffer sizing already use the dynamic `BrainLayout`. The fix targets two areas: (1) the vision dispatch shader's workgroup limit of 256 threads that caps ray count, and (2) dead/stale Rust code that hardcodes 8x6 constants.
 
@@ -136,7 +136,7 @@ pub fn pack_sensory_frame(frame: &SensoryFrame, layout: &BrainLayout, out: &mut 
 #[test]
 fn pack_sensory_frame_fills_buffer() {
     let layout = BrainLayout::default();
-    let frame = SensoryFrame::new_blank(layout.vision_w, layout.vision_h);
+    let frame = SensoryFrame::new_blank(layout.vision_width, layout.vision_height);
     let mut buf = vec![0.0_f32; layout.sensory_stride];
     pack_sensory_frame(&frame, &layout, &mut buf);
     assert!(buf.iter().all(|v| v.is_finite()));
@@ -187,15 +187,15 @@ Keep `NON_VISUAL_COUNT` — it's used by `BrainLayout::new()` and is vision-inde
 
 - [ ] **Step 4: Update convenience wrappers to derive layout from config**
 
-`init_brain_state()` and `build_config()` use `BrainLayout::default()`. Update them to derive layout from the config's `vision_w`/`vision_h`:
+`init_brain_state()` and `build_config()` use `BrainLayout::default()`. Update them to derive layout from the config's `vision_width`/`vision_height`:
 
 ```rust
 pub fn init_brain_state(config: &BrainConfig, rng: &mut impl rand::Rng) -> Vec<f32> {
-    init_brain_state_for(config, &BrainLayout::new(config.vision_w, config.vision_h), rng)
+    init_brain_state_for(config, &BrainLayout::new(config.vision_width, config.vision_height), rng)
 }
 
 pub fn build_config(config: &BrainConfig) -> Vec<f32> {
-    build_config_for(config, &BrainLayout::new(config.vision_w, config.vision_h))
+    build_config_for(config, &BrainLayout::new(config.vision_width, config.vision_height))
 }
 ```
 
@@ -274,8 +274,8 @@ Remove assertions against deleted constants. The test already checks internal co
 #[test]
 fn brain_layout_default_matches_constants() {
     let layout = BrainLayout::default();
-    assert_eq!(layout.vision_w, 8);
-    assert_eq!(layout.vision_h, 6);
+    assert_eq!(layout.vision_width, 8);
+    assert_eq!(layout.vision_height, 6);
     // Verify default layout values for 8x6 vision
     assert_eq!(layout.vision_color_count, 192);
     assert_eq!(layout.vision_depth_count, 48);
@@ -290,7 +290,7 @@ fn brain_layout_default_matches_constants() {
 #[test]
 fn init_brain_state_has_correct_length() {
     let config = BrainConfig::default();
-    let layout = BrainLayout::new(config.vision_w, config.vision_h);
+    let layout = BrainLayout::new(config.vision_width, config.vision_height);
     let mut rng = rand::rng();
     let state = init_brain_state(&config, &mut rng);
     assert_eq!(state.len(), layout.brain_stride);


### PR DESCRIPTION
## Summary
- Fix vision dispatch shader to handle > 256 rays per agent via strided loop (supports any vision grid size up to workgroup limit)
- Remove dead `wgsl_constants()` and `wgsl_physics_constants()` functions that emitted hardcoded 8x6 values
- Remove hardcoded `VISION_W`/`VISION_H`/`VISION_COLOR_COUNT`/`VISION_DEPTH_COUNT`/`SENSORY_STRIDE` constants from `buffers.rs`
- Make `pack_sensory_frame` layout-aware (accepts `&BrainLayout`)
- Update `init_brain_state`/`build_config` convenience wrappers to derive layout from config
- Add tests for 32x24 vision and dynamic sensory packing

Closes #66

## Test plan
- [x] `cargo test -p xagent-brain` — 22 tests pass including new `brain_layout_large_vision` and `pack_sensory_frame_dynamic_layout`
- [x] `cargo test -p xagent-sandbox --lib` — 65 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)