### PR TITLE
fix: decouple staging readback from dispatch for smooth motion at all speeds

### DIFF
--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -107,10 +107,10 @@ pub struct GpuKernel {
     bind_groups: [wgpu::BindGroup; 2],
     active_config_index: usize,
 
-    // ── Async state readback (triple-buffered, non-blocking) ──
-    // Three staging slots give readback 3 frames to complete before
-    // backpressure stalls dispatch — enough for 10x+ with 1 agent.
-    // Each slot contains phys + food buffers, mapped together.
+    // ── Async state readback (STAGING_SLOTS ring, non-blocking) ──
+    // Staging is decoupled from dispatch: in-flight readbacks do not
+    // block new dispatches. Each slot contains state + food staging
+    // buffers for one readback.
     // staging_ready counts completed map_async callbacks (need expected_staging_callbacks).
     state_staging: [wgpu::Buffer; STAGING_SLOTS],
     food_staging: [wgpu::Buffer; STAGING_SLOTS],
@@ -1294,8 +1294,9 @@ impl GpuKernel {
     ///
     /// Each kernel-batch runs `vision_stride` brain cycles in a single dispatch,
     /// followed by one global (grid+collisions) and one vision (raycasting) pass.
-    /// Non-blocking: skips if staging buffer is in flight (GPU backpressure).
-    /// Returns true if dispatched, false if skipped.
+    /// Always dispatches — compute is decoupled from staging readback.
+    /// Staging copy is opportunistic (skipped when all slots are in-flight).
+    /// Always returns `true` (kept for API compatibility).
     ///
     /// # Vision ordering guarantee
     ///

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -191,11 +191,7 @@ impl GpuKernel {
         self.reset_agents_with_rng(brain_config, &mut rng);
     }
 
-    fn reset_agents_with_rng(
-        &mut self,
-        brain_config: &BrainConfig,
-        rng: &mut impl rand::Rng,
-    ) {
+    fn reset_agents_with_rng(&mut self, brain_config: &BrainConfig, rng: &mut impl rand::Rng) {
         // Drain any pending async readback so staging buffers are clean.
         let expected = self.expected_staging_callbacks();
         for i in 0..STAGING_SLOTS {
@@ -246,11 +242,7 @@ impl GpuKernel {
         let mut pattern_data = Vec::with_capacity(n * PATTERN_STRIDE);
         let mut history_data = Vec::with_capacity(n * HISTORY_STRIDE);
         for _ in 0..n {
-            brain_data.extend_from_slice(&init_brain_state_for(
-                brain_config,
-                &self.layout,
-                rng,
-            ));
+            brain_data.extend_from_slice(&init_brain_state_for(brain_config, &self.layout, rng));
             pattern_data.extend_from_slice(&init_pattern_memory());
             history_data.extend_from_slice(&init_action_history());
         }
@@ -454,7 +446,7 @@ impl GpuKernel {
             mapped_at_creation: false,
         });
 
-        // ── Async state readback staging (double-buffered) ──
+        // ── Async state readback staging (STAGING_SLOTS ring buffer) ──
         let state_size = (n * PHYS_STRIDE * 4) as u64;
         let food_state_size = ((f * FOOD_STATE_STRIDE * 4) as u64).max(4);
         let staging_usage = wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST;
@@ -1465,14 +1457,15 @@ impl GpuKernel {
 
             let phys_flag = self.staging_ready[widx].clone();
             let phys_err = self.staging_had_error[widx].clone();
-            self.state_staging[widx]
-                .slice(..buf_size)
-                .map_async(wgpu::MapMode::Read, move |result| {
+            self.state_staging[widx].slice(..buf_size).map_async(
+                wgpu::MapMode::Read,
+                move |result| {
                     if result.is_err() {
                         phys_err.store(true, Ordering::Release);
                     }
                     phys_flag.fetch_add(1, Ordering::Release);
-                });
+                },
+            );
             if self.food_count > 0 {
                 let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
                 let food_flag = self.staging_ready[widx].clone();

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -12,9 +12,9 @@ use xagent_shared::{BrainConfig, WorldConfig};
 use crate::buffers::*;
 
 /// Number of async staging slots for state readback.
-/// Triple-buffering gives readback 3 frames to complete before backpressure
-/// stalls dispatch — enough for 10x+ speed at high FPS.
-const STAGING_SLOTS: usize = 3;
+/// Triple-buffering gives readback enough headroom while keeping the GPU
+/// queue shallow enough that `queue.submit()` never blocks.
+const STAGING_SLOTS: usize = 6;
 
 /// Pending async readback of 4 staging buffers for telemetry.
 struct TelemetryReadback {
@@ -177,7 +177,25 @@ impl GpuKernel {
     /// Re-initialize all per-agent GPU state for a new generation without
     /// recreating the device, pipelines, or buffers.  The caller must also
     /// call `upload_agents` afterwards to set physics positions.
+    /// Reset all agent state using a deterministic RNG seed.
+    /// Produces identical brain weights for the same seed + config,
+    /// enabling reproducible test runs across resets.
+    pub fn reset_agents_seeded(&mut self, brain_config: &BrainConfig, seed: u64) {
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        self.reset_agents_with_rng(brain_config, &mut rng);
+    }
+
     pub fn reset_agents(&mut self, brain_config: &BrainConfig) {
+        let mut rng = rand::rng();
+        self.reset_agents_with_rng(brain_config, &mut rng);
+    }
+
+    fn reset_agents_with_rng(
+        &mut self,
+        brain_config: &BrainConfig,
+        rng: &mut impl rand::Rng,
+    ) {
         // Drain any pending async readback so staging buffers are clean.
         let expected = self.expected_staging_callbacks();
         for i in 0..STAGING_SLOTS {
@@ -224,7 +242,6 @@ impl GpuKernel {
         let n = self.agent_count as usize;
 
         // Fresh brain state, pattern memory, and action history.
-        let mut rng = rand::rng();
         let mut brain_data = Vec::with_capacity(n * self.layout.brain_stride);
         let mut pattern_data = Vec::with_capacity(n * PATTERN_STRIDE);
         let mut history_data = Vec::with_capacity(n * HISTORY_STRIDE);
@@ -232,7 +249,7 @@ impl GpuKernel {
             brain_data.extend_from_slice(&init_brain_state_for(
                 brain_config,
                 &self.layout,
-                &mut rng,
+                rng,
             ));
             pattern_data.extend_from_slice(&init_pattern_memory());
             history_data.extend_from_slice(&init_action_history());
@@ -1065,6 +1082,19 @@ impl GpuKernel {
             .write_buffer(&self.agent_phys_buffer, 0, bytemuck::cast_slice(&data));
     }
 
+    /// Minimum ticks per dispatch to guarantee at least one brain cycle.
+    pub fn brain_tick_stride(&self) -> u32 {
+        self.brain_tick_stride
+    }
+
+    /// The number of physics ticks in one full kernel batch
+    /// (`vision_stride * brain_tick_stride`).  Dispatching in exact
+    /// multiples of this value guarantees deterministic global-pass and
+    /// vision-pass frequency regardless of how the total is decomposed.
+    pub fn kernel_batch_size(&self) -> u32 {
+        self.vision_stride * self.brain_tick_stride
+    }
+
     /// Write world config uniform with batch parameters.
     pub fn upload_world_config(&self, start_tick: u64, ticks_to_run: u32) {
         self.upload_world_config_masked(start_tick, ticks_to_run, 0x7);
@@ -1383,86 +1413,82 @@ impl GpuKernel {
 
         // Physics-only remainder (ticks that don't fill a brain cycle)
         let physics_remainder = ticks_to_run % self.brain_tick_stride;
-
-        // Readback is decoupled from dispatch: compute always runs,
-        // staging copy only happens when a slot is free. This prevents
-        // readback backpressure from stalling simulation at high FPS.
-        let widx = self.staging_index;
-        let readback = !self.staging_in_flight[widx];
-
-        if physics_remainder > 0 || readback {
+        if physics_remainder > 0 {
+            self.upload_world_config_masked(tick_cursor, physics_remainder, 0x1);
+            let pc: [u32; 2] = [tick_cursor as u32, physics_remainder];
             let mut encoder = self
                 .device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("dispatch_kernel_final"),
+                    label: Some("dispatch_kernel_phys"),
                 });
-
-            if physics_remainder > 0 {
-                self.upload_world_config_masked(tick_cursor, physics_remainder, 0x1);
-                let pc: [u32; 2] = [tick_cursor as u32, physics_remainder];
-                {
-                    let mut pass = encoder.begin_compute_pass(&Default::default());
-                    pass.set_pipeline(&self.physics_pipeline);
-                    pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
-                    pass.set_push_constants(0, bytemuck::cast_slice(&pc));
-                    pass.dispatch_workgroups(1, 1, 1);
-                }
+            {
+                let mut pass = encoder.begin_compute_pass(&Default::default());
+                pass.set_pipeline(&self.physics_pipeline);
+                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
+                pass.set_push_constants(0, bytemuck::cast_slice(&pc));
+                pass.dispatch_workgroups(1, 1, 1);
             }
+            self.queue.submit(std::iter::once(encoder.finish()));
+        }
 
-            if readback {
+        // Opportunistic staging copy: only when a slot is free.
+        // Compute dispatch above always runs — staging readback is
+        // decoupled so dispatch is never blocked by readback latency.
+        let widx = self.staging_index;
+        if !self.staging_in_flight[widx] {
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("dispatch_staging_copy"),
+                });
+            encoder.copy_buffer_to_buffer(
+                &self.agent_phys_buffer,
+                0,
+                &self.state_staging[widx],
+                0,
+                buf_size,
+            );
+            if self.food_count > 0 {
+                let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
                 encoder.copy_buffer_to_buffer(
-                    &self.agent_phys_buffer,
+                    &self.food_state_buffer,
                     0,
-                    &self.state_staging[widx],
+                    &self.food_staging[widx],
                     0,
-                    buf_size,
+                    food_size,
                 );
-                if self.food_count > 0 {
-                    let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
-                    encoder.copy_buffer_to_buffer(
-                        &self.food_state_buffer,
-                        0,
-                        &self.food_staging[widx],
-                        0,
-                        food_size,
-                    );
-                }
             }
-
             self.queue.submit(std::iter::once(encoder.finish()));
 
-            if readback {
-                self.staging_ready[widx].store(0, Ordering::Release);
-                self.staging_had_error[widx].store(false, Ordering::Release);
+            self.staging_ready[widx].store(0, Ordering::Release);
+            self.staging_had_error[widx].store(false, Ordering::Release);
 
-                let phys_flag = self.staging_ready[widx].clone();
-                let phys_err = self.staging_had_error[widx].clone();
-                self.state_staging[widx].slice(..buf_size).map_async(
+            let phys_flag = self.staging_ready[widx].clone();
+            let phys_err = self.staging_had_error[widx].clone();
+            self.state_staging[widx]
+                .slice(..buf_size)
+                .map_async(wgpu::MapMode::Read, move |result| {
+                    if result.is_err() {
+                        phys_err.store(true, Ordering::Release);
+                    }
+                    phys_flag.fetch_add(1, Ordering::Release);
+                });
+            if self.food_count > 0 {
+                let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
+                let food_flag = self.staging_ready[widx].clone();
+                let food_err = self.staging_had_error[widx].clone();
+                self.food_staging[widx].slice(..food_size).map_async(
                     wgpu::MapMode::Read,
                     move |result| {
                         if result.is_err() {
-                            phys_err.store(true, Ordering::Release);
+                            food_err.store(true, Ordering::Release);
                         }
-                        phys_flag.fetch_add(1, Ordering::Release);
+                        food_flag.fetch_add(1, Ordering::Release);
                     },
                 );
-                if self.food_count > 0 {
-                    let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
-                    let food_flag = self.staging_ready[widx].clone();
-                    let food_err = self.staging_had_error[widx].clone();
-                    self.food_staging[widx].slice(..food_size).map_async(
-                        wgpu::MapMode::Read,
-                        move |result| {
-                            if result.is_err() {
-                                food_err.store(true, Ordering::Release);
-                            }
-                            food_flag.fetch_add(1, Ordering::Release);
-                        },
-                    );
-                }
-                self.staging_in_flight[widx] = true;
-                self.staging_index = (self.staging_index + 1) % STAGING_SLOTS;
             }
+            self.staging_in_flight[widx] = true;
+            self.staging_index = (self.staging_index + 1) % STAGING_SLOTS;
         }
 
         self.active_config_index = 1 - self.active_config_index;
@@ -2036,12 +2062,14 @@ impl GpuKernel {
     }
 
     /// Unmap all pre-allocated telemetry staging buffers.
-    /// Safe to call even when buffers are not currently mapped.
+    /// Only unmaps when a telemetry readback was pending.
     fn unmap_telemetry_staging(&self) {
-        self.telemetry_staging.sensory.unmap();
-        self.telemetry_staging.decision.unmap();
-        self.telemetry_staging.brain.unmap();
-        self.telemetry_staging.phys.unmap();
+        if self.pending_telemetry.is_some() {
+            self.telemetry_staging.sensory.unmap();
+            self.telemetry_staging.decision.unmap();
+            self.telemetry_staging.brain.unmap();
+            self.telemetry_staging.phys.unmap();
+        }
     }
 
     /// Kick off non-blocking telemetry readback for one agent.

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -12,7 +12,7 @@ use xagent_shared::{BrainConfig, WorldConfig};
 use crate::buffers::*;
 
 /// Number of async staging slots for state readback.
-/// Triple-buffering gives readback enough headroom while keeping the GPU
+/// Six slots give async readback additional headroom while keeping the GPU
 /// queue shallow enough that `queue.submit()` never blocks.
 const STAGING_SLOTS: usize = 6;
 
@@ -1411,7 +1411,7 @@ impl GpuKernel {
             let mut encoder = self
                 .device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("dispatch_kernel_phys"),
+                    label: Some("dispatch_kernel_physics_remainder"),
                 });
             {
                 let mut pass = encoder.begin_compute_pass(&Default::default());
@@ -1423,11 +1423,13 @@ impl GpuKernel {
             self.queue.submit(std::iter::once(encoder.finish()));
         }
 
-        // Opportunistic staging copy: only when a slot is free.
+        // Opportunistic staging copy: scan for any free slot.
         // Compute dispatch above always runs — staging readback is
         // decoupled so dispatch is never blocked by readback latency.
-        let widx = self.staging_index;
-        if !self.staging_in_flight[widx] {
+        let write_slot = (0..STAGING_SLOTS)
+            .map(|offset| (self.staging_index + offset) % STAGING_SLOTS)
+            .find(|&slot| !self.staging_in_flight[slot]);
+        if let Some(slot_index) = write_slot {
             let mut encoder = self
                 .device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -1436,7 +1438,7 @@ impl GpuKernel {
             encoder.copy_buffer_to_buffer(
                 &self.agent_phys_buffer,
                 0,
-                &self.state_staging[widx],
+                &self.state_staging[slot_index],
                 0,
                 buf_size,
             );
@@ -1445,19 +1447,19 @@ impl GpuKernel {
                 encoder.copy_buffer_to_buffer(
                     &self.food_state_buffer,
                     0,
-                    &self.food_staging[widx],
+                    &self.food_staging[slot_index],
                     0,
                     food_size,
                 );
             }
             self.queue.submit(std::iter::once(encoder.finish()));
 
-            self.staging_ready[widx].store(0, Ordering::Release);
-            self.staging_had_error[widx].store(false, Ordering::Release);
+            self.staging_ready[slot_index].store(0, Ordering::Release);
+            self.staging_had_error[slot_index].store(false, Ordering::Release);
 
-            let phys_flag = self.staging_ready[widx].clone();
-            let phys_err = self.staging_had_error[widx].clone();
-            self.state_staging[widx].slice(..buf_size).map_async(
+            let phys_flag = self.staging_ready[slot_index].clone();
+            let phys_err = self.staging_had_error[slot_index].clone();
+            self.state_staging[slot_index].slice(..buf_size).map_async(
                 wgpu::MapMode::Read,
                 move |result| {
                     if result.is_err() {
@@ -1468,9 +1470,9 @@ impl GpuKernel {
             );
             if self.food_count > 0 {
                 let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
-                let food_flag = self.staging_ready[widx].clone();
-                let food_err = self.staging_had_error[widx].clone();
-                self.food_staging[widx].slice(..food_size).map_async(
+                let food_flag = self.staging_ready[slot_index].clone();
+                let food_err = self.staging_had_error[slot_index].clone();
+                self.food_staging[slot_index].slice(..food_size).map_async(
                     wgpu::MapMode::Read,
                     move |result| {
                         if result.is_err() {
@@ -1480,8 +1482,8 @@ impl GpuKernel {
                     },
                 );
             }
-            self.staging_in_flight[widx] = true;
-            self.staging_index = (self.staging_index + 1) % STAGING_SLOTS;
+            self.staging_in_flight[slot_index] = true;
+            self.staging_index = (slot_index + 1) % STAGING_SLOTS;
         }
 
         self.active_config_index = 1 - self.active_config_index;

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -11,6 +11,11 @@ use xagent_shared::{BrainConfig, WorldConfig};
 
 use crate::buffers::*;
 
+/// Number of async staging slots for state readback.
+/// Triple-buffering gives readback 3 frames to complete before backpressure
+/// stalls dispatch — enough for 10x+ speed at high FPS.
+const STAGING_SLOTS: usize = 3;
+
 /// Pending async readback of 4 staging buffers for telemetry.
 struct TelemetryReadback {
     /// Number of map_async callbacks that have fired (need all 4).
@@ -102,15 +107,17 @@ pub struct GpuKernel {
     bind_groups: [wgpu::BindGroup; 2],
     active_config_index: usize,
 
-    // ── Async state readback (double-buffered, non-blocking) ──
-    // Each staging slot contains phys + food buffers, mapped together.
+    // ── Async state readback (triple-buffered, non-blocking) ──
+    // Three staging slots give readback 3 frames to complete before
+    // backpressure stalls dispatch — enough for 10x+ with 1 agent.
+    // Each slot contains phys + food buffers, mapped together.
     // staging_ready counts completed map_async callbacks (need expected_staging_callbacks).
-    state_staging: [wgpu::Buffer; 2],
-    food_staging: [wgpu::Buffer; 2],
-    staging_index: usize,                    // which buffer to write NEXT
-    staging_in_flight: [bool; 2],            // submitted, not yet collected
-    staging_ready: [Arc<AtomicU32>; 2],      // map_async callbacks completed
-    staging_had_error: [Arc<AtomicBool>; 2], // set if any map_async callback errored
+    state_staging: [wgpu::Buffer; STAGING_SLOTS],
+    food_staging: [wgpu::Buffer; STAGING_SLOTS],
+    staging_index: usize,                           // which buffer to write NEXT
+    staging_in_flight: [bool; STAGING_SLOTS],       // submitted, not yet collected
+    staging_ready: [Arc<AtomicU32>; STAGING_SLOTS], // map_async callbacks completed
+    staging_had_error: [Arc<AtomicBool>; STAGING_SLOTS], // set if any map_async callback errored
     state_cache: Vec<f32>,
     food_cache: Vec<f32>,
     food_cache_valid: bool,
@@ -173,7 +180,7 @@ impl GpuKernel {
     pub fn reset_agents(&mut self, brain_config: &BrainConfig) {
         // Drain any pending async readback so staging buffers are clean.
         let expected = self.expected_staging_callbacks();
-        for i in 0..2 {
+        for i in 0..STAGING_SLOTS {
             if self.staging_in_flight[i] {
                 while self.staging_ready[i].load(Ordering::Acquire) < expected {
                     self.device.poll(wgpu::Maintain::Poll);
@@ -434,34 +441,22 @@ impl GpuKernel {
         let state_size = (n * PHYS_STRIDE * 4) as u64;
         let food_state_size = ((f * FOOD_STATE_STRIDE * 4) as u64).max(4);
         let staging_usage = wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST;
-        let state_staging = [
+        let state_staging = std::array::from_fn(|i| {
             device.create_buffer(&wgpu::BufferDescriptor {
-                label: Some("kernel_state_staging_0"),
+                label: Some(&format!("kernel_state_staging_{i}")),
                 size: state_size,
                 usage: staging_usage,
                 mapped_at_creation: false,
-            }),
+            })
+        });
+        let food_staging = std::array::from_fn(|i| {
             device.create_buffer(&wgpu::BufferDescriptor {
-                label: Some("kernel_state_staging_1"),
-                size: state_size,
-                usage: staging_usage,
-                mapped_at_creation: false,
-            }),
-        ];
-        let food_staging = [
-            device.create_buffer(&wgpu::BufferDescriptor {
-                label: Some("kernel_food_staging_0"),
+                label: Some(&format!("kernel_food_staging_{i}")),
                 size: food_state_size,
                 usage: staging_usage,
                 mapped_at_creation: false,
-            }),
-            device.create_buffer(&wgpu::BufferDescriptor {
-                label: Some("kernel_food_staging_1"),
-                size: food_state_size,
-                usage: staging_usage,
-                mapped_at_creation: false,
-            }),
-        ];
+            })
+        });
 
         // ── Pre-allocated telemetry staging buffers ──
         let tel_sensory_size = (layout.sensory_stride * 4) as u64;
@@ -992,12 +987,9 @@ impl GpuKernel {
             state_staging,
             food_staging,
             staging_index: 0,
-            staging_in_flight: [false, false],
-            staging_ready: [Arc::new(AtomicU32::new(0)), Arc::new(AtomicU32::new(0))],
-            staging_had_error: [
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(AtomicBool::new(false)),
-            ],
+            staging_in_flight: [false; STAGING_SLOTS],
+            staging_ready: std::array::from_fn(|_| Arc::new(AtomicU32::new(0))),
+            staging_had_error: std::array::from_fn(|_| Arc::new(AtomicBool::new(false))),
             state_cache: vec![0.0; n * PHYS_STRIDE],
             food_cache: vec![0.0; f * FOOD_STATE_STRIDE],
             food_cache_valid: false,
@@ -1230,7 +1222,7 @@ impl GpuKernel {
         let buf_size = (n * PHYS_STRIDE * 4) as u64;
         let expected = self.expected_staging_callbacks();
         let mut collected = false;
-        for i in 0..2 {
+        for i in 0..STAGING_SLOTS {
             if !self.staging_in_flight[i] {
                 continue;
             }
@@ -1464,7 +1456,7 @@ impl GpuKernel {
             );
         }
         self.staging_in_flight[widx] = true;
-        self.staging_index = 1 - self.staging_index;
+        self.staging_index = (self.staging_index + 1) % STAGING_SLOTS;
         self.active_config_index = 1 - self.active_config_index;
         true
     }
@@ -1852,7 +1844,7 @@ impl GpuKernel {
     pub fn try_reset_agents(&mut self, brain_config: &BrainConfig) -> bool {
         // Check if any staging buffer is still in flight.
         let expected = self.expected_staging_callbacks();
-        for i in 0..2 {
+        for i in 0..STAGING_SLOTS {
             if self.staging_in_flight[i] {
                 self.device.poll(wgpu::Maintain::Poll);
                 if self.staging_ready[i].load(Ordering::Acquire) < expected {

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -1300,12 +1300,6 @@ impl GpuKernel {
     /// `vision_stride * brain_tick_stride` physics ticks and the sensory lag
     /// is one batch = `vision_stride * brain_tick_stride` physics ticks.
     pub fn dispatch_batch(&mut self, start_tick: u64, ticks_to_run: u32) -> bool {
-        // Check if the write-target staging buffer is free.
-        let widx = self.staging_index;
-        if self.staging_in_flight[widx] {
-            return false;
-        }
-
         let n = self.agent_count as usize;
         let buf_size = (n * PHYS_STRIDE * 4) as u64;
 
@@ -1390,73 +1384,87 @@ impl GpuKernel {
         // Physics-only remainder (ticks that don't fill a brain cycle)
         let physics_remainder = ticks_to_run % self.brain_tick_stride;
 
-        // Final submit: physics remainder + async state readback
-        let mut encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("dispatch_kernel_final"),
-            });
-        if physics_remainder > 0 {
-            self.upload_world_config_masked(tick_cursor, physics_remainder, 0x1);
-            let pc: [u32; 2] = [tick_cursor as u32, physics_remainder];
-            {
-                let mut pass = encoder.begin_compute_pass(&Default::default());
-                pass.set_pipeline(&self.physics_pipeline);
-                pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
-                pass.set_push_constants(0, bytemuck::cast_slice(&pc));
-                pass.dispatch_workgroups(1, 1, 1);
+        // Readback is decoupled from dispatch: compute always runs,
+        // staging copy only happens when a slot is free. This prevents
+        // readback backpressure from stalling simulation at high FPS.
+        let widx = self.staging_index;
+        let readback = !self.staging_in_flight[widx];
+
+        if physics_remainder > 0 || readback {
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("dispatch_kernel_final"),
+                });
+
+            if physics_remainder > 0 {
+                self.upload_world_config_masked(tick_cursor, physics_remainder, 0x1);
+                let pc: [u32; 2] = [tick_cursor as u32, physics_remainder];
+                {
+                    let mut pass = encoder.begin_compute_pass(&Default::default());
+                    pass.set_pipeline(&self.physics_pipeline);
+                    pass.set_bind_group(0, &self.bind_groups[self.active_config_index], &[]);
+                    pass.set_push_constants(0, bytemuck::cast_slice(&pc));
+                    pass.dispatch_workgroups(1, 1, 1);
+                }
+            }
+
+            if readback {
+                encoder.copy_buffer_to_buffer(
+                    &self.agent_phys_buffer,
+                    0,
+                    &self.state_staging[widx],
+                    0,
+                    buf_size,
+                );
+                if self.food_count > 0 {
+                    let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
+                    encoder.copy_buffer_to_buffer(
+                        &self.food_state_buffer,
+                        0,
+                        &self.food_staging[widx],
+                        0,
+                        food_size,
+                    );
+                }
+            }
+
+            self.queue.submit(std::iter::once(encoder.finish()));
+
+            if readback {
+                self.staging_ready[widx].store(0, Ordering::Release);
+                self.staging_had_error[widx].store(false, Ordering::Release);
+
+                let phys_flag = self.staging_ready[widx].clone();
+                let phys_err = self.staging_had_error[widx].clone();
+                self.state_staging[widx].slice(..buf_size).map_async(
+                    wgpu::MapMode::Read,
+                    move |result| {
+                        if result.is_err() {
+                            phys_err.store(true, Ordering::Release);
+                        }
+                        phys_flag.fetch_add(1, Ordering::Release);
+                    },
+                );
+                if self.food_count > 0 {
+                    let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
+                    let food_flag = self.staging_ready[widx].clone();
+                    let food_err = self.staging_had_error[widx].clone();
+                    self.food_staging[widx].slice(..food_size).map_async(
+                        wgpu::MapMode::Read,
+                        move |result| {
+                            if result.is_err() {
+                                food_err.store(true, Ordering::Release);
+                            }
+                            food_flag.fetch_add(1, Ordering::Release);
+                        },
+                    );
+                }
+                self.staging_in_flight[widx] = true;
+                self.staging_index = (self.staging_index + 1) % STAGING_SLOTS;
             }
         }
 
-        // Async state readback into staging[widx]
-        encoder.copy_buffer_to_buffer(
-            &self.agent_phys_buffer,
-            0,
-            &self.state_staging[widx],
-            0,
-            buf_size,
-        );
-        if self.food_count > 0 {
-            let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
-            encoder.copy_buffer_to_buffer(
-                &self.food_state_buffer,
-                0,
-                &self.food_staging[widx],
-                0,
-                food_size,
-            );
-        }
-        self.queue.submit(std::iter::once(encoder.finish()));
-
-        self.staging_ready[widx].store(0, Ordering::Release);
-        self.staging_had_error[widx].store(false, Ordering::Release);
-
-        let phys_flag = self.staging_ready[widx].clone();
-        let phys_err = self.staging_had_error[widx].clone();
-        self.state_staging[widx]
-            .slice(..buf_size)
-            .map_async(wgpu::MapMode::Read, move |result| {
-                if result.is_err() {
-                    phys_err.store(true, Ordering::Release);
-                }
-                phys_flag.fetch_add(1, Ordering::Release);
-            });
-        if self.food_count > 0 {
-            let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
-            let food_flag = self.staging_ready[widx].clone();
-            let food_err = self.staging_had_error[widx].clone();
-            self.food_staging[widx].slice(..food_size).map_async(
-                wgpu::MapMode::Read,
-                move |result| {
-                    if result.is_err() {
-                        food_err.store(true, Ordering::Release);
-                    }
-                    food_flag.fetch_add(1, Ordering::Release);
-                },
-            );
-        }
-        self.staging_in_flight[widx] = true;
-        self.staging_index = (self.staging_index + 1) % STAGING_SLOTS;
         self.active_config_index = 1 - self.active_config_index;
         true
     }

--- a/crates/xagent-sandbox/src/bench.rs
+++ b/crates/xagent-sandbox/src/bench.rs
@@ -120,6 +120,116 @@ pub fn run_profile(
     println!("  total tps (full):  {:.0}", total_ticks as f64 / full);
 }
 
+/// Simulate the real tick loop with accumulator, staging backpressure,
+/// and per-frame dispatch — no rendering. Prints DIAG lines every second
+/// and returns the result.
+pub fn run_tick_loop_bench(
+    brain: BrainConfig,
+    world_config: WorldConfig,
+    agent_count: usize,
+    total_ticks: u64,
+    speed_multiplier: f32,
+    timeout_secs: f64,
+) -> BenchResult {
+    const SIM_DT: f64 = 1.0 / 60.0;
+
+    let (mut mk, _world) = create_kernel(&brain, &world_config, agent_count);
+
+    let start = Instant::now();
+    let mut tick: u64 = 0;
+    let mut accumulator: f64 = 0.0;
+    let mut gpu_tick_budget: u32 = 32;
+    let mut last_diag = Instant::now();
+    let mut diag_ticks_since: u64 = 0;
+    let mut bp_count: u64 = 0;
+    let mut dispatch_count: u64 = 0;
+
+    // Simulate 120fps frame rate (8.33ms per frame)
+    let frame_dt: f64 = 1.0 / 120.0;
+
+    while tick < total_ticks {
+        let wall_elapsed = start.elapsed().as_secs_f64();
+        if wall_elapsed > timeout_secs {
+            eprintln!(
+                "[BENCH] TIMEOUT after {:.1}s — only {}/{} ticks ({:.0} tps)",
+                wall_elapsed,
+                tick,
+                total_ticks,
+                tick as f64 / wall_elapsed
+            );
+            break;
+        }
+
+        // Accumulate
+        accumulator += frame_dt * speed_multiplier as f64;
+        let max_acc = SIM_DT * speed_multiplier as f64 * 3.0;
+        accumulator = accumulator.min(max_acc);
+
+        let remaining = (total_ticks - tick) as u32;
+        let ticks_to_run = ((accumulator / SIM_DT) as u32)
+            .min(gpu_tick_budget)
+            .min(500)
+            .min(remaining);
+
+        if ticks_to_run > 0 {
+            mk.try_collect_state();
+            let dispatched = mk.dispatch_batch(tick, ticks_to_run);
+
+            if dispatched {
+                accumulator -= ticks_to_run as f64 * SIM_DT;
+                gpu_tick_budget = (gpu_tick_budget + gpu_tick_budget / 4 + 1).min(64_000);
+                tick += ticks_to_run as u64;
+                diag_ticks_since += ticks_to_run as u64;
+                dispatch_count += 1;
+            } else {
+                bp_count += 1;
+            }
+        }
+
+        // DIAG every second
+        if last_diag.elapsed().as_secs_f64() >= 1.0 {
+            let tps = diag_ticks_since as f64 / last_diag.elapsed().as_secs_f64();
+            eprintln!(
+                "[BENCH-DIAG] tick={}/{} tps={:.0} budget={} bp={} dispatches={} acc={:.4}",
+                tick, total_ticks, tps, gpu_tick_budget, bp_count, dispatch_count, accumulator
+            );
+            diag_ticks_since = 0;
+            bp_count = 0;
+            dispatch_count = 0;
+            last_diag = Instant::now();
+        }
+    }
+
+    // Final readback
+    let state = mk.read_full_state_blocking();
+    let elapsed_secs = start.elapsed().as_secs_f64();
+    let ticks_per_sec = tick as f64 / elapsed_secs;
+
+    eprintln!(
+        "[BENCH] Done: {} ticks in {:.2}s = {:.0} tps",
+        tick, elapsed_secs, ticks_per_sec
+    );
+
+    let final_positions: Vec<[f32; 3]> = (0..agent_count)
+        .map(|i| {
+            let base = i * PHYS_STRIDE;
+            [
+                state[base + P_POS_X],
+                state[base + P_POS_Y],
+                state[base + P_POS_Z],
+            ]
+        })
+        .collect();
+
+    BenchResult {
+        total_ticks: tick,
+        agent_count,
+        elapsed_secs,
+        ticks_per_sec,
+        final_positions,
+    }
+}
+
 fn create_kernel(
     brain: &BrainConfig,
     world_config: &WorldConfig,

--- a/crates/xagent-sandbox/src/bench.rs
+++ b/crates/xagent-sandbox/src/bench.rs
@@ -31,13 +31,13 @@ pub fn run_bench(
 ) -> BenchResult {
     println!("[bench] Using GpuKernel ({} agents)", agent_count);
 
-    let (mut mk, _world) = create_kernel(&brain, &world_config, agent_count);
+    let (mut kernel, _world) = create_kernel(&brain, &world_config, agent_count);
 
     let start = Instant::now();
 
     // Single dispatch for all ticks
-    mk.dispatch_batch(0, total_ticks as u32);
-    let state = mk.read_full_state_blocking();
+    kernel.dispatch_batch(0, total_ticks as u32);
+    let state = kernel.read_full_state_blocking();
 
     let elapsed = start.elapsed();
     let elapsed_secs = elapsed.as_secs_f64();
@@ -76,29 +76,29 @@ pub fn run_profile(
         agent_count, total_ticks
     );
 
-    let (mut mk, _world) = create_kernel(&brain, &world_config, agent_count);
+    let (mut kernel, _world) = create_kernel(&brain, &world_config, agent_count);
 
     // mask=0: barriers only (no compute, same barrier structure)
     let t0 = Instant::now();
-    mk.dispatch_batch_masked(0, total_ticks as u32, 0);
+    kernel.dispatch_batch_masked(0, total_ticks as u32, 0);
     let barriers_only = t0.elapsed().as_secs_f64();
 
     // mask=1: physics only (barriers + physics compute)
-    let (mut mk, _) = create_kernel(&brain, &world_config, agent_count);
+    let (mut kernel, _) = create_kernel(&brain, &world_config, agent_count);
     let t1 = Instant::now();
-    mk.dispatch_batch_masked(0, total_ticks as u32, 1);
+    kernel.dispatch_batch_masked(0, total_ticks as u32, 1);
     let physics = t1.elapsed().as_secs_f64();
 
     // mask=3: physics + vision
-    let (mut mk, _) = create_kernel(&brain, &world_config, agent_count);
+    let (mut kernel, _) = create_kernel(&brain, &world_config, agent_count);
     let t2 = Instant::now();
-    mk.dispatch_batch_masked(0, total_ticks as u32, 3);
+    kernel.dispatch_batch_masked(0, total_ticks as u32, 3);
     let phys_vision = t2.elapsed().as_secs_f64();
 
     // mask=7: full (physics + vision + brain)
-    let (mut mk, _) = create_kernel(&brain, &world_config, agent_count);
+    let (mut kernel, _) = create_kernel(&brain, &world_config, agent_count);
     let t3 = Instant::now();
-    mk.dispatch_batch_masked(0, total_ticks as u32, 7);
+    kernel.dispatch_batch_masked(0, total_ticks as u32, 7);
     let full = t3.elapsed().as_secs_f64();
 
     println!("  barriers only:     {:.3}s", barriers_only);
@@ -120,9 +120,8 @@ pub fn run_profile(
     println!("  total tps (full):  {:.0}", total_ticks as f64 / full);
 }
 
-/// Simulate the real tick loop with accumulator, staging backpressure,
-/// and per-frame dispatch — no rendering. Prints DIAG lines every second
-/// and returns the result.
+/// Simulate the real tick loop with accumulator and per-frame dispatch —
+/// no rendering. Prints DIAG lines every second and returns the result.
 pub fn run_tick_loop_bench(
     brain: BrainConfig,
     world_config: WorldConfig,
@@ -133,7 +132,7 @@ pub fn run_tick_loop_bench(
 ) -> BenchResult {
     const SIM_DT: f64 = 1.0 / 60.0;
 
-    let (mut mk, _world) = create_kernel(&brain, &world_config, agent_count);
+    let (mut kernel, _world) = create_kernel(&brain, &world_config, agent_count);
 
     let start = Instant::now();
     let mut tick: u64 = 0;
@@ -141,11 +140,10 @@ pub fn run_tick_loop_bench(
     let mut gpu_tick_budget: u32 = 32;
     let mut last_diag = Instant::now();
     let mut diag_ticks_since: u64 = 0;
-    let mut bp_count: u64 = 0;
     let mut dispatch_count: u64 = 0;
 
     // Simulate 120fps frame rate (8.33ms per frame)
-    let frame_dt: f64 = 1.0 / 120.0;
+    let frame_delta_time: f64 = 1.0 / 120.0;
 
     while tick < total_ticks {
         let wall_elapsed = start.elapsed().as_secs_f64();
@@ -161,9 +159,9 @@ pub fn run_tick_loop_bench(
         }
 
         // Accumulate
-        accumulator += frame_dt * speed_multiplier as f64;
-        let max_acc = SIM_DT * speed_multiplier as f64 * 3.0;
-        accumulator = accumulator.min(max_acc);
+        accumulator += frame_delta_time * speed_multiplier as f64;
+        let max_accumulator = SIM_DT * speed_multiplier as f64 * 3.0;
+        accumulator = accumulator.min(max_accumulator);
 
         let remaining = (total_ticks - tick) as u32;
         let ticks_to_run = ((accumulator / SIM_DT) as u32)
@@ -172,36 +170,31 @@ pub fn run_tick_loop_bench(
             .min(remaining);
 
         if ticks_to_run > 0 {
-            mk.try_collect_state();
-            let dispatched = mk.dispatch_batch(tick, ticks_to_run);
+            kernel.try_collect_state();
+            kernel.dispatch_batch(tick, ticks_to_run);
 
-            if dispatched {
-                accumulator -= ticks_to_run as f64 * SIM_DT;
-                gpu_tick_budget = (gpu_tick_budget + gpu_tick_budget / 4 + 1).min(64_000);
-                tick += ticks_to_run as u64;
-                diag_ticks_since += ticks_to_run as u64;
-                dispatch_count += 1;
-            } else {
-                bp_count += 1;
-            }
+            accumulator -= ticks_to_run as f64 * SIM_DT;
+            gpu_tick_budget = (gpu_tick_budget + gpu_tick_budget / 4 + 1).min(64_000);
+            tick += ticks_to_run as u64;
+            diag_ticks_since += ticks_to_run as u64;
+            dispatch_count += 1;
         }
 
         // DIAG every second
         if last_diag.elapsed().as_secs_f64() >= 1.0 {
             let tps = diag_ticks_since as f64 / last_diag.elapsed().as_secs_f64();
             eprintln!(
-                "[BENCH-DIAG] tick={}/{} tps={:.0} budget={} bp={} dispatches={} acc={:.4}",
-                tick, total_ticks, tps, gpu_tick_budget, bp_count, dispatch_count, accumulator
+                "[BENCH-DIAG] tick={}/{} tps={:.0} budget={} dispatches={} accumulator={:.4}",
+                tick, total_ticks, tps, gpu_tick_budget, dispatch_count, accumulator
             );
             diag_ticks_since = 0;
-            bp_count = 0;
             dispatch_count = 0;
             last_diag = Instant::now();
         }
     }
 
     // Final readback
-    let state = mk.read_full_state_blocking();
+    let state = kernel.read_full_state_blocking();
     let elapsed_secs = start.elapsed().as_secs_f64();
     let ticks_per_sec = tick as f64 / elapsed_secs;
 
@@ -238,7 +231,7 @@ fn create_kernel(
     let world = WorldState::new(world_config.clone());
     let food_count = world.food_items.len();
 
-    let mk = GpuKernel::new(agent_count as u32, food_count, brain, world_config);
+    let kernel = GpuKernel::new(agent_count as u32, food_count, brain, world_config);
 
     // Upload world data
     let heights = world.terrain.heights.clone();
@@ -250,7 +243,7 @@ fn create_kernel(
         .collect();
     let food_consumed: Vec<bool> = world.food_items.iter().map(|f| f.consumed).collect();
     let food_timers: Vec<f32> = world.food_items.iter().map(|f| f.respawn_timer).collect();
-    mk.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
+    kernel.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
 
     // Upload agents
     let agent_data: Vec<(glam::Vec3, f32, f32, usize, usize)> = (0..agent_count)
@@ -265,7 +258,7 @@ fn create_kernel(
             )
         })
         .collect();
-    mk.upload_agents(&agent_data);
+    kernel.upload_agents(&agent_data);
 
-    (mk, world)
+    (kernel, world)
 }

--- a/crates/xagent-sandbox/src/bench.rs
+++ b/crates/xagent-sandbox/src/bench.rs
@@ -164,10 +164,16 @@ pub fn run_tick_loop_bench(
         accumulator = accumulator.min(max_accumulator);
 
         let remaining = (total_ticks - tick) as u32;
-        let ticks_to_run = ((accumulator / SIM_DT) as u32)
+        let min_dispatch = kernel.brain_tick_stride();
+        let raw_ticks = ((accumulator / SIM_DT) as u32)
             .min(gpu_tick_budget)
             .min(500)
             .min(remaining);
+        let ticks_to_run = if raw_ticks >= min_dispatch {
+            raw_ticks
+        } else {
+            0
+        };
 
         if ticks_to_run > 0 {
             kernel.try_collect_state();

--- a/crates/xagent-sandbox/src/headless.rs
+++ b/crates/xagent-sandbox/src/headless.rs
@@ -170,13 +170,7 @@ pub fn run_headless(config: FullConfig, db_path: &str, resume: bool, _has_gpu: b
 
         while ticks_done < tick_budget {
             let remaining = (tick_budget - ticks_done).min(HEATMAP_INTERVAL as u64) as u32;
-            // dispatch_batch is non-blocking and returns false under
-            // backpressure — drain staging buffers and retry.
-            while !kernel.dispatch_batch(ticks_done, remaining) {
-                while !kernel.try_collect_state() {
-                    std::thread::yield_now();
-                }
-            }
+            kernel.dispatch_batch(ticks_done, remaining);
             ticks_done += remaining as u64;
 
             // Advance governor tick counter

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1581,8 +1581,8 @@ impl ApplicationHandler for App {
                 // in the background to prevent catch-up hitch when it lands.
                 if !self.paused && self.gen_transition.is_none() && self.pending_kernel.is_none() {
                     self.sim_accumulator += dt * self.speed_multiplier as f32;
-                    // Cap accumulator to 2 frames' worth of ticks at the
-                    // current speed so debt stays bounded regardless of budget.
+                    // Cap accumulator to 2 fixed-timestep frames (2×SIM_DT)
+                    // worth at the current speed so debt stays bounded regardless of budget.
                     let max_acc = SIM_DT * self.speed_multiplier as f32 * 2.0;
                     self.sim_accumulator = self.sim_accumulator.min(max_acc);
                     let ticks_to_run =
@@ -1620,8 +1620,9 @@ impl ApplicationHandler for App {
                                 }
                             } else {
                                 // GPU backpressure — staging double-buffer full.
-                                // Drain accumulated debt to 1 frame's worth so the
-                                // next successful dispatch sends a normal-sized batch
+                                // Drain accumulated debt to at most one fixed sim
+                                // timestep at the current speed so the next
+                                // successful dispatch sends a normal-sized batch
                                 // instead of a burst that causes erratic position jumps.
                                 self.sim_accumulator = self
                                     .sim_accumulator

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1633,8 +1633,8 @@ impl ApplicationHandler for App {
                                 if let Some(tel) = kernel.try_collect_telemetry() {
                                     let a = &mut self.agents[self.selected_agent_idx];
                                     // Only update fields NOT already populated by
-                                    // the fresher async physics readback above.
-                                    // Phys readback already sets: cached_motor,
+                                    // the every-frame physics readback (below).
+                                    // Physics readback sets: cached_motor,
                                     // cached_gradient, cached_urgency,
                                     // cached_fatigue_factor, cached_prediction_error,
                                     // cached_exploration_rate.

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1619,13 +1619,13 @@ impl ApplicationHandler for App {
                                 }
                             } else {
                                 // GPU backpressure — staging double-buffer full.
-                                // Drain accumulated debt to at most one fixed sim
-                                // timestep at the current speed so the next
-                                // successful dispatch sends a normal-sized batch
-                                // instead of a burst that causes erratic position jumps.
+                                // Allow up to 2 frames' worth of debt so the
+                                // recovery dispatch can catch up for 1 skipped
+                                // frame. Larger debt is drained to prevent the
+                                // massive bursts that cause erratic position jumps.
                                 self.sim_accumulator = self
                                     .sim_accumulator
-                                    .min(SIM_DT * self.speed_multiplier as f32);
+                                    .min(SIM_DT * self.speed_multiplier as f32 * 2.0);
                             }
 
                             if state_updated || mk.try_collect_state() {

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1582,12 +1582,16 @@ impl ApplicationHandler for App {
                 if !self.paused && self.gen_transition.is_none() && self.pending_kernel.is_none() {
                     self.sim_accumulator += dt * self.speed_multiplier as f32;
                     // Cap accumulator to 2× budget so debt stays bounded.
-                    // This is a generous safety net; burst prevention during
-                    // GPU backpressure is handled in the `else` branch below.
                     let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
                     self.sim_accumulator = self.sim_accumulator.min(max_acc);
-                    let ticks_to_run =
-                        ((self.sim_accumulator / SIM_DT) as u32).min(self.gpu_tick_budget);
+                    // Limit ticks dispatched per frame to what the speed
+                    // multiplier demands, with 2× headroom for frame-time
+                    // variance. Fractional accumulator is preserved for the
+                    // next frame, avoiding precision loss at low render FPS.
+                    let speed_tick_cap = (self.speed_multiplier * 2).max(2);
+                    let ticks_to_run = ((self.sim_accumulator / SIM_DT) as u32)
+                        .min(self.gpu_tick_budget)
+                        .min(speed_tick_cap);
 
                     if ticks_to_run > 0 {
                         if let Some(ref mut mk) = self.gpu_kernel {

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1584,15 +1584,8 @@ impl ApplicationHandler for App {
                     // Cap accumulator to 2× budget so debt stays bounded.
                     let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
                     self.sim_accumulator = self.sim_accumulator.min(max_acc);
-                    // Limit ticks dispatched per frame to what the speed
-                    // multiplier demands. The 3× factor covers the dt clamp
-                    // ceiling (0.05s / SIM_DT ≈ 3 ticks at 1×). Fractional
-                    // accumulator is preserved for the next frame, avoiding
-                    // precision loss at low render FPS.
-                    let speed_tick_cap = (self.speed_multiplier * 3).max(3);
-                    let ticks_to_run = ((self.sim_accumulator / SIM_DT) as u32)
-                        .min(self.gpu_tick_budget)
-                        .min(speed_tick_cap);
+                    let ticks_to_run =
+                        ((self.sim_accumulator / SIM_DT) as u32).min(self.gpu_tick_budget);
 
                     if ticks_to_run > 0 {
                         if let Some(ref mut mk) = self.gpu_kernel {

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1585,10 +1585,11 @@ impl ApplicationHandler for App {
                     let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
                     self.sim_accumulator = self.sim_accumulator.min(max_acc);
                     // Limit ticks dispatched per frame to what the speed
-                    // multiplier demands, with 2× headroom for frame-time
-                    // variance. Fractional accumulator is preserved for the
-                    // next frame, avoiding precision loss at low render FPS.
-                    let speed_tick_cap = (self.speed_multiplier * 2).max(2);
+                    // multiplier demands. The 3× factor covers the dt clamp
+                    // ceiling (0.05s / SIM_DT ≈ 3 ticks at 1×). Fractional
+                    // accumulator is preserved for the next frame, avoiding
+                    // precision loss at low render FPS.
+                    let speed_tick_cap = (self.speed_multiplier * 3).max(3);
                     let ticks_to_run = ((self.sim_accumulator / SIM_DT) as u32)
                         .min(self.gpu_tick_budget)
                         .min(speed_tick_cap);

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1586,19 +1586,21 @@ impl ApplicationHandler for App {
                     let raw_ticks = ((self.sim_accumulator / sim_delta_time) as u32)
                         .min(self.gpu_tick_budget)
                         .min(500);
-                    // On the very first dispatch, force at least
-                    // brain_tick_stride ticks so the brain produces initial
-                    // motor commands. After that, dispatch exactly as many
-                    // ticks as the accumulator warrants to avoid borrowing
-                    // sim-time from the future and creating burst/stall motion.
-                    let ticks_to_run = if raw_ticks > 0 && self.tick == 0 {
-                        let min_batch = self
-                            .gpu_kernel
-                            .as_ref()
-                            .map_or(10, |kernel| kernel.brain_tick_stride());
-                        raw_ticks.max(min_batch)
-                    } else {
+                    // Only dispatch when the accumulator has enough for at
+                    // least brain_tick_stride ticks, so every dispatch
+                    // includes a brain cycle and produces motor commands.
+                    // Sub-stride dispatches would be physics-only (no brain
+                    // cycles), leaving agents with stale motor outputs.
+                    // The accumulator keeps its fractional remainder across
+                    // frames so no sim-time is lost.
+                    let min_dispatch = self
+                        .gpu_kernel
+                        .as_ref()
+                        .map_or(10, |kernel| kernel.brain_tick_stride());
+                    let ticks_to_run = if raw_ticks >= min_dispatch {
                         raw_ticks
+                    } else {
+                        0
                     };
 
                     if ticks_to_run > 0 {

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1581,8 +1581,9 @@ impl ApplicationHandler for App {
                 // in the background to prevent catch-up hitch when it lands.
                 if !self.paused && self.gen_transition.is_none() && self.pending_kernel.is_none() {
                     self.sim_accumulator += dt * self.speed_multiplier as f32;
-                    // Cap accumulator to 2× budget so debt stays bounded.
-                    let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
+                    // Cap accumulator to 2 frames' worth of ticks at the
+                    // current speed so debt stays bounded regardless of budget.
+                    let max_acc = SIM_DT * self.speed_multiplier as f32 * 2.0;
                     self.sim_accumulator = self.sim_accumulator.min(max_acc);
                     let ticks_to_run =
                         ((self.sim_accumulator / SIM_DT) as u32).min(self.gpu_tick_budget);
@@ -1617,8 +1618,15 @@ impl ApplicationHandler for App {
                                         gov.tick();
                                     }
                                 }
+                            } else {
+                                // GPU backpressure — staging double-buffer full.
+                                // Drain accumulated debt to 1 frame's worth so the
+                                // next successful dispatch sends a normal-sized batch
+                                // instead of a burst that causes erratic position jumps.
+                                self.sim_accumulator = self
+                                    .sim_accumulator
+                                    .min(SIM_DT * self.speed_multiplier as f32);
                             }
-                            // else: GPU backpressure — skip this frame, retry next
 
                             if state_updated || mk.try_collect_state() {
                                 let state = mk.cached_state();

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -276,7 +276,7 @@ struct App {
 
     /// Fixed-timestep accumulator — simulation ticks run at SIM_RATE Hz,
     /// decoupled from the render frame rate.
-    sim_accumulator: f32,
+    sim_accumulator: f64,
 
     // Speed controls (multiplier for simulation rate)
     speed_multiplier: u32,
@@ -343,6 +343,7 @@ struct App {
     tps_tick_count: u64,
     tps_last_reset: Instant,
     tps_display: f64,
+    bp_count: u64,
     db_path: String,
     governor_config: GovernorConfig,
 
@@ -495,6 +496,7 @@ impl App {
             tps_tick_count: 0,
             tps_last_reset: Instant::now(),
             tps_display: 0.0,
+            bp_count: 0,
             db_path: db_path.to_string(),
             governor_config,
             gen_transition: None,
@@ -1535,7 +1537,6 @@ impl ApplicationHandler for App {
                 let now = Instant::now();
                 let dt = (now - self.last_frame).as_secs_f32().min(0.05);
                 self.last_frame = now;
-
                 // ── FPS tracking ──────────────────────────────────
                 self.frame_times.push_back(now);
                 while self.frame_times.len() > 300 {
@@ -1580,107 +1581,43 @@ impl ApplicationHandler for App {
                 // Also skip accumulation when the kernel is being recreated
                 // in the background to prevent catch-up hitch when it lands.
                 if !self.paused && self.gen_transition.is_none() && self.pending_kernel.is_none() {
-                    self.sim_accumulator += dt * self.speed_multiplier as f32;
-                    // Cap accumulator to 2× budget so debt stays bounded.
-                    let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
+                    let sim_dt = SIM_DT as f64;
+                    self.sim_accumulator += dt as f64 * self.speed_multiplier as f64;
+                    let max_acc = sim_dt * self.speed_multiplier as f64 * 3.0;
                     self.sim_accumulator = self.sim_accumulator.min(max_acc);
-                    let ticks_to_run =
-                        ((self.sim_accumulator / SIM_DT) as u32).min(self.gpu_tick_budget);
+                    let raw_ticks = ((self.sim_accumulator / sim_dt) as u32)
+                        .min(self.gpu_tick_budget)
+                        .min(500);
+                    // Every dispatch must include at least brain_tick_stride
+                    // ticks so the brain produces motor commands.  At low
+                    // speeds this borrows sim-time from the future; the
+                    // accumulator goes negative and repays over the next
+                    // few frames.
+                    let min_batch = self.gpu_kernel.as_ref()
+                        .map_or(10, |mk| mk.brain_tick_stride());
+                    let ticks_to_run = if raw_ticks > 0 {
+                        raw_ticks.max(min_batch)
+                    } else {
+                        0
+                    };
 
                     if ticks_to_run > 0 {
                         if let Some(ref mut mk) = self.gpu_kernel {
-                            let state_updated = mk.try_collect_state();
-                            let t0 = Instant::now();
-                            let dispatched = mk.dispatch_batch(self.tick, ticks_to_run);
-                            let wall_ms = t0.elapsed().as_secs_f32() * 1000.0;
+                            mk.dispatch_batch(self.tick, ticks_to_run);
 
-                            if dispatched {
-                                // Shrink budget only if CPU encoding takes so
-                                // long it stalls the render loop.
-                                if wall_ms > 50.0 {
-                                    self.gpu_tick_budget = (self.gpu_tick_budget * 3 / 4).max(32);
-                                } else {
-                                    self.gpu_tick_budget =
-                                        (self.gpu_tick_budget + self.gpu_tick_budget / 4 + 1)
-                                            .min(64_000);
-                                }
+                            self.sim_accumulator -= ticks_to_run as f64 * sim_dt;
 
-                                self.tick += ticks_to_run as u64;
-                                self.tps_tick_count += ticks_to_run as u64;
-                                self.sim_accumulator -= SIM_DT * ticks_to_run as f32;
-                                self.snap_dirty = true;
+                            self.gpu_tick_budget =
+                                (self.gpu_tick_budget + self.gpu_tick_budget / 4 + 1)
+                                    .min(64_000);
 
-                                if let Some(gov) = &mut self.governor {
-                                    for _ in 0..ticks_to_run {
-                                        gov.tick();
-                                    }
-                                }
-                            }
+                            self.tick += ticks_to_run as u64;
+                            self.tps_tick_count += ticks_to_run as u64;
+                            self.snap_dirty = true;
 
-                            if state_updated || mk.try_collect_state() {
-                                let state = mk.cached_state();
-                                for i in 0..self.agents.len() {
-                                    let base = i * PHYS_STRIDE;
-                                    if base + P_URGENCY_OUT >= state.len() {
-                                        break;
-                                    }
-                                    let a = &mut self.agents[i];
-                                    a.body.body.position = Vec3::new(
-                                        state[base + P_POS_X],
-                                        state[base + P_POS_Y],
-                                        state[base + P_POS_Z],
-                                    );
-                                    a.body.body.alive = state[base + P_ALIVE] > 0.5;
-                                    a.body.yaw = state[base + P_YAW];
-                                    a.body.body.internal.energy = state[base + P_ENERGY];
-                                    a.body.body.internal.integrity = state[base + P_INTEGRITY];
-                                    a.body.body.internal.max_energy = state[base + P_MAX_ENERGY];
-                                    a.body.body.internal.max_integrity =
-                                        state[base + P_MAX_INTEGRITY];
-                                    a.body.body.velocity = Vec3::new(
-                                        state[base + P_VEL_X],
-                                        state[base + P_VEL_Y],
-                                        state[base + P_VEL_Z],
-                                    );
-                                    a.food_consumed = state[base + P_FOOD_COUNT] as u32;
-                                    a.total_ticks_alive = state[base + P_TICKS_ALIVE] as u64;
-                                    let new_deaths = state[base + P_DEATH_COUNT] as u32;
-                                    if new_deaths > a.death_count {
-                                        a.reset_trail();
-                                    }
-                                    a.death_count = new_deaths;
-                                    a.body.body.facing = Vec3::new(
-                                        state[base + P_FACING_X],
-                                        state[base + P_FACING_Y],
-                                        state[base + P_FACING_Z],
-                                    );
-                                    a.cached_prediction_error = state[base + P_PREDICTION_ERROR];
-                                    a.cached_exploration_rate =
-                                        state[base + P_EXPLORATION_RATE_OUT];
-                                    a.cached_fatigue_factor = state[base + P_FATIGUE_FACTOR_OUT];
-                                    a.cached_motor.forward = state[base + P_MOTOR_FWD_OUT];
-                                    a.cached_motor.turn = state[base + P_MOTOR_TURN_OUT];
-                                    a.cached_gradient = state[base + P_GRADIENT_OUT];
-                                    a.cached_urgency = state[base + P_URGENCY_OUT];
-                                }
-
-                                // Diagnostic: log first readback Y vs terrain height
-                                if !self.readback_logged {
-                                    if let Some(world) = &self.world {
-                                        let n = self.agents.len().min(5);
-                                        if n > 0 {
-                                            for i in 0..n {
-                                                let a = &self.agents[i];
-                                                let p = a.body.body.position;
-                                                let terrain_y = world.terrain.height_at(p.x, p.z);
-                                                log::info!(
-                                                    "[TERRAIN-DIAG] Agent {} pos=({:.2}, {:.2}, {:.2}) terrain_y={:.2} diff={:.2}",
-                                                    i, p.x, p.y, p.z, terrain_y, p.y - terrain_y,
-                                                );
-                                            }
-                                            self.readback_logged = true;
-                                        }
-                                    }
+                            if let Some(gov) = &mut self.governor {
+                                for _ in 0..ticks_to_run {
+                                    gov.tick();
                                 }
                             }
 
@@ -1757,41 +1694,118 @@ impl ApplicationHandler for App {
                             }
                         }
 
-                        // Heatmap + trail recording
+                    }
+
+                    // ── Every-frame state readback ──
+                    // Collect GPU staging data and update agent positions
+                    // regardless of whether ticks were dispatched this frame.
+                    // This ensures smooth visual updates at low speed multipliers
+                    // where dispatches happen infrequently.
+                    if let Some(ref mut mk) = self.gpu_kernel {
+                        if mk.try_collect_state() {
+                            let state = mk.cached_state();
+                            for i in 0..self.agents.len() {
+                                let base = i * PHYS_STRIDE;
+                                if base + P_URGENCY_OUT >= state.len() {
+                                    break;
+                                }
+                                let a = &mut self.agents[i];
+                                a.body.body.position = Vec3::new(
+                                    state[base + P_POS_X],
+                                    state[base + P_POS_Y],
+                                    state[base + P_POS_Z],
+                                );
+                                a.body.body.alive = state[base + P_ALIVE] > 0.5;
+                                a.body.yaw = state[base + P_YAW];
+                                a.body.body.internal.energy = state[base + P_ENERGY];
+                                a.body.body.internal.integrity = state[base + P_INTEGRITY];
+                                a.body.body.internal.max_energy = state[base + P_MAX_ENERGY];
+                                a.body.body.internal.max_integrity =
+                                    state[base + P_MAX_INTEGRITY];
+                                a.body.body.velocity = Vec3::new(
+                                    state[base + P_VEL_X],
+                                    state[base + P_VEL_Y],
+                                    state[base + P_VEL_Z],
+                                );
+                                a.food_consumed = state[base + P_FOOD_COUNT] as u32;
+                                a.total_ticks_alive = state[base + P_TICKS_ALIVE] as u64;
+                                let new_deaths = state[base + P_DEATH_COUNT] as u32;
+                                if new_deaths > a.death_count {
+                                    a.reset_trail();
+                                }
+                                a.death_count = new_deaths;
+                                a.body.body.facing = Vec3::new(
+                                    state[base + P_FACING_X],
+                                    state[base + P_FACING_Y],
+                                    state[base + P_FACING_Z],
+                                );
+                                a.cached_prediction_error = state[base + P_PREDICTION_ERROR];
+                                a.cached_exploration_rate =
+                                    state[base + P_EXPLORATION_RATE_OUT];
+                                a.cached_fatigue_factor = state[base + P_FATIGUE_FACTOR_OUT];
+                                a.cached_motor.forward = state[base + P_MOTOR_FWD_OUT];
+                                a.cached_motor.turn = state[base + P_MOTOR_TURN_OUT];
+                                a.cached_gradient = state[base + P_GRADIENT_OUT];
+                                a.cached_urgency = state[base + P_URGENCY_OUT];
+                            }
+
+                            self.snap_dirty = true;
+                            self.hud_dirty = true;
+
+                            // Diagnostic: log first readback Y vs terrain height
+                            if !self.readback_logged {
+                                if let Some(world) = &self.world {
+                                    let n = self.agents.len().min(5);
+                                    if n > 0 {
+                                        for i in 0..n {
+                                            let a = &self.agents[i];
+                                            let p = a.body.body.position;
+                                            let terrain_y = world.terrain.height_at(p.x, p.z);
+                                            log::info!(
+                                                "[TERRAIN-DIAG] Agent {} pos=({:.2}, {:.2}, {:.2}) terrain_y={:.2} diff={:.2}",
+                                                i, p.x, p.y, p.z, terrain_y, p.y - terrain_y,
+                                            );
+                                        }
+                                        self.readback_logged = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Heatmap + trail recording
+                    if let Some(world) = &self.world {
+                        for agent in &mut self.agents {
+                            if agent.body.body.alive {
+                                agent.record_heatmap(world.config.world_size);
+                                agent.record_trail();
+                            }
+                        }
+                    }
+
+                    // Sparkline histories + CSV logging
+                    {
                         if let Some(world) = &self.world {
                             for agent in &mut self.agents {
-                                if agent.body.body.alive {
-                                    agent.record_heatmap(world.config.world_size);
-                                    agent.record_trail();
-                                }
+                                record_agent_histories(agent);
+                            }
+                            if self.selected_agent_idx < self.agents.len() {
+                                let agent = &self.agents[self.selected_agent_idx];
+                                let life_ticks = agent.age(self.tick);
+                                let motor = agent.cached_motor.clone();
+                                log_tick_to_csv(
+                                    &mut self.logger,
+                                    agent,
+                                    world,
+                                    &motor,
+                                    life_ticks,
+                                );
+                                self.error_count += 1;
                             }
                         }
-
-                        // Sparkline histories + CSV logging
-                        {
-                            if let Some(world) = &self.world {
-                                for agent in &mut self.agents {
-                                    record_agent_histories(agent);
-                                }
-                                if self.selected_agent_idx < self.agents.len() {
-                                    let agent = &self.agents[self.selected_agent_idx];
-                                    let life_ticks = agent.age(self.tick);
-                                    let motor = agent.cached_motor.clone();
-                                    log_tick_to_csv(
-                                        &mut self.logger,
-                                        agent,
-                                        world,
-                                        &motor,
-                                        life_ticks,
-                                    );
-                                    self.error_count += 1;
-                                }
-                            }
-                        }
-
-                        self.heatmap_dirty = true;
-                        self.hud_dirty = true;
                     }
+
+                    self.heatmap_dirty = true;
 
                     // ── Generation completion check (after tick batch) ──
                     if self.gen_transition.is_none() {
@@ -2215,6 +2229,7 @@ impl ApplicationHandler for App {
                                 if tps_elapsed >= 1.0 {
                                     self.tps_display = self.tps_tick_count as f64 / tps_elapsed;
                                     self.tps_tick_count = 0;
+                                    self.bp_count = 0;
                                     self.tps_last_reset = Instant::now();
                                 }
                                 self.evo_snapshot.ticks_per_sec = self.tps_display;
@@ -2674,6 +2689,12 @@ impl ApplicationHandler for App {
                             log::warn!("Surface error: {:?}", e);
                         }
                     }
+                }
+
+                // Poll GPU kernel device after rendering so map_async
+                // callbacks can complete before the next frame.
+                if let Some(ref mk) = self.gpu_kernel {
+                    mk.device().poll(wgpu::Maintain::Poll);
                 }
 
                 // Handle evolution actions (outside renderer borrow)

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1595,10 +1595,8 @@ impl ApplicationHandler for App {
                             let wall_ms = t0.elapsed().as_secs_f32() * 1000.0;
 
                             if dispatched {
-                                // Grow budget aggressively — staging double-buffer
-                                // is the real throttle (dispatch_batch returns false
-                                // when both are in-flight). Only shrink if CPU
-                                // encoding takes so long it stalls the render loop.
+                                // Shrink budget only if CPU encoding takes so
+                                // long it stalls the render loop.
                                 if wall_ms > 50.0 {
                                     self.gpu_tick_budget = (self.gpu_tick_budget * 3 / 4).max(32);
                                 } else {
@@ -1618,7 +1616,6 @@ impl ApplicationHandler for App {
                                     }
                                 }
                             }
-                            // else: GPU backpressure — skip this frame, retry next
 
                             if state_updated || mk.try_collect_state() {
                                 let state = mk.cached_state();

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1581,9 +1581,10 @@ impl ApplicationHandler for App {
                 // in the background to prevent catch-up hitch when it lands.
                 if !self.paused && self.gen_transition.is_none() && self.pending_kernel.is_none() {
                     self.sim_accumulator += dt * self.speed_multiplier as f32;
-                    // Cap accumulator to 2 fixed-timestep frames (2×SIM_DT)
-                    // worth at the current speed so debt stays bounded regardless of budget.
-                    let max_acc = SIM_DT * self.speed_multiplier as f32 * 2.0;
+                    // Cap accumulator to 2× budget so debt stays bounded.
+                    // This is a generous safety net; burst prevention during
+                    // GPU backpressure is handled in the `else` branch below.
+                    let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
                     self.sim_accumulator = self.sim_accumulator.min(max_acc);
                     let ticks_to_run =
                         ((self.sim_accumulator / SIM_DT) as u32).min(self.gpu_tick_budget);

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -343,7 +343,6 @@ struct App {
     tps_tick_count: u64,
     tps_last_reset: Instant,
     tps_display: f64,
-    bp_count: u64,
     db_path: String,
     governor_config: GovernorConfig,
 
@@ -496,7 +495,6 @@ impl App {
             tps_tick_count: 0,
             tps_last_reset: Instant::now(),
             tps_display: 0.0,
-            bp_count: 0,
             db_path: db_path.to_string(),
             governor_config,
             gen_transition: None,
@@ -1581,33 +1579,33 @@ impl ApplicationHandler for App {
                 // Also skip accumulation when the kernel is being recreated
                 // in the background to prevent catch-up hitch when it lands.
                 if !self.paused && self.gen_transition.is_none() && self.pending_kernel.is_none() {
-                    let sim_dt = SIM_DT as f64;
+                    let sim_delta_time = SIM_DT as f64;
                     self.sim_accumulator += dt as f64 * self.speed_multiplier as f64;
-                    let max_acc = sim_dt * self.speed_multiplier as f64 * 3.0;
-                    self.sim_accumulator = self.sim_accumulator.min(max_acc);
-                    let raw_ticks = ((self.sim_accumulator / sim_dt) as u32)
+                    let max_accumulator = sim_delta_time * self.speed_multiplier as f64 * 3.0;
+                    self.sim_accumulator = self.sim_accumulator.min(max_accumulator);
+                    let raw_ticks = ((self.sim_accumulator / sim_delta_time) as u32)
                         .min(self.gpu_tick_budget)
                         .min(500);
-                    // Every dispatch must include at least brain_tick_stride
-                    // ticks so the brain produces motor commands.  At low
-                    // speeds this borrows sim-time from the future; the
-                    // accumulator goes negative and repays over the next
-                    // few frames.
-                    let min_batch = self
-                        .gpu_kernel
-                        .as_ref()
-                        .map_or(10, |mk| mk.brain_tick_stride());
-                    let ticks_to_run = if raw_ticks > 0 {
+                    // On the very first dispatch, force at least
+                    // brain_tick_stride ticks so the brain produces initial
+                    // motor commands. After that, dispatch exactly as many
+                    // ticks as the accumulator warrants to avoid borrowing
+                    // sim-time from the future and creating burst/stall motion.
+                    let ticks_to_run = if raw_ticks > 0 && self.tick == 0 {
+                        let min_batch = self
+                            .gpu_kernel
+                            .as_ref()
+                            .map_or(10, |kernel| kernel.brain_tick_stride());
                         raw_ticks.max(min_batch)
                     } else {
-                        0
+                        raw_ticks
                     };
 
                     if ticks_to_run > 0 {
-                        if let Some(ref mut mk) = self.gpu_kernel {
-                            mk.dispatch_batch(self.tick, ticks_to_run);
+                        if let Some(ref mut kernel) = self.gpu_kernel {
+                            kernel.dispatch_batch(self.tick, ticks_to_run);
 
-                            self.sim_accumulator -= ticks_to_run as f64 * sim_dt;
+                            self.sim_accumulator -= ticks_to_run as f64 * sim_delta_time;
 
                             self.gpu_tick_budget =
                                 (self.gpu_tick_budget + self.gpu_tick_budget / 4 + 1).min(64_000);
@@ -1629,10 +1627,10 @@ impl ApplicationHandler for App {
                             if self.selected_agent_idx < self.agents.len() {
                                 let brain_idx = self.agents[self.selected_agent_idx].brain_idx;
 
-                                mk.request_agent_telemetry(brain_idx);
+                                kernel.request_agent_telemetry(brain_idx);
 
                                 // Collect any completed readback (non-blocking)
-                                if let Some(tel) = mk.try_collect_telemetry() {
+                                if let Some(tel) = kernel.try_collect_telemetry() {
                                     let a = &mut self.agents[self.selected_agent_idx];
                                     // Only update fields NOT already populated by
                                     // the fresher async physics readback above.
@@ -1701,9 +1699,9 @@ impl ApplicationHandler for App {
                     // regardless of whether ticks were dispatched this frame.
                     // This ensures smooth visual updates at low speed multipliers
                     // where dispatches happen infrequently.
-                    if let Some(ref mut mk) = self.gpu_kernel {
-                        if mk.try_collect_state() {
-                            let state = mk.cached_state();
+                    if let Some(ref mut kernel) = self.gpu_kernel {
+                        if kernel.try_collect_state() {
+                            let state = kernel.cached_state();
                             for i in 0..self.agents.len() {
                                 let base = i * PHYS_STRIDE;
                                 if base + P_URGENCY_OUT >= state.len() {
@@ -2221,7 +2219,6 @@ impl ApplicationHandler for App {
                                 if tps_elapsed >= 1.0 {
                                     self.tps_display = self.tps_tick_count as f64 / tps_elapsed;
                                     self.tps_tick_count = 0;
-                                    self.bp_count = 0;
                                     self.tps_last_reset = Instant::now();
                                 }
                                 self.evo_snapshot.ticks_per_sec = self.tps_display;
@@ -2685,8 +2682,8 @@ impl ApplicationHandler for App {
 
                 // Poll GPU kernel device after rendering so map_async
                 // callbacks can complete before the next frame.
-                if let Some(ref mk) = self.gpu_kernel {
-                    mk.device().poll(wgpu::Maintain::Poll);
+                if let Some(ref kernel) = self.gpu_kernel {
+                    kernel.device().poll(wgpu::Maintain::Poll);
                 }
 
                 // Handle evolution actions (outside renderer borrow)

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1593,7 +1593,9 @@ impl ApplicationHandler for App {
                     // speeds this borrows sim-time from the future; the
                     // accumulator goes negative and repays over the next
                     // few frames.
-                    let min_batch = self.gpu_kernel.as_ref()
+                    let min_batch = self
+                        .gpu_kernel
+                        .as_ref()
                         .map_or(10, |mk| mk.brain_tick_stride());
                     let ticks_to_run = if raw_ticks > 0 {
                         raw_ticks.max(min_batch)
@@ -1608,8 +1610,7 @@ impl ApplicationHandler for App {
                             self.sim_accumulator -= ticks_to_run as f64 * sim_dt;
 
                             self.gpu_tick_budget =
-                                (self.gpu_tick_budget + self.gpu_tick_budget / 4 + 1)
-                                    .min(64_000);
+                                (self.gpu_tick_budget + self.gpu_tick_budget / 4 + 1).min(64_000);
 
                             self.tick += ticks_to_run as u64;
                             self.tps_tick_count += ticks_to_run as u64;
@@ -1693,7 +1694,6 @@ impl ApplicationHandler for App {
                                 rec.record_tick(tick, &records);
                             }
                         }
-
                     }
 
                     // ── Every-frame state readback ──
@@ -1720,8 +1720,7 @@ impl ApplicationHandler for App {
                                 a.body.body.internal.energy = state[base + P_ENERGY];
                                 a.body.body.internal.integrity = state[base + P_INTEGRITY];
                                 a.body.body.internal.max_energy = state[base + P_MAX_ENERGY];
-                                a.body.body.internal.max_integrity =
-                                    state[base + P_MAX_INTEGRITY];
+                                a.body.body.internal.max_integrity = state[base + P_MAX_INTEGRITY];
                                 a.body.body.velocity = Vec3::new(
                                     state[base + P_VEL_X],
                                     state[base + P_VEL_Y],
@@ -1740,8 +1739,7 @@ impl ApplicationHandler for App {
                                     state[base + P_FACING_Z],
                                 );
                                 a.cached_prediction_error = state[base + P_PREDICTION_ERROR];
-                                a.cached_exploration_rate =
-                                    state[base + P_EXPLORATION_RATE_OUT];
+                                a.cached_exploration_rate = state[base + P_EXPLORATION_RATE_OUT];
                                 a.cached_fatigue_factor = state[base + P_FATIGUE_FACTOR_OUT];
                                 a.cached_motor.forward = state[base + P_MOTOR_FWD_OUT];
                                 a.cached_motor.turn = state[base + P_MOTOR_TURN_OUT];
@@ -1793,13 +1791,7 @@ impl ApplicationHandler for App {
                                 let agent = &self.agents[self.selected_agent_idx];
                                 let life_ticks = agent.age(self.tick);
                                 let motor = agent.cached_motor.clone();
-                                log_tick_to_csv(
-                                    &mut self.logger,
-                                    agent,
-                                    world,
-                                    &motor,
-                                    life_ticks,
-                                );
+                                log_tick_to_csv(&mut self.logger, agent, world, &motor, life_ticks);
                                 self.error_count += 1;
                             }
                         }

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1617,16 +1617,8 @@ impl ApplicationHandler for App {
                                         gov.tick();
                                     }
                                 }
-                            } else {
-                                // GPU backpressure — staging double-buffer full.
-                                // Allow up to 2 frames' worth of debt so the
-                                // recovery dispatch can catch up for 1 skipped
-                                // frame. Larger debt is drained to prevent the
-                                // massive bursts that cause erratic position jumps.
-                                self.sim_accumulator = self
-                                    .sim_accumulator
-                                    .min(SIM_DT * self.speed_multiplier as f32 * 2.0);
                             }
+                            // else: GPU backpressure — skip this frame, retry next
 
                             if state_updated || mk.try_collect_state() {
                                 let state = mk.cached_state();

--- a/crates/xagent-sandbox/src/renderer/mod.rs
+++ b/crates/xagent-sandbox/src/renderer/mod.rs
@@ -203,12 +203,15 @@ impl Renderer {
             .copied()
             .unwrap_or(surface_caps.formats[0]);
 
+        // Use AutoVsync (or Mailbox) to cap render submissions to the
+        // display refresh rate.  PresentMode::Immediate floods the GPU
+        // command queue at 300-600+ fps, which starves the compute device's
+        // async staging readback (adds 40-60ms latency on Metal) and
+        // prevents sim TPS from reaching the target at high speed
+        // multipliers.  AutoVsync matches the display rate (typically
+        // 60-120Hz on macOS) — smooth enough for UI interaction while
+        // giving the compute device adequate GPU scheduling time.
         let present_mode = if surface_caps
-            .present_modes
-            .contains(&wgpu::PresentMode::Immediate)
-        {
-            wgpu::PresentMode::Immediate
-        } else if surface_caps
             .present_modes
             .contains(&wgpu::PresentMode::Mailbox)
         {

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -651,7 +651,13 @@ fn deterministic_across_batch_sizes() {
     let food_timers: Vec<f32> = world.food_items.iter().map(|f| f.respawn_timer).collect();
     let spawn_pos = world.safe_spawn_position();
     let food_count = world.food_items.len();
-    let agent_data = vec![(spawn_pos, 100.0_f32, 100.0_f32, brain.memory_capacity, brain.processing_slots)];
+    let agent_data = vec![(
+        spawn_pos,
+        100.0_f32,
+        100.0_f32,
+        brain.memory_capacity,
+        brain.processing_slots,
+    )];
 
     // Helper: create a fresh kernel with deterministic brain state,
     // dispatch total_ticks in given batch size, return final position.
@@ -659,9 +665,11 @@ fn deterministic_across_batch_sizes() {
         let mut mk = xagent_brain::GpuKernel::new(1, food_count, &brain, &world_config);
         let kbs = mk.kernel_batch_size();
         assert_eq!(
-            batch_size % kbs, 0,
+            batch_size % kbs,
+            0,
             "batch_size {} must be a multiple of kernel_batch_size {}",
-            batch_size, kbs
+            batch_size,
+            kbs
         );
         // Overwrite random brain state with deterministic seed
         mk.reset_agents_seeded(&brain, 12345);
@@ -685,14 +693,8 @@ fn deterministic_across_batch_sizes() {
     eprintln!("2×500:   {:?}", pos_500);
     eprintln!("10×100:  {:?}", pos_100);
 
-    assert_eq!(
-        pos_1000, pos_500,
-        "2×500 diverged from 1×1000"
-    );
-    assert_eq!(
-        pos_1000, pos_100,
-        "10×100 diverged from 1×1000"
-    );
+    assert_eq!(pos_1000, pos_500, "2×500 diverged from 1×1000");
+    assert_eq!(pos_1000, pos_100, "10×100 diverged from 1×1000");
 }
 
 // ── GPU Tick Loop Tests ─────────────────────────────────────────────

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -617,8 +617,9 @@ fn bench_runner_completes_and_reports_ticks_per_sec() {
 /// affect simulation results, as long as each batch is a multiple of
 /// `kernel_batch_size` (= `vision_stride * brain_tick_stride`, default 100).
 ///
-/// Uses a single GPU kernel instance and re-uploads initial state
-/// between runs to avoid cross-device FP non-determinism.
+/// Each run creates a fresh kernel from the same initial state so the
+/// comparison focuses on whether different batch decompositions change
+/// the simulation result.
 ///
 /// Test cases (all multiples of 100, total = 1000):
 ///   1. 1 × 1000   (1 dispatch)
@@ -662,26 +663,26 @@ fn deterministic_across_batch_sizes() {
     // Helper: create a fresh kernel with deterministic brain state,
     // dispatch total_ticks in given batch size, return final position.
     let run_with_batch_size = |batch_size: u32| -> [f32; 3] {
-        let mut mk = xagent_brain::GpuKernel::new(1, food_count, &brain, &world_config);
-        let kbs = mk.kernel_batch_size();
+        let mut kernel = xagent_brain::GpuKernel::new(1, food_count, &brain, &world_config);
+        let kernel_batch = kernel.kernel_batch_size();
         assert_eq!(
-            batch_size % kbs,
+            batch_size % kernel_batch,
             0,
             "batch_size {} must be a multiple of kernel_batch_size {}",
             batch_size,
-            kbs
+            kernel_batch
         );
         // Overwrite random brain state with deterministic seed
-        mk.reset_agents_seeded(&brain, 12345);
-        mk.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
-        mk.upload_agents(&agent_data);
+        kernel.reset_agents_seeded(&brain, 12345);
+        kernel.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
+        kernel.upload_agents(&agent_data);
 
         let num_batches = total_ticks / batch_size;
         for i in 0..num_batches {
-            mk.dispatch_batch((i * batch_size) as u64, batch_size);
+            kernel.dispatch_batch((i * batch_size) as u64, batch_size);
         }
 
-        let state = mk.read_full_state_blocking();
+        let state = kernel.read_full_state_blocking();
         [state[P_POS_X], state[P_POS_Y], state[P_POS_Z]]
     };
 

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -613,6 +613,88 @@ fn bench_runner_completes_and_reports_ticks_per_sec() {
     );
 }
 
+/// Proves that decomposing ticks into different batch sizes doesn't
+/// affect simulation results, as long as each batch is a multiple of
+/// `kernel_batch_size` (= `vision_stride * brain_tick_stride`, default 100).
+///
+/// Uses a single GPU kernel instance and re-uploads initial state
+/// between runs to avoid cross-device FP non-determinism.
+///
+/// Test cases (all multiples of 100, total = 1000):
+///   1. 1 × 1000   (1 dispatch)
+///   2. 2 × 500    (2 dispatches)
+///   3. 10 × 100   (10 dispatches)
+#[test]
+fn deterministic_across_batch_sizes() {
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+    use xagent_brain::buffers::{P_POS_X, P_POS_Y, P_POS_Z};
+
+    let brain = BrainConfig::default();
+    let world_config = WorldConfig {
+        seed: 42,
+        ..Default::default()
+    };
+    let total_ticks: u32 = 1000;
+
+    let world = xagent_sandbox::world::WorldState::new(world_config.clone());
+    let heights = world.terrain.heights.clone();
+    let biomes = world.biome_map.grid_as_u32();
+    let food_pos: Vec<(f32, f32, f32)> = world
+        .food_items
+        .iter()
+        .map(|f| (f.position.x, f.position.y, f.position.z))
+        .collect();
+    let food_consumed: Vec<bool> = world.food_items.iter().map(|f| f.consumed).collect();
+    let food_timers: Vec<f32> = world.food_items.iter().map(|f| f.respawn_timer).collect();
+    let spawn_pos = world.safe_spawn_position();
+    let food_count = world.food_items.len();
+    let agent_data = vec![(spawn_pos, 100.0_f32, 100.0_f32, brain.memory_capacity, brain.processing_slots)];
+
+    // Helper: create a fresh kernel with deterministic brain state,
+    // dispatch total_ticks in given batch size, return final position.
+    let run_with_batch_size = |batch_size: u32| -> [f32; 3] {
+        let mut mk = xagent_brain::GpuKernel::new(1, food_count, &brain, &world_config);
+        let kbs = mk.kernel_batch_size();
+        assert_eq!(
+            batch_size % kbs, 0,
+            "batch_size {} must be a multiple of kernel_batch_size {}",
+            batch_size, kbs
+        );
+        // Overwrite random brain state with deterministic seed
+        mk.reset_agents_seeded(&brain, 12345);
+        mk.upload_world(&heights, &biomes, &food_pos, &food_consumed, &food_timers);
+        mk.upload_agents(&agent_data);
+
+        let num_batches = total_ticks / batch_size;
+        for i in 0..num_batches {
+            mk.dispatch_batch((i * batch_size) as u64, batch_size);
+        }
+
+        let state = mk.read_full_state_blocking();
+        [state[P_POS_X], state[P_POS_Y], state[P_POS_Z]]
+    };
+
+    let pos_1000 = run_with_batch_size(1000);
+    let pos_500 = run_with_batch_size(500);
+    let pos_100 = run_with_batch_size(100);
+
+    eprintln!("1×1000:  {:?}", pos_1000);
+    eprintln!("2×500:   {:?}", pos_500);
+    eprintln!("10×100:  {:?}", pos_100);
+
+    assert_eq!(
+        pos_1000, pos_500,
+        "2×500 diverged from 1×1000"
+    );
+    assert_eq!(
+        pos_1000, pos_100,
+        "10×100 diverged from 1×1000"
+    );
+}
+
 // ── GPU Tick Loop Tests ─────────────────────────────────────────────
 
 #[test]

--- a/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
+++ b/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
@@ -19,11 +19,11 @@ The accumulator cap (`SIM_DT * gpu_tick_budget * 2`) makes this worse: the budge
 
 ## Fix
 
-Two changes in `main.rs`, both in the tick loop:
+One change in `main.rs`, in the tick loop:
 
-### 1. Drain accumulator on backpressure
+### Drain accumulator on backpressure
 
-When `dispatch_batch` returns `false`, cap the accumulator to 1 frame's worth of ticks so the next successful dispatch sends a normal-sized batch:
+When `dispatch_batch` returns `false`, cap the accumulator to one fixed-timestep (`SIM_DT`) worth at the current speed multiplier so the next successful dispatch sends a normal-sized batch:
 
 ```rust
 if dispatched {
@@ -35,19 +35,7 @@ if dispatched {
 }
 ```
 
-### 2. Tighten accumulator cap
-
-Replace the budget-based cap with a speed-aware cap:
-
-```rust
-// Before:
-let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
-
-// After:
-let max_acc = SIM_DT * self.speed_multiplier as f32 * 2.0;
-```
-
-This limits debt to 2 frames' worth regardless of budget. The budget still controls GPU batch size for high-speed modes (100x+), but the accumulator can't build up disproportionate debt.
+The existing budget-based accumulator cap (`SIM_DT * budget * 2`) is kept as a generous safety net. Tightening it to a speed-based cap would cause precision loss at low render FPS (e.g., 30fps at 1x would alternate 1/2 ticks → ~45 TPS instead of 60) because the cap discards fractional accumulator remainder needed across frames.
 
 ## Tradeoff
 

--- a/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
+++ b/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
@@ -19,9 +19,20 @@ The accumulator cap (`SIM_DT * gpu_tick_budget * 2`) makes this worse: the budge
 
 ## Fix
 
-One change in `main.rs`, in the tick loop:
+Two changes in `main.rs`, both in the tick loop:
 
-### Drain accumulator on backpressure
+### 1. Cap `ticks_to_run` by speed multiplier
+
+Instead of tightening the accumulator cap (which discards fractional time and causes precision loss at low render FPS), cap `ticks_to_run` with 2× headroom. The accumulator retains its fractional remainder for the next frame:
+
+```rust
+let speed_tick_cap = (self.speed_multiplier * 2).max(2);
+let ticks_to_run = ((self.sim_accumulator / SIM_DT) as u32)
+    .min(self.gpu_tick_budget)
+    .min(speed_tick_cap);
+```
+
+### 2. Drain accumulator on backpressure
 
 When `dispatch_batch` returns `false`, cap the accumulator to one fixed-timestep (`SIM_DT`) worth at the current speed multiplier so the next successful dispatch sends a normal-sized batch:
 
@@ -35,7 +46,7 @@ if dispatched {
 }
 ```
 
-The existing budget-based accumulator cap (`SIM_DT * budget * 2`) is kept as a generous safety net. Tightening it to a speed-based cap would cause precision loss at low render FPS (e.g., 30fps at 1x would alternate 1/2 ticks → ~45 TPS instead of 60) because the cap discards fractional accumulator remainder needed across frames.
+The existing budget-based accumulator cap (`SIM_DT * budget * 2`) is kept as a generous overall safety net.
 
 ## Tradeoff
 

--- a/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
+++ b/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
@@ -1,0 +1,58 @@
+# Fix: Tick Accumulator Debt During GPU Backpressure
+
+**Date:** 2026-04-13
+**Branch:** `fix/tick-accumulator-backpressure`
+
+## Problem
+
+At 10x speed multiplier with `PresentMode::Immediate`, the UI freezes and updates become erratic. 1x/2x/5x work smoothly. Observed with a single agent, so hardware throughput is not the bottleneck.
+
+## Root Cause
+
+`PresentMode::Immediate` drives the frame rate to 200-400+ FPS. The simulation accumulator adds `dt * speed_multiplier` per frame and dispatches `floor(accumulator / SIM_DT)` ticks to the GPU. At 10x, every frame crosses the `SIM_DT` threshold and triggers a `dispatch_batch` call, which starts an async staging-buffer readback.
+
+The readback pipeline is double-buffered: only 2 staging slots can be in-flight. When both are occupied, `dispatch_batch` returns `false` (GPU backpressure). Currently, the accumulator is **not drained** on backpressure — it keeps growing each frame. When a staging slot frees up, the next dispatch fires a burst of accumulated ticks, causing an irregular position jump. The cycle repeats: dispatch, dispatch, skip, skip, burst-dispatch, skip...
+
+At 5x, `dt * 5` doesn't always cross `SIM_DT` at high FPS, so many frames skip dispatch naturally, giving staging buffers breathing room.
+
+The accumulator cap (`SIM_DT * gpu_tick_budget * 2`) makes this worse: the budget grows aggressively (25%/frame, cap 64k), allowing the accumulator cap to reach ~2100 seconds of sim-time — far beyond what any speed multiplier needs per frame.
+
+## Fix
+
+Two changes in `main.rs`, both in the tick loop:
+
+### 1. Drain accumulator on backpressure
+
+When `dispatch_batch` returns `false`, cap the accumulator to 1 frame's worth of ticks so the next successful dispatch sends a normal-sized batch:
+
+```rust
+if dispatched {
+    // ... existing budget/tick/accumulator logic
+} else {
+    // GPU backpressure — drop ticks rather than accumulating debt
+    // that causes burst dispatches when staging frees up.
+    self.sim_accumulator = self.sim_accumulator.min(SIM_DT * self.speed_multiplier as f32);
+}
+```
+
+### 2. Tighten accumulator cap
+
+Replace the budget-based cap with a speed-aware cap:
+
+```rust
+// Before:
+let max_acc = SIM_DT * self.gpu_tick_budget as f32 * 2.0;
+
+// After:
+let max_acc = SIM_DT * self.speed_multiplier as f32 * 2.0;
+```
+
+This limits debt to 2 frames' worth regardless of budget. The budget still controls GPU batch size for high-speed modes (100x+), but the accumulator can't build up disproportionate debt.
+
+## Tradeoff
+
+At 10x + very high FPS, the simulation may run slightly below 600 TPS (dropped ticks during backpressure). Smooth visual updates over exact TPS is the right tradeoff — the user chose 10x for faster visual progression, not for precise tick counting. At 100x+ the user explicitly trades smoothness for throughput, and the larger `ticks_to_run` naturally gives staging more time between dispatches.
+
+## Files Changed
+
+- `crates/xagent-sandbox/src/main.rs` — tick loop accumulator logic (~lines 1582-1620)

--- a/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
+++ b/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
@@ -1,50 +1,62 @@
-# Fix: Tick Accumulator Debt During GPU Backpressure
+# Fix: Tick Accumulator Backpressure & State Readback Decoupling
 
 **Date:** 2026-04-13
 **Branch:** `fix/tick-accumulator-backpressure`
 
 ## Problem
 
-At 10x speed multiplier with `PresentMode::Immediate`, the UI freezes and updates become erratic. 1x/2x/5x work smoothly. Observed with a single agent, so hardware throughput is not the bottleneck.
+At 10x speed multiplier with `PresentMode::Immediate`, the UI freezes and updates become erratic. At 1x–10x, agents appear frozen despite ticks advancing.
 
-## Root Cause
+## Root Causes
 
-`PresentMode::Immediate` drives the frame rate to 200-400+ FPS. The simulation accumulator adds `dt * speed_multiplier` per frame and dispatches `floor(accumulator / SIM_DT)` ticks to the GPU. At 10x, every frame crosses the `SIM_DT` threshold and triggers a `dispatch_batch` call, which starts an async staging-buffer readback.
+### 1. Staging pipeline bottleneck (10x freezes)
 
-The readback pipeline was double-buffered: only 2 staging slots could be in-flight. When both were occupied, `dispatch_batch` returned `false` (GPU backpressure). The accumulator was **not drained** on backpressure — it kept growing each frame. When a staging slot freed up, the next dispatch fired a burst of accumulated ticks, causing an irregular position jump. The cycle repeated: dispatch, dispatch, skip, skip, burst-dispatch, skip...
+`PresentMode::Immediate` drives the frame rate to 200-400+ FPS. The simulation accumulator adds `dt * speed_multiplier` per frame and dispatches `floor(accumulator / SIM_DT)` ticks to the GPU. At 10x, every frame triggers a `dispatch_batch` call with an async staging-buffer readback.
 
-At 5x, `dt * 5` doesn't always cross `SIM_DT` at high FPS, so many frames skip dispatch naturally, giving staging buffers breathing room.
+The readback pipeline was double-buffered: only 2 staging slots could be in-flight. When both were occupied, `dispatch_batch` returned `false` (GPU backpressure). The accumulator was **not drained** on backpressure — it kept growing each frame. When a staging slot freed up, the next dispatch fired a burst of accumulated ticks, causing position jumps.
+
+### 2. State readback gated on dispatch (1x–10x frozen agents)
+
+The GPU state readback and agent position copy was nested inside `if ticks_to_run > 0`. At 1x, dispatches only happen every ~20 frames (accumulator needs ~20 render frames at 120fps to accumulate enough for `brain_tick_stride` ticks). On the other ~19 frames, the position update was skipped entirely.
+
+Additionally, both the pre-dispatch `try_collect_state()` and post-render `try_collect_state()` consumed staging data without applying it to agent positions, so even when the every-frame block ran, it found nothing to collect.
 
 ## Rejected Approaches
 
 Several accumulator-side fixes were attempted and rejected:
 
-1. **Drain accumulator on backpressure** — capping to 1 frame's worth halved effective TPS at 10x (50% backpressure rate → ~300 TPS).
+1. **Drain accumulator on backpressure** — capping to 1 fixed-timestep's worth halved effective TPS at 10x (50% backpressure rate → ~300 TPS).
 2. **`speed_tick_cap`** — capping `ticks_to_run` to `speed_multiplier * 2` throttled throughput to ~300 TPS at all speeds above 5x.
 3. **Speed-based accumulator cap** — `max_acc = SIM_DT * speed * 2.0` lost fractional precision at low FPS, causing ~45 TPS at 1x/30fps.
 4. **Larger backpressure drain (2× speed)** — dispatching 20 ticks in one batch vs 10+10 changes vision/global pass frequency, breaking simulation determinism.
+5. **Batch alignment** — rounding `ticks_to_run` to `kernel_batch_size` multiples rounded to 0 at low speeds.
 
-All of these either throttle throughput or sacrifice determinism. The root cause is in the staging pipeline, not the accumulator.
+All of these either throttle throughput or sacrifice determinism.
 
 ## Fix
 
-Triple-buffer the staging pipeline in `gpu_kernel.rs`: 3 slots instead of 2. This gives readback 3 frames to complete before backpressure stalls dispatch, eliminating the bottleneck at moderate speeds without changing batch sizes or accumulator behavior.
+### Staging pipeline: 6-slot ring buffer
 
-Changes in `gpu_kernel.rs`:
+Increase `STAGING_SLOTS` from 2 to 6 in `gpu_kernel.rs`. This gives readback ample time to complete before backpressure stalls dispatch, eliminating the bottleneck at moderate speeds.
 
-- Add `const STAGING_SLOTS: usize = 3;` — single source of truth for slot count
-- Buffer creation uses `std::array::from_fn` to create `STAGING_SLOTS` buffers
-- Struct initialization uses `[false; STAGING_SLOTS]` and `std::array::from_fn` for Arc arrays
-- All `for i in 0..2` loops changed to `for i in 0..STAGING_SLOTS` (3 locations: `reset_agents`, `try_collect_staging`, `try_reset_agents`)
-- Index flip changed from `1 - self.staging_index` to `(self.staging_index + 1) % STAGING_SLOTS`
-- `active_config_index` flip unchanged (separate double-buffered concern for world config bind groups)
+Compute dispatch is fully decoupled from staging: `dispatch_batch` always submits GPU work, and only attempts a staging copy when a slot is free.
 
-The accumulator logic in `main.rs` is unchanged — no drain, no speed cap.
+### State readback: every-frame collection
 
-## Tradeoff
+Move the state readback + agent position update to an every-frame block outside the `if ticks_to_run > 0` gate. Remove the pre-dispatch `try_collect_state()` (the every-frame block handles all collection). Replace the post-render `try_collect_state()` with a bare `device.poll()` so map_async callbacks fire without consuming staging data.
 
-One additional staging buffer per kernel (~few KB). No throughput penalty — dispatch is no longer blocked at moderate speeds. At extreme speeds (100x+), the per-batch `queue.submit()` overhead becomes the bottleneck (tracked separately in issue #79), not staging.
+### Minimum dispatch size
+
+Every dispatch includes at least `brain_tick_stride` ticks so the brain always produces motor commands. At low speeds this borrows sim-time from the future (accumulator goes negative), repaid over the next few frames.
+
+### PresentMode: Mailbox
+
+Switch from `Immediate` to `Mailbox` to cap render at the display refresh rate (~120fps), reducing unnecessary frame pressure.
 
 ## Files Changed
 
-- `crates/xagent-brain/src/gpu_kernel.rs` — triple-buffered staging pipeline
+- `crates/xagent-brain/src/gpu_kernel.rs` — 6-slot staging ring buffer, `kernel_batch_size()`/`brain_tick_stride()` accessors, `reset_agents_seeded()`, telemetry unmap guard
+- `crates/xagent-sandbox/src/main.rs` — every-frame state readback, min-batch dispatch, remove redundant collect calls
+- `crates/xagent-sandbox/src/bench.rs` — `run_tick_loop_bench()` headless accumulator test
+- `crates/xagent-sandbox/src/renderer/mod.rs` — PresentMode::Mailbox
+- `crates/xagent-sandbox/tests/integration.rs` — `deterministic_across_batch_sizes` test

--- a/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
+++ b/docs/superpowers/specs/2026-04-13-tick-accumulator-backpressure-design.md
@@ -11,47 +11,40 @@ At 10x speed multiplier with `PresentMode::Immediate`, the UI freezes and update
 
 `PresentMode::Immediate` drives the frame rate to 200-400+ FPS. The simulation accumulator adds `dt * speed_multiplier` per frame and dispatches `floor(accumulator / SIM_DT)` ticks to the GPU. At 10x, every frame crosses the `SIM_DT` threshold and triggers a `dispatch_batch` call, which starts an async staging-buffer readback.
 
-The readback pipeline is double-buffered: only 2 staging slots can be in-flight. When both are occupied, `dispatch_batch` returns `false` (GPU backpressure). Currently, the accumulator is **not drained** on backpressure — it keeps growing each frame. When a staging slot frees up, the next dispatch fires a burst of accumulated ticks, causing an irregular position jump. The cycle repeats: dispatch, dispatch, skip, skip, burst-dispatch, skip...
+The readback pipeline was double-buffered: only 2 staging slots could be in-flight. When both were occupied, `dispatch_batch` returned `false` (GPU backpressure). The accumulator was **not drained** on backpressure — it kept growing each frame. When a staging slot freed up, the next dispatch fired a burst of accumulated ticks, causing an irregular position jump. The cycle repeated: dispatch, dispatch, skip, skip, burst-dispatch, skip...
 
 At 5x, `dt * 5` doesn't always cross `SIM_DT` at high FPS, so many frames skip dispatch naturally, giving staging buffers breathing room.
 
-The accumulator cap (`SIM_DT * gpu_tick_budget * 2`) makes this worse: the budget grows aggressively (25%/frame, cap 64k), allowing the accumulator cap to reach ~2100 seconds of sim-time — far beyond what any speed multiplier needs per frame.
+## Rejected Approaches
+
+Several accumulator-side fixes were attempted and rejected:
+
+1. **Drain accumulator on backpressure** — capping to 1 frame's worth halved effective TPS at 10x (50% backpressure rate → ~300 TPS).
+2. **`speed_tick_cap`** — capping `ticks_to_run` to `speed_multiplier * 2` throttled throughput to ~300 TPS at all speeds above 5x.
+3. **Speed-based accumulator cap** — `max_acc = SIM_DT * speed * 2.0` lost fractional precision at low FPS, causing ~45 TPS at 1x/30fps.
+4. **Larger backpressure drain (2× speed)** — dispatching 20 ticks in one batch vs 10+10 changes vision/global pass frequency, breaking simulation determinism.
+
+All of these either throttle throughput or sacrifice determinism. The root cause is in the staging pipeline, not the accumulator.
 
 ## Fix
 
-Two changes in `main.rs`, both in the tick loop:
+Triple-buffer the staging pipeline in `gpu_kernel.rs`: 3 slots instead of 2. This gives readback 3 frames to complete before backpressure stalls dispatch, eliminating the bottleneck at moderate speeds without changing batch sizes or accumulator behavior.
 
-### 1. Cap `ticks_to_run` by speed multiplier
+Changes in `gpu_kernel.rs`:
 
-Instead of tightening the accumulator cap (which discards fractional time and causes precision loss at low render FPS), cap `ticks_to_run` with 2× headroom. The accumulator retains its fractional remainder for the next frame:
+- Add `const STAGING_SLOTS: usize = 3;` — single source of truth for slot count
+- Buffer creation uses `std::array::from_fn` to create `STAGING_SLOTS` buffers
+- Struct initialization uses `[false; STAGING_SLOTS]` and `std::array::from_fn` for Arc arrays
+- All `for i in 0..2` loops changed to `for i in 0..STAGING_SLOTS` (3 locations: `reset_agents`, `try_collect_staging`, `try_reset_agents`)
+- Index flip changed from `1 - self.staging_index` to `(self.staging_index + 1) % STAGING_SLOTS`
+- `active_config_index` flip unchanged (separate double-buffered concern for world config bind groups)
 
-```rust
-let speed_tick_cap = (self.speed_multiplier * 2).max(2);
-let ticks_to_run = ((self.sim_accumulator / SIM_DT) as u32)
-    .min(self.gpu_tick_budget)
-    .min(speed_tick_cap);
-```
-
-### 2. Drain accumulator on backpressure
-
-When `dispatch_batch` returns `false`, cap the accumulator to one fixed-timestep (`SIM_DT`) worth at the current speed multiplier so the next successful dispatch sends a normal-sized batch:
-
-```rust
-if dispatched {
-    // ... existing budget/tick/accumulator logic
-} else {
-    // GPU backpressure — drop ticks rather than accumulating debt
-    // that causes burst dispatches when staging frees up.
-    self.sim_accumulator = self.sim_accumulator.min(SIM_DT * self.speed_multiplier as f32);
-}
-```
-
-The existing budget-based accumulator cap (`SIM_DT * budget * 2`) is kept as a generous overall safety net.
+The accumulator logic in `main.rs` is unchanged — no drain, no speed cap.
 
 ## Tradeoff
 
-At 10x + very high FPS, the simulation may run slightly below 600 TPS (dropped ticks during backpressure). Smooth visual updates over exact TPS is the right tradeoff — the user chose 10x for faster visual progression, not for precise tick counting. At 100x+ the user explicitly trades smoothness for throughput, and the larger `ticks_to_run` naturally gives staging more time between dispatches.
+One additional staging buffer per kernel (~few KB). No throughput penalty — dispatch is no longer blocked at moderate speeds. At extreme speeds (100x+), the per-batch `queue.submit()` overhead becomes the bottleneck (tracked separately in issue #79), not staging.
 
 ## Files Changed
 
-- `crates/xagent-sandbox/src/main.rs` — tick loop accumulator logic (~lines 1582-1620)
+- `crates/xagent-brain/src/gpu_kernel.rs` — triple-buffered staging pipeline


### PR DESCRIPTION
## Summary

- Decouple GPU state readback from tick dispatch so agent positions update every frame, not just on dispatch frames
- Increase staging slots from 3 to 6 for headroom at high speed multipliers
- Switch `PresentMode` to Mailbox to cap render at display refresh rate
- Add deterministic reset and batch-size determinism test
- Agents now move smoothly at 1x through 10000x with no UI freezes

## Root Cause

Two issues caused agents to appear frozen at low speeds (1x-10x):

1. **Position update gated on dispatch**: The state readback + agent position copy was inside `if ticks_to_run > 0`. At 1x, dispatches only happen every ~20 frames (when enough sim-time accumulates for `brain_tick_stride` ticks). On the other ~19 frames, positions were never applied.

2. **Staging data consumed before position update**: Both the pre-dispatch `try_collect_state()` and the post-render `try_collect_state()` consumed staging buffers without updating agent positions, leaving nothing for the position-update block.

## Changes

- **`main.rs`**: Move state readback + position update to an every-frame block outside the dispatch gate. Remove pre-dispatch `try_collect_state()`. Replace post-render `try_collect_state()` with bare `device.poll()`. Enforce `min_batch = brain_tick_stride` so brain always runs.
- **`gpu_kernel.rs`**: Add `kernel_batch_size()`, `brain_tick_stride()` accessors. Add `reset_agents_seeded()` for deterministic resets. Guard `unmap_telemetry_staging()` against unmapping when no readback pending. Increase `STAGING_SLOTS` to 6.
- **`bench.rs`**: Add `run_tick_loop_bench()` for headless accumulator + backpressure testing.
- **`renderer/mod.rs`**: Switch `PresentMode` from Immediate to Mailbox.
- **`tests/integration.rs`**: Add `deterministic_across_batch_sizes` test verifying identical outcomes across different batch sizes.

Closes #78

## Test plan

- [x] `cargo test -p xagent-sandbox` — all 44 tests pass (including new determinism test)
- [x] Manual: agents move smoothly at 1x, 2x, 5x, 10x — confirmed via diagnostic logging
- [x] Manual: no performance regression at high speeds
- [x] Determinism test passes: same final state across 1x1000, 2x500, 10x100 batch splits

🤖 Generated with [Claude Code](https://claude.com/claude-code)