### PR TITLE
fix: smooth agent trails using Catmull-Rom subdivision

### DIFF
--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -29,7 +29,7 @@ pub const MAX_TRAIL_POINTS: usize = 4000;
 
 /// Minimum distance (squared) between consecutive trail samples.
 /// Only record a new point when the agent has moved at least this far.
-const MIN_TRAIL_DIST_SQ: f32 = 9.0; // 3.0²
+pub(crate) const MIN_TRAIL_DIST_SQ: f32 = 9.0; // 3.0²
 
 /// Runtime agent body extending shared [`BodyState`] with simulation bookkeeping.
 ///

--- a/crates/xagent-sandbox/src/overlay.rs
+++ b/crates/xagent-sandbox/src/overlay.rs
@@ -67,6 +67,61 @@ pub fn build_heatmap_mesh(
     Mesh { vertices, indices }
 }
 
+const MAX_SUBDIVISIONS: usize = 8;
+
+/// Subdivide a trail's control points using Catmull-Rom interpolation.
+/// Returns a denser polyline that smooths sharp corners.
+fn catmull_rom_subdivide(points: &[[f32; 3]]) -> std::borrow::Cow<'_, [[f32; 3]]> {
+    if points.len() < 3 {
+        return std::borrow::Cow::Borrowed(points);
+    }
+
+    let min_trail_dist_sq = crate::agent::MIN_TRAIL_DIST_SQ;
+
+    let mut result = Vec::with_capacity((points.len() - 1) * MAX_SUBDIVISIONS + 1);
+    for i in 0..points.len() - 1 {
+        let p0 = points[i.saturating_sub(1)];
+        let p1 = points[i];
+        let p2 = points[(i + 1).min(points.len() - 1)];
+        let p3 = points[(i + 2).min(points.len() - 1)];
+
+        let dist_sq = (p2[0] - p1[0]).powi(2) + (p2[1] - p1[1]).powi(2) + (p2[2] - p1[2]).powi(2);
+
+        let mut subdivisions = MAX_SUBDIVISIONS;
+        for k in 1..MAX_SUBDIVISIONS {
+            if dist_sq <= (k * k) as f32 * min_trail_dist_sq {
+                subdivisions = k;
+                break;
+            }
+        }
+
+        for s in 0..subdivisions {
+            let t = s as f32 / subdivisions as f32;
+            let t2 = t * t;
+            let t3 = t2 * t;
+            // Catmull-Rom matrix coefficients
+            let x = 0.5
+                * ((2.0 * p1[0])
+                    + (-p0[0] + p2[0]) * t
+                    + (2.0 * p0[0] - 5.0 * p1[0] + 4.0 * p2[0] - p3[0]) * t2
+                    + (-p0[0] + 3.0 * p1[0] - 3.0 * p2[0] + p3[0]) * t3);
+            let y = 0.5
+                * ((2.0 * p1[1])
+                    + (-p0[1] + p2[1]) * t
+                    + (2.0 * p0[1] - 5.0 * p1[1] + 4.0 * p2[1] - p3[1]) * t2
+                    + (-p0[1] + 3.0 * p1[1] - 3.0 * p2[1] + p3[1]) * t3);
+            let z = 0.5
+                * ((2.0 * p1[2])
+                    + (-p0[2] + p2[2]) * t
+                    + (2.0 * p0[2] - 5.0 * p1[2] + 4.0 * p2[2] - p3[2]) * t2
+                    + (-p0[2] + 3.0 * p1[2] - 3.0 * p2[2] + p3[2]) * t3);
+            result.push([x, y, z]);
+        }
+    }
+    result.push(*points.last().unwrap());
+    std::borrow::Cow::Owned(result)
+}
+
 /// Build a linear ribbon trail from the agent's distance-sampled control points.
 /// Only rebuilt when the trail dirty flag is set.
 pub fn build_trail_mesh(points: &[[f32; 3]], agent_color: &[f32; 3]) -> Mesh {
@@ -78,6 +133,9 @@ pub fn build_trail_mesh(points: &[[f32; 3]], agent_color: &[f32; 3]) -> Mesh {
         };
     }
 
+    let subdivided_points = catmull_rom_subdivide(points);
+    let n = subdivided_points.len();
+
     let num_segments = n - 1;
     let mut vertices = Vec::with_capacity(num_segments * 4);
     let mut indices: Vec<u32> = Vec::with_capacity(num_segments * 6);
