### PR TITLE
fix: replace missing SUBGROUP_TOPK_ARGS placeholder in kernel shader

### DIFF
--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -648,9 +648,7 @@ impl GpuKernel {
         let brain_functions_src = include_str!("shaders/kernel/brain_tick.wgsl");
         let brain_fn_end = brain_functions_src
             .find("@compute @workgroup_size(256)\nfn brain_tick(")
-            .or_else(|| {
-                brain_functions_src.find("@compute @workgroup_size(256)\r\nfn brain_tick(")
-            })
+            .or_else(|| brain_functions_src.find("@compute @workgroup_size(256)\r\nfn brain_tick("))
             .unwrap_or(brain_functions_src.len());
         let brain_fns_only = &brain_functions_src[..brain_fn_end];
 

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -2261,7 +2261,7 @@ mod tests {
     }
 
     #[test]
-    fn kernel_subgroup_placeholders_are_symmetric() {
+    fn brain_tick_subgroup_placeholders_are_symmetric() {
         // Verify that brain_tick.wgsl's SUBGROUP_TOPK placeholders come in matched pairs
         let src = include_str!("shaders/kernel/brain_tick.wgsl");
         let has_params = src.contains("/* SUBGROUP_TOPK_PARAMS */");

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -2253,10 +2253,18 @@ mod tests {
         let src = include_str!("shaders/kernel/brain_tick.wgsl");
         let marker_lf = "@compute @workgroup_size(256)\nfn brain_tick(";
         let marker_crlf = "@compute @workgroup_size(256)\r\nfn brain_tick(";
-        let found = src.find(marker_lf).or_else(|| src.find(marker_crlf));
+
+        // Synthesize the opposite line-ending variant so both paths are exercised
+        let src_lf = src.replace("\r\n", "\n");
+        let src_crlf = src_lf.replace('\n', "\r\n");
+
         assert!(
-            found.is_some(),
-            "brain_tick entry point marker not found — check line endings in brain_tick.wgsl"
+            src_lf.find(marker_lf).is_some(),
+            "brain_tick entry point LF marker not found in LF-normalized source"
+        );
+        assert!(
+            src_crlf.find(marker_crlf).is_some(),
+            "brain_tick entry point CRLF marker not found in CRLF-normalized source"
         );
     }
 
@@ -2264,11 +2272,11 @@ mod tests {
     fn brain_tick_subgroup_placeholders_are_symmetric() {
         // Verify that brain_tick.wgsl's SUBGROUP_TOPK placeholders come in matched pairs
         let src = include_str!("shaders/kernel/brain_tick.wgsl");
-        let has_params = src.contains("/* SUBGROUP_TOPK_PARAMS */");
-        let has_args = src.contains("/* SUBGROUP_TOPK_ARGS */");
+        let params_count = src.matches("/* SUBGROUP_TOPK_PARAMS */").count();
+        let args_count = src.matches("/* SUBGROUP_TOPK_ARGS */").count();
         assert_eq!(
-            has_params, has_args,
-            "SUBGROUP_TOPK_PARAMS and SUBGROUP_TOPK_ARGS must both be present or both absent"
+            params_count, args_count,
+            "SUBGROUP_TOPK_PARAMS and SUBGROUP_TOPK_ARGS must appear the same number of times"
         );
     }
 }

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -648,6 +648,9 @@ impl GpuKernel {
         let brain_functions_src = include_str!("shaders/kernel/brain_tick.wgsl");
         let brain_fn_end = brain_functions_src
             .find("@compute @workgroup_size(256)\nfn brain_tick(")
+            .or_else(|| {
+                brain_functions_src.find("@compute @workgroup_size(256)\r\nfn brain_tick(")
+            })
             .unwrap_or(brain_functions_src.len());
         let brain_fns_only = &brain_functions_src[..brain_fn_end];
 
@@ -671,6 +674,7 @@ impl GpuKernel {
 
             // Also replace brain_tick.wgsl's own markers (included via brain_fns_only)
             kernel_source = kernel_source.replace("/* SUBGROUP_TOPK_PARAMS */", ", sgid: u32");
+            kernel_source = kernel_source.replace("/* SUBGROUP_TOPK_ARGS */", ", sgid");
 
             let begin_marker = "// BEGIN_BITONIC_SORT";
             let end_marker = "// END_BITONIC_SORT";
@@ -690,6 +694,7 @@ impl GpuKernel {
             kernel_source = kernel_source.replace(" /* KERNEL_SUBGROUP_TOPK_INNER_ARGS */", "");
             // Also strip brain_tick.wgsl's own markers
             kernel_source = kernel_source.replace(" /* SUBGROUP_TOPK_PARAMS */", "");
+            kernel_source = kernel_source.replace(" /* SUBGROUP_TOPK_ARGS */", "");
         }
 
         // ── Compose global-pass shader ──
@@ -2240,5 +2245,32 @@ impl GpuKernel {
     /// Returns the most recently collected telemetry, if any.
     pub fn cached_telemetry(&self) -> Option<&AgentTelemetry> {
         self.cached_telemetry.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn brain_tick_entry_point_marker_found_regardless_of_line_endings() {
+        let src = include_str!("shaders/kernel/brain_tick.wgsl");
+        let marker_lf = "@compute @workgroup_size(256)\nfn brain_tick(";
+        let marker_crlf = "@compute @workgroup_size(256)\r\nfn brain_tick(";
+        let found = src.find(marker_lf).or_else(|| src.find(marker_crlf));
+        assert!(
+            found.is_some(),
+            "brain_tick entry point marker not found — check line endings in brain_tick.wgsl"
+        );
+    }
+
+    #[test]
+    fn kernel_subgroup_placeholders_are_symmetric() {
+        // Verify that brain_tick.wgsl's SUBGROUP_TOPK placeholders come in matched pairs
+        let src = include_str!("shaders/kernel/brain_tick.wgsl");
+        let has_params = src.contains("/* SUBGROUP_TOPK_PARAMS */");
+        let has_args = src.contains("/* SUBGROUP_TOPK_ARGS */");
+        assert_eq!(
+            has_params, has_args,
+            "SUBGROUP_TOPK_PARAMS and SUBGROUP_TOPK_ARGS must both be present or both absent"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes kernel_tick shader validation failure on Windows with subgroup-capable GPUs (Vulkan/DX12)
- `coop_recall_topk` was called with 2 args but defined with 3 params because `/* SUBGROUP_TOPK_ARGS */` was never replaced in the kernel shader composition path
- Root cause: CRLF line endings in `brain_tick.wgsl` caused the entry point marker search to fail, so `brain_fns_only` included the entire file — exposing the unreplaced placeholder to the kernel shader

## Changes

1. **CRLF-aware entry point search** (`gpu_kernel.rs:649-653`): `.find()` now falls back to `\r\n` if `\n` match fails, so `brain_fns_only` correctly excludes the entry point regardless of line endings
2. **Missing ARGS replacement** (`gpu_kernel.rs:677`): adds `kernel_source.replace("/* SUBGROUP_TOPK_ARGS */", ", sgid")` in the subgroup path, mirroring `brain_source` at line 625
3. **Non-subgroup strip** (`gpu_kernel.rs:697`): strips `/* SUBGROUP_TOPK_ARGS */` in the non-subgroup path for completeness
4. **Two regression tests**: entry point marker found regardless of line endings, and PARAMS/ARGS placeholders are always symmetric

## Test plan

- [x] `cargo check -p xagent-brain` — compiles cleanly
- [x] `cargo test -p xagent-brain` — 24 tests pass (22 existing + 2 new)
- [x] `cargo test -p xagent-sandbox` — 1 pre-existing failure (`momentum_persists_across_resume`, `/tmp` path on Windows), unrelated
- [ ] Manual verification on a Windows machine with a subgroup-capable GPU (Vulkan/DX12)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)