### PR TITLE
fix: revert credit history to post-noise motor to escape zero-gradient trap

### DIFF
--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -559,13 +559,6 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         }
         brain_state[b + O_FATIGUE_FACTOR] = fatigue_factor;
 
-        // Save pre-noise, pre-fatigue policy output for credit assignment history.
-        // Credit must correlate outcomes with policy intent, not random
-        // exploration noise or fatigue scaling — otherwise weight updates
-        // are randomly directed.
-        let policy_fwd = fwd;
-        let policy_trn = trn;
-
         // Exploration noise — scaled by mean habituation attenuation so that
         // noise amplitude tracks the attenuated policy signal, preserving SNR.
         let tick_u = u32(tick_count);
@@ -580,12 +573,17 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         fwd *= fatigue_factor;
         trn *= fatigue_factor;
 
-        // History recording — stores pre-noise policy output and
-        // full-strength encoded state for accurate credit assignment.
+        // History recording — stores the actual motor command (post-noise,
+        // post-fatigue) so credit assignment can correlate taken actions with
+        // outcomes.  The noise component serves as the exploration signal for
+        // REINFORCE-style learning: when weights are zero the policy output is
+        // zero, and multiplying credit by zero would create a zero-gradient
+        // trap.  The post-noise motor is non-zero even at initialization,
+        // allowing bootstrap learning.
         let hist_cursor = u32(history_buf[hi_base + O_HIST_CURSOR]);
         let hist_off = hist_cursor * 5u;
-        history_buf[hi_base + O_MOTOR_RING + hist_off] = policy_fwd;
-        history_buf[hi_base + O_MOTOR_RING + hist_off + 1u] = policy_trn;
+        history_buf[hi_base + O_MOTOR_RING + hist_off] = fwd;
+        history_buf[hi_base + O_MOTOR_RING + hist_off + 1u] = trn;
         history_buf[hi_base + O_MOTOR_RING + hist_off + 2u] = tick_count;
         history_buf[hi_base + O_MOTOR_RING + hist_off + 3u] = gradient;
         history_buf[hi_base + O_MOTOR_RING + hist_off + 4u] = 0.0;


### PR DESCRIPTION
## Summary

PR #94 stored pre-noise policy output (`policy_fwd`) in the credit history. This created a **zero-gradient trap**: with zero-init action weights, `policy_fwd = tanh(0) = 0`, so the weight update `lr × credit × 0 × feat = 0`. Agents could not learn at all — explaining why circling persists after 20+ generations.

The exploration noise is not corruption — it is the REINFORCE exploration signal. The post-noise motor command provides the action-specific gradient direction for credit assignment. Reverts history recording to store the actual motor command (`fwd`, post-noise post-fatigue), which is non-zero even at initialization (`~±0.025` with `mean_atten` scaling).

Keeps the other PR #94 fixes:
- Noise scaled by `mean_atten` (preserves SNR)
- `s_encoded` in state history (unattenuated features for stronger weight updates)

## Test plan
- [ ] `cargo test -p xagent-brain` passes (24 tests)
- [ ] `cargo test -p xagent-sandbox` passes (44 tests)
- [ ] Verify `fwd`/`trn` (not `policy_fwd`/`policy_trn`) stored in history at lines 585-586
- [ ] Run simulation: agents should begin showing directional behavior within a few generations

🤖 Generated with [Claude Code](https://claude.com/claude-code)