### PR TITLE
feat: raise energy drain 3x and set movement speed floor to 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Additional world parameters: `world_size` (default 256), `integrity_regen_rate` 
     "hazard_damage_rate": 1.0,
     "integrity_regen_rate": 0.005,
     "food_energy_value": 20.0,
-    "food_density": 0.002,
+    "food_density": 0.005,
     "tick_rate": 30.0,
     "seed": 42
   }

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Additional world parameters: `world_size` (default 256), `integrity_regen_rate` 
     "world_size": 256.0,
     "energy_depletion_rate": 0.03,
     "movement_energy_cost": 0.005,
-    "hazard_damage_rate": 0.1,
+    "hazard_damage_rate": 1.0,
     "integrity_regen_rate": 0.005,
     "food_energy_value": 20.0,
     "food_density": 0.002,

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Additional world parameters: `world_size` (default 256), `integrity_regen_rate` 
   },
   "world": {
     "world_size": 256.0,
-    "energy_depletion_rate": 0.01,
+    "energy_depletion_rate": 0.03,
     "movement_energy_cost": 0.005,
     "hazard_damage_rate": 0.1,
     "integrity_regen_rate": 0.005,

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -108,8 +108,8 @@ fn agent_physics(agent_id: u32, tick: u32) {
 
     // Energy depletion
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
-    // Normalize by default speed (8.0) so baseline energy drain is unchanged.
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 8.0);
+    // Normalize by default speed (20.0) so baseline energy drain is unchanged.
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 20.0);
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -94,9 +94,9 @@ fn phase_physics(tid: u32, tick: u32) {
 
     // Energy depletion (scaled by metabolic_rate from brain config)
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
-    // Normalize by default speed (8.0) so baseline energy drain is unchanged;
+    // Normalize by default speed (20.0) so baseline energy drain is unchanged;
     // faster agents pay proportionally more, slower agents pay less.
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 8.0);
+    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 20.0);
     var energy = agent_phys[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;

--- a/crates/xagent-sandbox/README.md
+++ b/crates/xagent-sandbox/README.md
@@ -642,7 +642,7 @@ On death the agent is respawned with a **fresh brain** (no persistence in headle
 | Field | Default | Easy | Hard | Description |
 |---|---|---|---|---|
 | `world_size` | 256.0 | 256.0 | 256.0 | Square terrain side length (units) |
-| `energy_depletion_rate` | 0.01 | 0.005 | 0.02 | Base metabolic cost per tick |
+| `energy_depletion_rate` | 0.03 | 0.015 | 0.05 | Base metabolic cost per tick |
 | `movement_energy_cost` | 0.005 | 0.002 | 0.01 | Energy cost per unit of movement magnitude |
 | `hazard_damage_rate` | 1.0 | 0.5 | 2.0 | Integrity damage per tick in Danger biomes |
 | `integrity_regen_rate` | 0.005 | 0.005 | 0.005 | Integrity recovery per tick (when energy > 50%) |

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -364,7 +364,7 @@ pub fn mutate_config_with_strength(
         integrity_scale: parent.integrity_scale,
         movement_speed: momentum
             .biased_perturb_f(&mut rng, parent.movement_speed, "movement_speed", strength)
-            .clamp(2.0, 20.0),
+            .clamp(20.0, 100.0),
     }
 }
 
@@ -690,35 +690,35 @@ mod tests {
         let momentum = MutationMomentum::new(0.9);
         // Push initial config to extreme values to verify clamps.
         let too_fast = BrainConfig {
-            movement_speed: 100.0,
+            movement_speed: 200.0,
             ..BrainConfig::default()
         };
         let too_slow = BrainConfig {
-            movement_speed: 0.1,
+            movement_speed: 1.0,
             ..BrainConfig::default()
         };
         for _ in 0..50 {
             let child = mutate_config_with_strength(&too_fast, 0.3, &momentum);
             assert!(
-                child.movement_speed <= 20.0,
-                "movement_speed must be <= 20.0, got {}",
+                child.movement_speed <= 100.0,
+                "movement_speed must be <= 100.0, got {}",
                 child.movement_speed,
             );
             assert!(
-                child.movement_speed >= 2.0,
-                "movement_speed must be >= 2.0, got {}",
+                child.movement_speed >= 20.0,
+                "movement_speed must be >= 20.0, got {}",
                 child.movement_speed,
             );
 
             let child = mutate_config_with_strength(&too_slow, 0.3, &momentum);
             assert!(
-                child.movement_speed <= 20.0,
-                "movement_speed must be <= 20.0, got {}",
+                child.movement_speed <= 100.0,
+                "movement_speed must be <= 100.0, got {}",
                 child.movement_speed,
             );
             assert!(
-                child.movement_speed >= 2.0,
-                "movement_speed must be >= 2.0, got {}",
+                child.movement_speed >= 20.0,
+                "movement_speed must be >= 20.0, got {}",
                 child.movement_speed,
             );
         }

--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1441,8 +1441,8 @@ impl<'a> TabContext<'a> {
                     ui.label("movement_speed");
                     ui.add(
                         egui::DragValue::new(&mut b.movement_speed)
-                            .range(2.0..=20.0)
-                            .speed(0.5)
+                            .range(20.0..=100.0)
+                            .speed(1.0)
                             .max_decimals(1),
                     );
                     ui.end_row();

--- a/crates/xagent-shared/README.md
+++ b/crates/xagent-shared/README.md
@@ -307,7 +307,7 @@ World simulation parameters:
 | Parameter | Default | Description |
 |---|---|---|
 | `world_size` | 256.0 | Side length of the square terrain in world units. Larger worlds require more exploration. |
-| `energy_depletion_rate` | 0.01 | Energy drained per tick from base metabolism. This is the constant pressure that forces the agent to eat. |
+| `energy_depletion_rate` | 0.03 | Energy drained per tick from base metabolism. This is the constant pressure that forces the agent to eat. |
 | `movement_energy_cost` | 0.005 | Additional energy cost per unit of movement. Moving is expensive — the agent must learn to balance exploration (costly) with exploitation (staying near known food). |
 | `hazard_damage_rate` | 0.1 | Integrity damage per tick while in a hazard zone. Higher values make hazards more lethal, increasing the selection pressure to learn avoidance. |
 | `integrity_regen_rate` | 0.005 | Integrity recovered per tick when energy is above 50%. Recovery is slow relative to damage — the agent must avoid hazards rather than tanking through them. |

--- a/crates/xagent-shared/README.md
+++ b/crates/xagent-shared/README.md
@@ -309,10 +309,10 @@ World simulation parameters:
 | `world_size` | 256.0 | Side length of the square terrain in world units. Larger worlds require more exploration. |
 | `energy_depletion_rate` | 0.03 | Energy drained per tick from base metabolism. This is the constant pressure that forces the agent to eat. |
 | `movement_energy_cost` | 0.005 | Additional energy cost per unit of movement. Moving is expensive — the agent must learn to balance exploration (costly) with exploitation (staying near known food). |
-| `hazard_damage_rate` | 0.1 | Integrity damage per tick while in a hazard zone. Higher values make hazards more lethal, increasing the selection pressure to learn avoidance. |
+| `hazard_damage_rate` | 1.0 | Integrity damage per tick while in a hazard zone. Higher values make hazards more lethal, increasing the selection pressure to learn avoidance. |
 | `integrity_regen_rate` | 0.005 | Integrity recovered per tick when energy is above 50%. Recovery is slow relative to damage — the agent must avoid hazards rather than tanking through them. |
 | `food_energy_value` | 20.0 | Energy restored per food item consumed. Higher values make each food item more impactful, reducing the frequency of foraging needed. |
-| `food_density` | 0.002 | Density of food items in food-rich biomes (items per unit²). Higher density means food is easier to find, lower density increases starvation pressure. |
+| `food_density` | 0.005 | Density of food items in food-rich biomes (items per unit²). Higher density means food is easier to find, lower density increases starvation pressure. |
 | `tick_rate` | 30.0 | Simulation ticks per second. Affects the real-time speed of the simulation. |
 | `seed` | 42 | Random seed for world generation. Same seed = same terrain, biome layout, and initial food placement. |
 

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -60,8 +60,8 @@ pub struct BrainConfig {
     /// Lower = agents take less damage. Higher = hazard zones are deadlier.
     #[serde(default = "default_integrity_scale")]
     pub integrity_scale: f32,
-    /// Base movement speed (units per second). Default 8.0.
-    /// Heritable: mutated during breeding, clamped to [2.0, 20.0].
+    /// Base movement speed (units per second). Default 20.0.
+    /// Heritable: mutated during breeding, clamped to [20.0, 100.0].
     #[serde(default = "default_movement_speed")]
     pub movement_speed: f32,
 }
@@ -135,7 +135,7 @@ fn default_integrity_scale() -> f32 {
 }
 
 fn default_movement_speed() -> f32 {
-    8.0
+    20.0
 }
 
 /// Describes an agent to be spawned into the world.
@@ -310,7 +310,7 @@ impl Default for WorldConfig {
     fn default() -> Self {
         Self {
             world_size: 256.0,
-            energy_depletion_rate: 0.01,
+            energy_depletion_rate: 0.03,
             movement_energy_cost: 0.005,
             hazard_damage_rate: 1.0,
             integrity_regen_rate: 0.005,
@@ -326,7 +326,7 @@ impl WorldConfig {
     /// Lots of food, slow energy drain, mild hazards.
     pub fn easy() -> Self {
         Self {
-            energy_depletion_rate: 0.005,
+            energy_depletion_rate: 0.015,
             movement_energy_cost: 0.002,
             hazard_damage_rate: 0.5,
             food_density: 0.005,
@@ -338,7 +338,7 @@ impl WorldConfig {
     /// Scarce food, fast energy drain, deadly hazards.
     pub fn hard() -> Self {
         Self {
-            energy_depletion_rate: 0.02,
+            energy_depletion_rate: 0.05,
             movement_energy_cost: 0.01,
             hazard_damage_rate: 2.0,
             food_density: 0.001,
@@ -374,7 +374,7 @@ mod tests {
         assert_eq!(config.vision_height, 6);
         assert!((config.metabolic_rate - 0.01).abs() < 1e-6);
         assert!((config.integrity_scale - 0.01).abs() < 1e-6);
-        assert!((config.movement_speed - 8.0).abs() < 1e-6);
+        assert!((config.movement_speed - 20.0).abs() < 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **energy_depletion_rate**: 0.01 → 0.03 (default, 3×), 0.005 → 0.015 (easy, 3×), 0.02 → 0.05 (hard, 2.5×). Agents now need ~13 food items to survive a full generation. The "sit still" strategy dies at tick ~281k.
- **movement_speed bounds**: [2.0, 20.0] → [20.0, 100.0] in mutation clamp, UI slider, and default (8.0 → 20.0). Evolution can no longer disable locomotion.
- **Movement energy normalization**: updated from `move_speed / 8.0` to `move_speed / 20.0` in both `kernel_tick.wgsl` and `phase_physics.wgsl` to match the new default speed.

### Why
DB analysis of 320 generations showed evolution driving `movement_speed` from 14.3 → 2.0 and food consumption from 10.3 → 4.2 per generation. Fitness was inversely correlated with food (0-death agents: fitness 0.41, avg food 3.3 vs 6+-death agents: fitness 0.13, avg food 17.6). The metabolic drain was low enough that agents survived full generations eating ~3 passive food items — making food-seeking irrational.

## Test plan
- [ ] `cargo test --workspace` passes (139 tests)
- [ ] UI slider for movement_speed shows 20.0–100.0 range
- [ ] Agents die of starvation without eating (~tick 281k at default settings)
- [ ] Movement energy normalization uses 20.0 in both shader files

🤖 Generated with [Claude Code](https://claude.com/claude-code)