@@ -86,8 +144,8 @@ pub fn build_trail_mesh(points: &[[f32; 3]], agent_color: &[f32; 3]) -> Mesh {
     let y_offset: f32 = 0.3;
 
     for i in 0..num_segments {
-        let a = points[i];
-        let b = points[i + 1];
+        let a = subdivided_points[i];
+        let b = subdivided_points[i + 1];
 
         // Gentle fade: oldest 20% fades from 0.3→0.7, rest is 0.7
         let progress = i as f32 / num_segments as f32;
@@ -153,8 +211,8 @@ pub fn build_all_trails_mesh(
         };
     }
 
-    let mut vertices = Vec::with_capacity(total_segments * 4);
-    let mut indices: Vec<u32> = Vec::with_capacity(total_segments * 6);
+    let mut vertices = Vec::with_capacity(total_segments.saturating_mul(4));
+    let mut indices: Vec<u32> = Vec::with_capacity(total_segments.saturating_mul(6));
 
     let ribbon_half_width: f32 = 0.3;
     let y_offset: f32 = 0.3;
@@ -164,10 +222,15 @@ pub fn build_all_trails_mesh(
             continue;
         }
 
-        let num_segments = trail.len() - 1;
+        let subdivided_trail = catmull_rom_subdivide(trail);
+        let num_segments = subdivided_trail.len() - 1;
+
+        vertices.reserve(num_segments * 4);
+        indices.reserve(num_segments * 6);
+
         for i in 0..num_segments {
-            let a = trail[i];
-            let b = trail[i + 1];
+            let a = subdivided_trail[i];
+            let b = subdivided_trail[i + 1];
 
             let progress = i as f32 / num_segments as f32;
             let brightness = if progress < 0.2 {
@@ -285,6 +348,33 @@ mod tests {
     // ── build_trail_mesh ─────────────────────────────────────────────
 
     #[test]
+    fn catmull_rom_subdivide_preserves_endpoints() {
+        let points = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 1.0, 0.0]];
+        let result = catmull_rom_subdivide(&points);
+        assert_eq!(result.first().unwrap(), &points[0]);
+        assert_eq!(result.last().unwrap(), points.last().unwrap());
+    }
+
+    #[test]
+    fn catmull_rom_subdivide_increases_point_count() {
+        let points = vec![
+            [0.0, 0.0, 0.0],
+            [15.0, 0.0, 0.0],
+            [30.0, 15.0, 0.0],
+            [45.0, 15.0, 0.0],
+        ];
+        let result = catmull_rom_subdivide(&points);
+        assert!(result.len() > points.len());
+    }
+
+    #[test]
+    fn catmull_rom_subdivide_short_input_unchanged() {
+        let points = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]];
+        let result = catmull_rom_subdivide(&points);
+        assert_eq!(result.len(), points.len());
+    }
+
+    #[test]
     fn trail_mesh_empty_on_zero_points() {
         let m = build_trail_mesh(&[], &white());
         assert!(m.vertices.is_empty());
@@ -309,8 +399,13 @@ mod tests {
     fn trail_mesh_three_points_two_segments() {
         let pts = [[0.0, 0.0, 0.0], [5.0, 0.0, 0.0], [10.0, 0.0, 0.0]];
         let m = build_trail_mesh(&pts, &white());
-        assert_eq!(m.vertices.len(), 8);
-        assert_eq!(m.indices.len(), 12);
+
+        let expected_segments = catmull_rom_subdivide(&pts).len() - 1;
+        assert_eq!(m.vertices.len(), expected_segments * 4);
+        assert_eq!(m.indices.len(), expected_segments * 6);
+
+        // Prove subdivision was actually applied
+        assert!(expected_segments > pts.len() - 1);
     }
 
     #[test]
@@ -353,18 +448,24 @@ mod tests {
 
     #[test]
     fn all_trails_combines_two_agents() {
-        let t1 = vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]]; // 1 segment
-        let t2 = vec![[0.0, 0.0, 5.0], [5.0, 0.0, 5.0], [10.0, 0.0, 5.0]]; // 2 segments
+        let t1 = vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]]; // 1 segment (too short for subdiv)
+        let t2 = vec![[0.0, 0.0, 5.0], [5.0, 0.0, 5.0], [10.0, 0.0, 5.0]]; // 4 segments after subdiv
         let red = [1.0, 0.0, 0.0];
         let blue = [0.0, 0.0, 1.0];
         let agents: Vec<(&[[f32; 3]], &[f32; 3], bool)> =
             vec![(t1.as_slice(), &red, true), (t2.as_slice(), &blue, true)];
         let m = build_all_trails_mesh(&agents);
-        // 3 segments total → 12 verts, 18 indices
-        assert_eq!(m.vertices.len(), 12);
-        assert_eq!(m.indices.len(), 18);
-    }
 
+        let expected_segments =
+            (catmull_rom_subdivide(&t1).len() - 1) + (catmull_rom_subdivide(&t2).len() - 1);
+
+        assert_eq!(m.vertices.len(), expected_segments * 4);
+        assert_eq!(m.indices.len(), expected_segments * 6);
+
+        let original_segments = (t1.len() - 1) + (t2.len() - 1);
+        // Prove subdivision was actually applied
+        assert!(expected_segments > original_segments);
+    }
     #[test]
     fn all_trails_mixed_alive_and_dead() {
         let t1 = vec![[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]];


### PR DESCRIPTION
Fixes #69. Implements Catmull-Rom spline interpolation to prevent jagged trails at high time multipliers.