### PR TITLE
fix: allow population size of 1

### DIFF
--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1449,8 +1449,8 @@ impl<'a> TabContext<'a> {
 
                     ui.label("population_size");
                     let mut ps = g.population_size as i32;
-                    ui.add(egui::DragValue::new(&mut ps).range(2..=100).speed(1));
-                    g.population_size = ps.max(2) as usize;
+                    ui.add(egui::DragValue::new(&mut ps).range(1..=100).speed(1));
+                    g.population_size = ps.max(1) as usize;
                     ui.end_row();
 
                     ui.label("tick_budget");


### PR DESCRIPTION
## Summary

- Lowers the UI minimum for `population_size` from 2 to 1
- The breeding logic already handles this correctly: crossover requires `elite_configs.len() >= 2` (skipped), elitism clamps via `unique_count.saturating_sub(1)` (becomes 0), and the champion fills the single slot

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p xagent-sandbox` — 115 tests pass
- [ ] Visual: start simulation with population=1, verify single agent runs and evolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)