### PR TITLE
fix: raise encoder credit scaling from 0.001 to 0.01 for viable representation learning

### DIFF
--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -626,7 +626,7 @@ fn coop_learn_and_store(agent_id: u32, tid: u32) {
     if (tid < DIM) {
         let credit_d = decision_buf[d_base + DIM + tid];
         if (abs(credit_d) >= 1e-6) {
-            let scale = learning_rate * credit_d * 0.001;
+            let scale = learning_rate * credit_d * 0.01;
             for (var j: u32 = 0u; j < FEATURE_COUNT; j = j + 1u) {
                 var w = brain_state[b + O_ENC_WEIGHTS + j * DIM + tid] + scale * s_features[j];
                 w = clamp(w, -2.0, 2.0);


### PR DESCRIPTION
## Summary
- Changes encoder credit multiplier from `0.001` to `0.01` in `coop_learn_and_store` pass 7b
- This makes encoder learning 10x faster while remaining 100x slower than action weight updates (appropriate stability hierarchy)
- The `[-2.0, 2.0]` weight clamp already prevents runaway weights, making the extreme conservatism of `0.001` unnecessary
- At the old rate, ~20,000 food encounters were needed to meaningfully shape the encoder; at the new rate, ~2,000 — still slow but viable over a simulation run

Closes #91

## Test plan
- [x] `cargo test -p xagent-brain` passes (24/24)
- [x] `cargo check -p xagent-sandbox` passes
- [ ] Verify encoder weight update magnitude: with `learning_rate=0.1, credit=0.05, feature=0.5`, old delta = `0.0000025`, new delta = `0.000025`

🤖 Generated with [Claude Code](https://claude.com/claude-code)