### PR TITLE
chore: consolidate contributing rules into CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Project: xagent
 
 ## Contributing Rules
-All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That file is the single source of truth for code style, naming, GPU/buffer safety, async readback, concurrency, performance, and testing rules.
+All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That file is the single source of truth for code style, naming, numeric safety, GPU/buffer safety, WGSL safety, async readback, state invariants, concurrency, performance, serialization compatibility, testing, CI discipline, logging, and related rules.
 
 ## Build & Test
 - `cargo check -p xagent-sandbox` — quick compile check for the sandbox crate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # Project: xagent
 
+## Contributing Rules
+All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That file is the single source of truth for code style, naming, GPU/buffer safety, async readback, concurrency, performance, and testing rules.
+
 ## Build & Test
 - `cargo check -p xagent-sandbox` — quick compile check for the sandbox crate
 - `cargo test -p xagent-sandbox` — runs 58 lib unit + 3 bin unit + 34 integration tests (95 total)
@@ -30,41 +33,5 @@
 - `rust-toolchain.toml` — pins Rust stable channel for CI and local dev
 - Release flow: tag on `develop` (`git tag v0.x.0 && git push origin v0.x.0`) triggers the full pipeline
 
-## Performance Invariants
-- Per-tick simulation logic belongs in WGSL shaders, never in Rust
-- The CPU main loop submits GPU dispatches (batched) and collects async readback results (non-blocking)
-- Recording/telemetry/history functions run once per frame, sampling the latest state
-- No CPU-side work should scale with `ticks_to_run` — up to 64,000 ticks may be scheduled per frame/batch call, with GPU work dispatched in chunks
-- Never clone large collections (`Vec`, `HashMap`) in per-frame hot paths — use `clone_from()` or borrow
-- Use squared-distance comparisons to avoid `sqrt()` in loops
-
-## GPU & Buffer Rules
-- All buffer offsets must derive from `BrainLayout` / kernel config, never hardcoded constants
-- Validate index/count inputs against kernel state before computing buffer offsets
-- Constants shared between Rust and WGSL must have a single canonical source for each constant in each shader/pipeline; use whichever source that shader already treats as authoritative (e.g., `wgsl_physics_constants()` or `wconfig`)
-- Never define the same constant in multiple headers that get concatenated — import or reference the canonical one for that shader/pipeline
-
-## Async Readback Rules
-- Track in-flight state explicitly: never overwrite pending async operations without cleanup
-- Always handle both success and failure paths for `map_async` — stuck-forever states are bugs
-- When multiple sources provide the same field (e.g., phys readback vs telemetry), document which is authoritative and never overwrite fresher data with stale
-- Unmap staging buffers on all paths: success, error, agent switch, and generation reset
-
-## Concurrency Rules
-- All SQLite connections must set `busy_timeout` — default is 0 (instant fail)
-- Background threads must have a shutdown path: drop sender → recv returns Disconnected → thread exits
-- `Drop` impls must join threads and log panics, never silently discard
-- Never use `.expect()` for fallible I/O/GPU/thread operations — return `Result` or `Option`
-
-## Testing Rules
-- New concurrency-sensitive code paths require end-to-end tests exercising failure modes
-- Cache invalidation logic must be tested: populate → invalidate → verify fresh
-- Non-trivial algorithms (color generation, distance checks) need unit tests with boundary cases
-
-## Code Style
+## Specs & Plans
 - Specs: `docs/superpowers/specs/`, Plans: `docs/superpowers/plans/`
-- Commit prefixes: `feat:`, `fix:`, `perf:`
-- Docstrings must match implementation — "non-blocking" means non-blocking, "pre-allocates" means pre-allocates
-- Distinguish "start operation" from "poll/collect operation" in API naming
-- Avoid abbreviations in identifiers — use full words (e.g. `vision_width` not `vision_w`, `position` not `pos`). Exceptions: buffer layout constants (O_*, P_*, CFG_*), loop variables, external API types.
-- No commented-out code or tombstone comments — delete removed code completely, git history preserves everything

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to XAgent
 
+These rules are distilled from 305 code review comments across PRs #1–#100. They represent the project's hard-won invariants.
+
 ## Tooling
 
 All code must pass the following before merge:
