### PR TITLE
fix: raise tonic credit scale and lower deadzone to restore credit assignment

### DIFF
--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -354,7 +354,9 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
                 is_tonic = true;
             }
             if (!is_tonic && abs(credit_input) < DEADZONE) { continue; }
-            if (abs(credit_input) < 1e-6) { continue; }
+            // Epsilon gate: skip near-zero tonic signals that would produce negligible weight updates.
+            // Non-tonic path already enforces abs(credit_input) >= DEADZONE, so this only matters for tonic.
+            if (is_tonic && abs(credit_input) < 1e-6) { continue; }
             var effective: f32;
             if (credit_input < 0.0) { effective = credit_input * PAIN_AMP; }
             else { effective = credit_input; }

--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -348,10 +348,13 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
             if (temporal < 0.01) { continue; }
             let improvement = gradient - rec_grad;
             var credit_input = improvement;
+            var is_tonic = false;
             if (abs(improvement) < DEADZONE) {
                 credit_input = gradient * urgency * TONIC_CREDIT_SCALE;
+                is_tonic = true;
             }
-            if (abs(credit_input) < DEADZONE) { continue; }
+            if (!is_tonic && abs(credit_input) < DEADZONE) { continue; }
+            if (abs(credit_input) < 1e-6) { continue; }
             var effective: f32;
             if (credit_input < 0.0) { effective = credit_input * PAIN_AMP; }
             else { effective = credit_input; }

--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -348,15 +348,12 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
             if (temporal < 0.01) { continue; }
             let improvement = gradient - rec_grad;
             var credit_input = improvement;
-            var is_tonic = false;
             if (abs(improvement) < DEADZONE) {
                 credit_input = gradient * urgency * TONIC_CREDIT_SCALE;
-                is_tonic = true;
             }
-            if (!is_tonic && abs(credit_input) < DEADZONE) { continue; }
-            // Epsilon gate: skip near-zero tonic signals that would produce negligible weight updates.
-            // Non-tonic path already enforces abs(credit_input) >= DEADZONE, so this only matters for tonic.
-            if (is_tonic && abs(credit_input) < 1e-6) { continue; }
+            // Epsilon gate: skip near-zero tonic signals (non-tonic path
+            // already guarantees abs >= DEADZONE)
+            if (abs(credit_input) < 1e-6) { continue; }
             var effective: f32;
             if (credit_input < 0.0) { effective = credit_input * PAIN_AMP; }
             else { effective = credit_input; }

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -248,10 +248,10 @@ const GRAD_BLEND_SLOW: f32 = 0.15;
 const CREDIT_DECAY: f32 = 0.04;
 const WEIGHT_LR: f32 = 0.10;
 const PAIN_AMP: f32 = 3.0;
-const DEADZONE: f32 = 0.01;
+const DEADZONE: f32 = 0.005;
 const MAX_WEIGHT_NORM: f32 = 2.0;
 const ANTICIPATION_WEIGHT: f32 = 0.5;
-const TONIC_CREDIT_SCALE: f32 = 0.1;
+const TONIC_CREDIT_SCALE: f32 = 0.5;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Buffer bindings — 15 storage + 2 uniform, single bind group


### PR DESCRIPTION
## Summary
- Raises `TONIC_CREDIT_SCALE` from `0.1` to `0.5` so the tonic fallback exceeds the deadzone in sustained-danger scenarios
- Lowers `DEADZONE` from `0.01` to `0.005` to allow weaker but real learning signals through
- Makes tonic credit bypass the deadzone check — tonic is a deliberate fallback, not noise; a `1e-6` epsilon gate prevents near-zero signals from producing negligible weight updates

Closes #87, closes #88

## Test plan
- [x] `cargo test -p xagent-brain` passes (24/24)
- [x] `cargo check -p xagent-sandbox` passes
- [ ] Verify tonic fires in sustained-danger scenario: `gradient=-0.1, urgency=0.5 → tonic = -0.025 > 0.005`

🤖 Generated with [Claude Code](https://claude.com/claude-code)