### PR TITLE
fix: add movement_speed to evolution setup UI

### DIFF
--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1437,6 +1437,15 @@ impl<'a> TabContext<'a> {
                             .max_decimals(2),
                     );
                     ui.end_row();
+
+                    ui.label("movement_speed");
+                    ui.add(
+                        egui::DragValue::new(&mut b.movement_speed)
+                            .range(2.0..=20.0)
+                            .speed(0.5)
+                            .max_decimals(1),
+                    );
+                    ui.end_row();
                 });
         });
 


### PR DESCRIPTION
## Summary

- Adds `movement_speed` drag value to the brain config editor in the evolution setup panel
- Range [2.0, 20.0] matches the heritable mutation clamp bounds
- The field was already in `BrainConfig` and shown read-only in agent details, but missing from the new-run form

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p xagent-sandbox` — all tests pass
- [ ] Visual: verify movement_speed appears in setup UI and persists to the simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)