@@ -25,6 +27,7 @@ defaults.
 | No single-letter variables outside closures, iterators, or trivial math (`x`, `y`). | `gw` → `grid_width`, `c` → `contact` |
 | No bare abbreviations. Spell out names so they read clearly. | `ppp` → `pixels_per_point`, `fc` → `feature_count` |
 | Domain abbreviations that are universal in the project may be used if documented here. | `buf` (buffer), `wt`/`wts` (weight/weights) |
+| Buffer layout constants (`O_*`, `P_*`, `CFG_*`), loop variables, and external API types are exempt. | |
 
 ### Magic Numbers
 
@@ -46,7 +49,94 @@ reviewed and refactored as part of normal code review.
 
 - All public types and functions should have `///` doc comments.
 - Module-level `//!` docs should describe purpose and key concepts.
+- Docstrings must match implementation — "non-blocking" means non-blocking, "pre-allocates" means pre-allocates. Rename functions when behavior changes (e.g., `read_agent_telemetry` → `read_agent_telemetry_blocking`).
+- Comments that make performance claims ("non-blocking", "pre-allocates", "reuses allocation") are contractual — verify them on every change.
+- When changing a numeric value, default, range, or behavior, search for all comments and docs referencing the old value. `grep` for both the old literal and the concept name.
+- Comments referencing removed or renamed parameters, fields, or functions must be updated or deleted in the same commit.
+- Distinguish "start operation" from "poll/collect operation" in API naming. A function that both starts and polls should document that clearly.
+- Keep PR descriptions synchronized with code. Constant values, radius sizes, and architectural claims must reflect what the code actually does.
+- No commented-out code or tombstone comments. Delete removed code completely — git history preserves everything.
+- No stale TODOs. If the referenced work is done or abandoned, delete the TODO.
+- Do not write values to buffers or fields that nothing reads. Unused writes waste bandwidth and mislead readers about data flow.
 - We plan to enable `#![warn(missing_docs)]` incrementally per crate.
+
+### Logging
+
+- Use `log::warn!` / `log::error!` (or `tracing`) for all diagnostic output. Never use `eprintln!` or `println!` for errors or warnings — they bypass log filtering and are invisible in structured logging setups.
+
+### Commit Messages
+
+Use conventional commit prefixes: `feat:`, `fix:`, `perf:`.
+
+## Numeric Safety
+
+- Never use `as` for potentially lossy integer conversions (`u64` → `i64`, `u64` → `u32`). Use `try_into()` or `TryFrom` and handle the error.
+- Size and count multiplications that derive buffer sizes must use `checked_mul()` or validate against a reasonable upper bound before allocating.
+- Any value used as a divisor must be guarded against zero — use `max(value, epsilon)` or check before dividing. This applies to both Rust and WGSL.
+- After subtracting from a bounded quantity (energy, integrity), immediately clamp to the valid range in the same scope. Do not defer invariant enforcement to the next tick.
+
+## GPU & Buffer Safety
+
+- All buffer offsets must derive from `BrainLayout` / kernel config, never hardcoded constants. Hardcoded strides like `SENSORY_STRIDE` break when `BrainLayout` uses non-default vision dimensions.
+- Validate index and count inputs against kernel state before computing buffer offsets. Out-of-bounds offsets trigger wgpu validation errors or silent corruption.
+- Constants shared between Rust and WGSL must have a single canonical source within a given shader pipeline / concatenated header set. A pipeline may use either the `wgsl_physics_constants()` template or the `wconfig` uniform buffer for a given constant, but do not define the same constant from both sources when headers are combined. Use named constants, not magic indices (e.g., `WC_FOOD_RADIUS`, not `wc(7u)`).
+- Rust structs used as WGSL `var<uniform>` buffers must match WGSL struct alignment rules (16-byte aligned struct size, `vec4`-aligned members). Use `#[repr(C)]` and explicit padding, or validate with `assert_eq!(std::mem::size_of::<T>() % 16, 0)`.
+- When agents have per-instance heritable config, GPU upload functions must iterate all agents, not just apply the first config. Document whether a reset/upload function applies to a single agent or the entire population.
+
+## WGSL Safety
+
+- `select()` evaluates all arguments before choosing — guard divisions with `max(denominator, epsilon)` instead of relying on the condition to skip them.
+- Use `storageBarrier()` (not `workgroupBarrier()`) to synchronize reads/writes to `var<storage>` buffers within a workgroup.
+- Early-return in a workgroup shader does not exempt an invocation from barrier participation — restructure control flow to ensure all invocations reach each barrier.
+- When removing or renaming a constant or function in a shared WGSL header, grep all shaders that concatenate that header to verify no dangling references.
+
+## Async Readback
+
+- Track in-flight state explicitly. Never overwrite a pending `map_async` operation without unmapping/cleaning up the previous one first.
+- Always handle both success and failure paths. If any `map_async` callback fails, the system must clean up and allow retry — "stuck forever" states are bugs.
+- Establish data authority. When physics readback and telemetry readback both provide the same field, document which is authoritative and never overwrite fresher data with stale async results.
+- Unmap staging buffers on all paths: success, error, agent switch, and generation reset.
+
+## State Invariants
+
+- After modifying a value that has downstream invariants (e.g., energy), immediately re-establish the invariant (clamp, death check) in the same scope. Do not defer invariant enforcement to the next tick.
+- When associating cause (action) with effect (reward/gradient), verify temporal alignment: the gradient recorded with a motor command must reflect the outcome of that command, not the previous tick's outcome.
+- State machines must handle all states for all input conditions. If a transition requires a precondition (e.g., non-empty agent list), guard the transition — do not enter a stuck state.
+
+## Concurrency
+
+- All SQLite connections must set `busy_timeout`. The default is 0 (instant `SQLITE_BUSY` failure). Both main and background connections need matching timeout policies.
+- Background threads must have a deterministic shutdown path. Drop sender → `recv` returns `Disconnected` → thread exits. `Drop` impls must join threads and log any panics.
+- Return `Result` or `Option` from fallible operations. Never use `.expect()` for I/O, GPU, or thread operations. Silent failures are worse than explicit errors.
+
+## Performance
+
+- Per-tick simulation logic belongs in WGSL shaders, never in Rust.
+- The CPU main loop submits GPU dispatches (batched) and collects async readback results (non-blocking).
+- No CPU-side work should scale with `ticks_to_run` — up to 64,000 ticks may be scheduled per frame/batch call, with GPU work dispatched in chunks.
+- Never clone large collections in per-frame hot paths. Use `clone_from()` for in-place updates or borrow patterns. A throttled rebuild is useless if you deep-clone every frame.
+- Use squared-distance comparisons to avoid `sqrt()` in loops. Both CPU and GPU code should use `_SQ` variants for radius checks.
+- Only mark throttle windows as consumed when work actually happens. Updating `last_rebuild` without rebuilding silently wastes the throttle budget.
+
+## Serialization & Config Compatibility
+
+- When renaming or restructuring serialized fields (`serde` JSON, SQLite columns), add `#[serde(alias = "old_name")]` or a migration path so existing configs and saved data still load.
+- Binary persistence formats (BLOBs, recordings) must document their endianness and validate decoded sizes against expected dimensions. Prefer little-endian for portability.
+
+## Testing
+
+- New concurrency-sensitive code paths require end-to-end tests exercising the async lifecycle: request → complete → consume, and request → fail → cleanup.
+- Cache invalidation must be tested: populate → invalidate → verify fresh data returned.
+- Non-trivial algorithms need unit tests with representative inputs and boundary conditions.
+- Tests must be falsifiable: a test that passes for all inputs (tautology, arithmetic identity) is not a test. If deleting the code under test would not break the test, the test is wrong.
+- Tests must assert invariants, not skip violations. Filtering out bad data and asserting on the remainder hides bugs.
+- Test names and doc comments must accurately describe what is verified. A claim like "verified here" requires an actual assertion.
+- Tests must not depend on hardware availability (GPU). Gate hardware-dependent tests behind a feature flag or `#[cfg]` attribute.
+
+## CI Discipline
+
+- Benchmark and release-profile steps should not run on every push — gate them on `workflow_dispatch` or schedule triggers.
+- Clippy must lint `--all-targets` to catch issues in tests, benches, and examples.
 
 ## Incremental Cleanup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to XAgent
 
-These rules are distilled from 305 code review comments across PRs #1–#100. They represent the project's hard-won invariants.
+These rules are distilled from hundreds of code review comments through PR #100. They represent the project's hard-won invariants.
 
 ## Tooling
 
@@ -62,11 +62,11 @@ reviewed and refactored as part of normal code review.
 
 ### Logging
 
-- Use `log::warn!` / `log::error!` (or `tracing`) for all diagnostic output. Never use `eprintln!` or `println!` for errors or warnings — they bypass log filtering and are invisible in structured logging setups.
+- In library code and long-lived runtime paths, use `log::warn!` / `log::error!` (or `tracing`) for warnings and errors. Do not use `eprintln!` or `println!` there, because they bypass log filtering and are invisible in structured logging setups. Direct `println!` / `eprintln!` output is acceptable for intentional user-facing CLI messages and in tests/benches where stdout/stderr is part of the interface or harness behavior.
 
 ### Commit Messages
 
-Use conventional commit prefixes: `feat:`, `fix:`, `perf:`.
+Use conventional commit prefixes: `feat:`, `fix:`, `perf:`, `refactor:`, `doc:`, `chore:`.
 
 ## Numeric Safety
 
@@ -86,8 +86,8 @@ Use conventional commit prefixes: `feat:`, `fix:`, `perf:`.
 ## WGSL Safety
 
 - `select()` evaluates all arguments before choosing — guard divisions with `max(denominator, epsilon)` instead of relying on the condition to skip them.
-- Use `storageBarrier()` (not `workgroupBarrier()`) to synchronize reads/writes to `var<storage>` buffers within a workgroup.
-- Early-return in a workgroup shader does not exempt an invocation from barrier participation — restructure control flow to ensure all invocations reach each barrier.
+- When synchronizing reads/writes to `var<storage>` buffers within a workgroup, use `storageBarrier()` together with `workgroupBarrier()` when you need both memory visibility and execution synchronization.
+- Early-return in a workgroup shader is only safe when the return condition is uniform across the entire workgroup and occurs before the first barrier; otherwise, restructure control flow to ensure all invocations reach each barrier.
 - When removing or renaming a constant or function in a shared WGSL header, grep all shaders that concatenate that header to verify no dangling references.
 
 ## Async Readback
@@ -113,7 +113,7 @@ Use conventional commit prefixes: `feat:`, `fix:`, `perf:`.
 
 - Per-tick simulation logic belongs in WGSL shaders, never in Rust.
 - The CPU main loop submits GPU dispatches (batched) and collects async readback results (non-blocking).
-- No CPU-side work should scale with `ticks_to_run` — up to 64,000 ticks may be scheduled per frame/batch call, with GPU work dispatched in chunks.
+- No CPU-side work should scale with `ticks_to_run` — the sandbox loop dispatches GPU work in chunks of at most 500 ticks per frame/batch call, while the internal accumulated tick budget may grow up to 64,000.
 - Never clone large collections in per-frame hot paths. Use `clone_from()` for in-place updates or borrow patterns. A throttled rebuild is useless if you deep-clone every frame.
 - Use squared-distance comparisons to avoid `sqrt()` in loops. Both CPU and GPU code should use `_SQ` variants for radius checks.
 - Only mark throttle windows as consumed when work actually happens. Updating `last_rebuild` without rebuilding silently wastes the throttle budget.
@@ -135,7 +135,7 @@ Use conventional commit prefixes: `feat:`, `fix:`, `perf:`.
 
 ## CI Discipline
 
-- Benchmark and release-profile steps should not run on every push — gate them on `workflow_dispatch` or schedule triggers.
+- Benchmark and release-profile steps should generally be gated on `workflow_dispatch` or schedule triggers; running them on pushes to `develop` is acceptable when they are intentionally non-blocking CI signal.
 - Clippy must lint `--all-targets` to catch issues in tests, benches, and examples.
 
 ## Incremental Cleanup

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ The simulation's throughput depends on keeping per-tick work on the GPU. These r
 
 ## 12. Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full set of code style, naming, GPU/buffer safety, concurrency, performance, and testing rules.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full set of code style, naming, GPU/buffer safety, concurrency, performance, testing, and related rules.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -516,41 +516,9 @@ The simulation's throughput depends on keeping per-tick work on the GPU. These r
 
 ---
 
-## 12. Contributing Guidelines
+## 12. Contributing
 
-These rules are distilled from 88 review comments across PRs #33–#49. They represent the project's hard-won invariants.
-
-### GPU & Buffer Safety
-- **All buffer offsets must derive from `BrainLayout` / kernel config, never hardcoded constants.** Hardcoded strides like `SENSORY_STRIDE` break when `BrainLayout` uses non-default vision dimensions.
-- **Validate index and count inputs against kernel state before computing buffer offsets.** Out-of-bounds offsets trigger wgpu validation errors or silent corruption.
-- **Constants shared between Rust and WGSL must have a single canonical source within a given shader pipeline / concatenated header set.** A pipeline may use either the `wgsl_physics_constants()` template or the `wconfig` uniform buffer for a given constant, but do not define the same constant from both sources when headers are combined. Use named constants, not magic indices (e.g., `WC_FOOD_RADIUS`, not `wc(7u)`).
-
-### Async Readback
-- **Track in-flight state explicitly.** Never overwrite a pending `map_async` operation without unmapping/cleaning up the previous one first.
-- **Always handle both success and failure paths.** If any `map_async` callback fails, the system must clean up and allow retry — "stuck forever" states are bugs.
-- **Establish data authority.** When physics readback and telemetry readback both provide the same field, document which is authoritative and never overwrite fresher data with stale async results.
-- **Unmap staging buffers on all paths:** success, error, agent switch, and generation reset.
-
-### Concurrency
-- **All SQLite connections must set `busy_timeout`.** The default is 0 (instant `SQLITE_BUSY` failure). Both main and background connections need matching timeout policies.
-- **Background threads must have a deterministic shutdown path.** Drop sender → `recv` returns `Disconnected` → thread exits. `Drop` impls must join threads and log any panics.
-- **Return `Result` or `Option` from fallible operations.** Never use `.expect()` for I/O, GPU, or thread operations. Silent failures are worse than explicit errors.
-
-### Performance
-- **Never clone large collections in per-frame hot paths.** Use `clone_from()` for in-place updates or borrow patterns. A throttled rebuild is useless if you deep-clone every frame.
-- **Use squared-distance comparisons to avoid `sqrt()` in loops.** Both CPU and GPU code should use `_SQ` variants for radius checks.
-- **Only mark throttle windows as consumed when work actually happens.** Updating `last_rebuild` without rebuilding silently wastes the throttle budget.
-
-### Documentation & Naming
-- **Docstrings must match implementation.** "Non-blocking" means non-blocking, "pre-allocates" means pre-allocates. Rename functions when behavior changes (e.g., `read_agent_telemetry` → `read_agent_telemetry_blocking`).
-- **Distinguish "start operation" from "poll/collect operation" in API naming.** A function that both starts and polls should document that clearly.
-- **Keep PR descriptions synchronized with code.** Constant values, radius sizes, and architectural claims must reflect what the code actually does.
-- **No commented-out code or tombstone comments.** Delete removed code completely — don't comment it out or leave comments describing code that no longer exists. The git history preserves everything.
-
-### Testing
-- **New concurrency-sensitive code paths require end-to-end tests** exercising the async lifecycle: request → complete → consume, and request → fail → cleanup.
-- **Cache invalidation must be tested:** populate → invalidate → verify fresh data returned.
-- **Non-trivial algorithms need unit tests** with representative inputs and boundary conditions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full set of code style, naming, GPU/buffer safety, concurrency, performance, and testing rules.
 
 ---
 


### PR DESCRIPTION
## Summary
- Merged README section 12 (Contributing Guidelines) and CLAUDE.md rule sections into a single authoritative CONTRIBUTING.md
- Added new rules derived from analysis of 305 Copilot review comments across PRs #1–#100: WGSL safety, numeric safety, state invariants, serialization compatibility, CI discipline, and logging
- Strengthened existing rules for documentation accuracy, test quality, and dead code
- README section 12 now points to CONTRIBUTING.md
- CLAUDE.md references CONTRIBUTING.md as the single source of truth instead of duplicating rules

## Test plan
- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify README link to CONTRIBUTING.md resolves
- [ ] Verify CLAUDE.md directive is picked up by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)