### PR TITLE
feat: circling investigation foundation — klinotaxis, memory, naming, movement

### DIFF
--- a/EVOLUTION_JOURNEY.md
+++ b/EVOLUTION_JOURNEY.md
@@ -236,7 +236,7 @@ Agents discover everything through experience. No behavior is hardcoded. The onl
 
 10. **REINFORCE feedback loop on turn weights.** Credit assignment used the full motor value (`policy + noise`) for weight updates. Any small turn bias got amplified: positive turn bias → `recorded_turn` biased positive → positive credit × positive turn → bias grows. Fixed: store exploration noise in credit history, not full motor. Noise is zero-mean, breaking the feedback loop.
 
-11. **Memory blend injected stale motor bias.** Recalled memories blended stored motor values (now noise) directly into the policy. Surviving food-event memories had fixed random noise values that created a persistent turn injection. Fixed: removed memory motor blend — memory contributes through recall scoring only.
+11. **Memory blend injected stale motor bias.** Recalled memories blended stored motor values (originally noise) directly into the policy. Surviving food-event memories had fixed random noise values that created a persistent turn injection. Fixed: replaced the old direct noise-injection blend with a constrained valence-weighted memory blend using actual motor commands. Memory now stores real approach actions and recall uses valence sign to produce escape (negative valence negates the approach direction).
 
 12. **Random walk in weight space.** Even with noise-only credit, each food/hazard event added a random-direction vector to action weights. After ~50 events, the accumulated drift produced a detectable turn bias. Weight decay (`ACTION_WEIGHT_DECAY=0.01`) prevents unbounded drift. The drift-vs-decay equilibrium keeps bias below noise level.
 

--- a/EVOLUTION_JOURNEY.md
+++ b/EVOLUTION_JOURNEY.md
@@ -259,15 +259,13 @@ Agents discover everything through experience. No behavior is hardcoded. The onl
 
 Our agents had the gradient signal (homeostatic fast EMA) but never used it for movement modulation. The exploration rate was based on policy confidence, novelty, and curiosity — none of which carried gradient-direction information.
 
-**Fix:** Added `KLINOTAXIS_SENSITIVITY=100.0` to the exploration rate computation. The fast gradient (`gradient_fast`) modulates exploration:
+**Fix:** Added `KLINOTAXIS_SENSITIVITY=500.0` scaling the final turn motor output. Klinotaxis uses the fast-vs-medium gradient deviation to modulate steering:
 
-- Gradient improving (approaching food, leaving danger) → exploration decreases → agent goes straighter → persists in the improving direction
-- Gradient worsening (entering danger, starving) → exploration increases → agent turns more → changes direction
+- Gradient worsening suddenly (fast drops below medium) → turn amplitude amplified up to 3× → agent reorients
+- Gradient stabilizing after worsening (fast recovers, medium still shifted) → turn amplitude suppressed to 0.3× → agent goes straight → escapes
+- Gradient improving (food eaten) → turn suppressed → agent persists in the rewarding direction
 
-This requires zero learning — it's a reactive feedback loop. Expected behaviors:
-- Hazard avoidance: enter danger → gradient worsens → turn more → exit → gradient improves → go straight → escape
-- Post-food persistence: eat food → gradient spikes positive → go straight → continue in food-rich area
-- Starvation response: prolonged energy drain → gradient worsens → explore more → find new area
+This produces the biological escape sequence: brief reorientation burst then straight-line flight. It requires zero learning — it's a reactive feedback loop driven by multi-timescale gradient comparison.
 
 Learning (credit assignment) then builds on this reactive foundation, associating specific visual patterns with gradient predictions.
 

--- a/EVOLUTION_JOURNEY.md
+++ b/EVOLUTION_JOURNEY.md
@@ -208,6 +208,71 @@ Agents discover everything through experience. No behavior is hardcoded. The onl
 
 **Lesson:** CPU↔GPU coordination overhead dominates at high tick rates. The simulation math was already fast — the bottleneck was 11–19 dispatches per tick, per-tick uniform writes, and blocking readback. Fusing passes and batching cycles eliminated the coordination cost. Also: when composing shaders from fragments, marker-based string replacement is fragile — every code path that uses the markers must be tested with subgroups both enabled and disabled.
 
+### 19. The Circling Investigation (Issue #13)
+
+**Symptom:** After thousands of iterations, agents ran in persistent circles instead of developing food-seeking or danger-avoidance behavior.
+
+**Investigation:** Deep analysis of the credit assignment pipeline, homeostatic gradient system, and motor output chain revealed a cascade of independent failures. Four sub-issues (#14–#17) were already closed with fixes for depth in features, habituation silencing memory, credit assignment freeze, and memory blend freeze — but agents still circled.
+
+**Root causes found and fixed (PRs #87–#100):**
+
+1. **Tonic credit too weak (#87, #88).** `TONIC_CREDIT_SCALE=0.1` made the tonic fallback fall below `DEADZONE=0.01` in all realistic scenarios. Credit only fired during brief gradient transitions (~5 ticks per food event), leaving 95%+ of simulation time with zero learning. Fixed: `TONIC_CREDIT_SCALE=0.5`, `DEADZONE=0.005`, tonic bypasses DEADZONE.
+
+2. **Policy evaluated in attenuated space (#89, #100).** Credit trained weights against `s_encoded` (full strength) but the policy read `s_habituated` (attenuated 10× by habituation floor 0.1). SNR was 0.25 — noise dominated 4:1. Fixed: policy reads `s_encoded` directly.
+
+3. **Credit assignment serialized on thread 0 (#96).** After enabling tonic credit, the credit loop processed ~60 of 64 history entries instead of ~4, causing a 15× workload increase on thread 0 while 255 threads waited. Max TPS dropped from 45k to 15k. Fixed: two-phase cooperative credit — thread 0 computes scalar credits, threads 0–31 update weights in parallel.
+
+4. **Zero-gradient trap (#97).** Storing pre-noise policy output in credit history meant `rec_forward = tanh(0) = 0` with zero-init weights, making all weight updates exactly zero. Fixed: store post-noise motor — the noise IS the REINFORCE exploration signal.
+
+5. **Exploration noise scaled by habituation (#99).** Noise amplitude of ±0.0125 (with mean_atten=0.1) produced near-zero motor commands, a second death spiral. Fixed: constant noise amplitude independent of habituation.
+
+6. **Energy economics rewarded inertia (#98).** At `energy_depletion_rate=0.01`, agents survived full generations eating ~3 food items passively. Evolution drove `movement_speed` from 14.3→2.0 over 300 generations, selecting for immobility. Fixed: drain 3× higher (0.03), movement_speed floor raised to 20.
+
+7. **Prospective blending dampened policy (#100).** Predictor targeted habituated space but policy evaluated in encoded space. Scale mismatch made `(fwd_future - fwd) ≈ -0.9 × fwd`, systematically dampening the policy by ~45%. Fixed: removed prospective blending until predictor is retrained.
+
+8. **Correlated noise seeds.** Forward noise at tick T+1 used the same seed as turn noise at tick T (`seed_base + 1`), creating identical values — a deterministic spiral. Fixed: independent hash-based seeds (`pcg_hash(agent_id ^ (tick * 747796405))` with double-hash for turn).
+
+9. **Tick-0 gradient spike imprinted random turn bias.** `prev_energy` initialized to 0.0 while sensory buffer was also 0.0 (vision hadn't run yet). On tick 1, energy jumped 0→1.0, creating a massive fake gradient that credited whatever random noise the agent had. Fixed: clamp homeostatic deltas to `MAX_HOMEOSTATIC_DELTA=0.3` — no real gameplay event exceeds this.
+
+10. **REINFORCE feedback loop on turn weights.** Credit assignment used the full motor value (`policy + noise`) for weight updates. Any small turn bias got amplified: positive turn bias → `recorded_turn` biased positive → positive credit × positive turn → bias grows. Fixed: store exploration noise in credit history, not full motor. Noise is zero-mean, breaking the feedback loop.
+
+11. **Memory blend injected stale motor bias.** Recalled memories blended stored motor values (now noise) directly into the policy. Surviving food-event memories had fixed random noise values that created a persistent turn injection. Fixed: removed memory motor blend — memory contributes through recall scoring only.
+
+12. **Random walk in weight space.** Even with noise-only credit, each food/hazard event added a random-direction vector to action weights. After ~50 events, the accumulated drift produced a detectable turn bias. Weight decay (`ACTION_WEIGHT_DECAY=0.01`) prevents unbounded drift. The drift-vs-decay equilibrium keeps bias below noise level.
+
+13. **Forward bias for exploration.** With zero turn AND zero forward policy, agents random-walked in place (50% of steps backward, canceling forward progress). Added `INITIAL_FORWARD_BIAS=0.3` so agents default to moving forward. Learning adjusts turn direction; the forward drive provides the mobility for exploration.
+
+14. **Boundary trapping.** Forward bias drove agents to world edges where position clamping absorbed forward motion. Fixed: bounce reflection (yaw reflected on wall contact, velocity component reversed).
+
+**Lesson:** Circling had 14 independent causes that compounded. No single fix was sufficient. The investigation required systematic elimination: zeroing turn weights confirmed the bias was learned (not mechanical), which pointed to the credit assignment feedback loop, which led to the noise-only credit fix, which revealed the random drift, which led to weight decay. Each fix exposed the next layer.
+
+### 20. Klinotaxis — The Missing Reactive Layer
+
+**Symptom:** After fixing all circling causes, agents wandered naturally but showed zero deliberate behavior. No food-seeking, no danger-avoidance, flat fitness across 21 generations. Food-per-death of 0.87 was consistent with random bumping.
+
+**Root cause:** The REINFORCE credit assignment can't learn spatial responses because: (A) the credit window (7 ticks at CREDIT_DECAY=0.3) is shorter than the time to reach visible food (~30 ticks), so the causal turn is outside the window when food is eaten; (B) the random encoder destroys spatial information, making "food left" and "food right" produce nearly identical encoded states.
+
+**Insight from biology:** We skipped the two simplest spatial navigation strategies that evolution developed billions of years before directional steering:
+
+- **Klinokinesis** (bacteria): modulate turning rate based on stimulus intensity. No direction sense needed.
+- **Klinotaxis** (C. elegans, 302 neurons): compare current gradient with recent past. Improving → go straight. Worsening → turn. Produces directed approach/avoidance through temporal comparison alone.
+
+Our agents had the gradient signal (homeostatic fast EMA) but never used it for movement modulation. The exploration rate was based on policy confidence, novelty, and curiosity — none of which carried gradient-direction information.
+
+**Fix:** Added `KLINOTAXIS_SENSITIVITY=100.0` to the exploration rate computation. The fast gradient (`gradient_fast`) modulates exploration:
+
+- Gradient improving (approaching food, leaving danger) → exploration decreases → agent goes straighter → persists in the improving direction
+- Gradient worsening (entering danger, starving) → exploration increases → agent turns more → changes direction
+
+This requires zero learning — it's a reactive feedback loop. Expected behaviors:
+- Hazard avoidance: enter danger → gradient worsens → turn more → exit → gradient improves → go straight → escape
+- Post-food persistence: eat food → gradient spikes positive → go straight → continue in food-rich area
+- Starvation response: prolonged energy drain → gradient worsens → explore more → find new area
+
+Learning (credit assignment) then builds on this reactive foundation, associating specific visual patterns with gradient predictions.
+
+**Lesson:** Before asking "why can't agents learn to seek food?" ask "do agents have the reactive machinery to seek ANYTHING?" The simplest organisms don't learn to navigate — they navigate reactively and learn to refine. We were trying to learn level-3 behavior (spatial steering) without implementing level-1 (klinokinesis/klinotaxis).
+
 ---
 
 ## The Disconnect (Current State)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This is the **only** evaluative signal. There is no reward function.
 |---|---|
 | `memory_capacity` | Finite pattern storage → forced forgetting → what survives = what matters |
 | `processing_slots` | Limited recall per tick → forced prioritization → attention-like behavior |
-| `representation_dim` | Fixed encoding size → forced compression → abstraction |
+| `representation_dimension` | Fixed encoding size → forced compression → abstraction |
 
 See the [brain crate README](crates/xagent-brain/README.md) for a deep dive into each component.
 
@@ -262,7 +262,7 @@ Camera controls (drag, scroll) are routed to the 3D viewport only when the point
 
 ### Brain Presets
 
-| Preset | `memory_capacity` | `processing_slots` | `visual_encoding_size` | `representation_dim` | `learning_rate` | `decay_rate` | `distress_exponent` | `habituation_sensitivity` | `max_curiosity_bonus` | `fatigue_recovery_sensitivity` | `fatigue_floor` |
+| Preset | `memory_capacity` | `processing_slots` | `visual_encoding_size` | `representation_dimension` | `learning_rate` | `decay_rate` | `distress_exponent` | `habituation_sensitivity` | `max_curiosity_bonus` | `fatigue_recovery_sensitivity` | `fatigue_floor` |
 |--------|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | **tiny** | 24 | 8 | 32 | 16 | 0.08 | 0.002 | 2.0 | 20.0 | 0.6 | 8.0 | 0.1 |
 | **default** | 128 | 16 | 64 | 32 | 0.05 | 0.001 | 2.0 | 20.0 | 0.6 | 8.0 | 0.1 |
@@ -275,7 +275,7 @@ Camera controls (drag, scroll) are routed to the 3D viewport only when the point
 | `memory_capacity` | Max stored patterns. Smaller → faster forgetting, stronger capacity pressure. |
 | `processing_slots` | Max recall operations per tick. Smaller → narrower attention. |
 | `visual_encoding_size` | Resolution of visual encoding (average-pooled bins). Smaller → coarser visual perception. |
-| `representation_dim` | Internal representation vector length. Fixed across generations (not evolved) to preserve weight inheritance. Smaller → more compression, more abstraction. |
+| `representation_dimension` | Internal representation vector length. Fixed across generations (not evolved) to preserve weight inheritance. Smaller → more compression, more abstraction. |
 | `learning_rate` | Base rate for weight updates (encoder, predictor, memory). Higher → faster adaptation but less stability. |
 | `decay_rate` | Rate of memory decay per tick. Higher → more aggressive forgetting, favoring recent experience. |
 | `distress_exponent` | Distress curve shape (default 2.0). Higher → calm longer, panic harder at critical levels. Heritable. |
@@ -307,7 +307,7 @@ Additional world parameters: `world_size` (default 256), `integrity_regen_rate` 
     "memory_capacity": 128,
     "processing_slots": 16,
     "visual_encoding_size": 64,
-    "representation_dim": 32,
+    "representation_dimension": 128,
     "learning_rate": 0.05,
     "decay_rate": 0.001,
     "distress_exponent": 2.0,

--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ Camera controls (drag, scroll) are routed to the 3D viewport only when the point
 | `vision_rays` | Number of vision rays, W×H (default 48 = 8×6). Affects sensory buffer size. |
 | `brain_tick_stride` | Physics ticks per brain+vision cycle (default 4). Higher → faster but less responsive. |
 | `vision_stride` | Brain cycles between global passes — grid rebuild, collisions, vision (default 10). Higher → more brain throughput, less frequent vision updates. |
-| `metabolic_rate` | Multiplier for all energy costs (default 1.0). Lower → agents survive longer. |
-| `integrity_scale` | Multiplier for integrity damage and regen (default 1.0). Higher → deadlier hazards. |
+| `metabolic_rate` | Multiplier for all energy costs (default 0.5). Lower → agents survive longer. |
+| `integrity_scale` | Multiplier for integrity damage and regen (default 0.5). Higher → deadlier hazards. |
 
 ### World Presets
 
@@ -318,8 +318,8 @@ Additional world parameters: `world_size` (default 256), `integrity_regen_rate` 
     "vision_rays": 48,
     "brain_tick_stride": 4,
     "vision_stride": 10,
-    "metabolic_rate": 1.0,
-    "integrity_scale": 1.0
+    "metabolic_rate": 0.5,
+    "integrity_scale": 0.5
   },
   "world": {
     "world_size": 256.0,

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -18,7 +18,7 @@ pub const PREDICTOR_DIMENSION: usize = ENCODED_DIMENSION;
 /// Used to compute default brain state offsets (`O_ENC_BIASES`),
 /// `FEATURES_STRIDE`, and `FIXED_TAIL_SIZE`.
 /// For other vision dimensions, use `BrainLayout::feature_count`.
-const FEATURE_COUNT: usize = 8 * 6 * 4 + 8 * 6 + 25; // 265
+const FEATURE_COUNT: usize = 8 * 6 * 4 + 8 * 6 + 25;
 pub const MEMORY_CAP: usize = 128;
 pub const RECALL_K: usize = 16;
 pub const ACTION_HISTORY_LEN: usize = 64;
@@ -40,68 +40,68 @@ pub const NON_VISUAL_COUNT: usize = 3 + 3 + 1 + 1 + 1 + 1 + 1 + MAX_TOUCH_CONTAC
 // `O_FOO - O_PREDICTOR_CONTEXT_WEIGHT` is the same regardless of vision size.
 
 pub const O_ENC_WEIGHTS: usize = 0;
-pub const O_ENC_BIASES: usize = O_ENC_WEIGHTS + FEATURE_COUNT * ENCODED_DIMENSION; // 8480
-pub const O_PREDICTOR_WEIGHTS: usize = O_ENC_BIASES + ENCODED_DIMENSION; // 8512
+pub const O_ENC_BIASES: usize = O_ENC_WEIGHTS + FEATURE_COUNT * ENCODED_DIMENSION;
+pub const O_PREDICTOR_WEIGHTS: usize = O_ENC_BIASES + ENCODED_DIMENSION;
 pub const O_PREDICTOR_CONTEXT_WEIGHT: usize =
     O_PREDICTOR_WEIGHTS + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
-pub const O_PREDICTION_ERROR_RING: usize = O_PREDICTOR_CONTEXT_WEIGHT + 1; // 9537
-pub const O_PREDICTION_ERROR_CURSOR: usize = O_PREDICTION_ERROR_RING + ERROR_HISTORY_LEN; // 9665
-pub const O_PREDICTION_ERROR_COUNT: usize = O_PREDICTION_ERROR_CURSOR + 1; // 9666
-pub const O_HAB_EMA: usize = O_PREDICTION_ERROR_COUNT + 1; // 9667
-pub const O_HAB_ATTEN: usize = O_HAB_EMA + ENCODED_DIMENSION; // 9699
-pub const O_PREV_ENCODED: usize = O_HAB_ATTEN + ENCODED_DIMENSION; // 9731
+pub const O_PREDICTION_ERROR_RING: usize = O_PREDICTOR_CONTEXT_WEIGHT + 1;
+pub const O_PREDICTION_ERROR_CURSOR: usize = O_PREDICTION_ERROR_RING + ERROR_HISTORY_LEN;
+pub const O_PREDICTION_ERROR_COUNT: usize = O_PREDICTION_ERROR_CURSOR + 1;
+pub const O_HAB_EMA: usize = O_PREDICTION_ERROR_COUNT + 1;
+pub const O_HAB_ATTEN: usize = O_HAB_EMA + ENCODED_DIMENSION;
+pub const O_PREV_ENCODED: usize = O_HAB_ATTEN + ENCODED_DIMENSION;
 
 // homeo: [grad_fast, grad_med, grad_slow, urgency, prev_energy, prev_integrity]
-pub const O_HOMEO: usize = O_PREV_ENCODED + ENCODED_DIMENSION; // 9763
-pub const O_ACTION_FORWARD_WEIGHTS: usize = O_HOMEO + 6; // 9769
-pub const O_ACTION_TURN_WEIGHTS: usize = O_ACTION_FORWARD_WEIGHTS + ENCODED_DIMENSION; // 9801
+pub const O_HOMEO: usize = O_PREV_ENCODED + ENCODED_DIMENSION;
+pub const O_ACTION_FORWARD_WEIGHTS: usize = O_HOMEO + 6;
+pub const O_ACTION_TURN_WEIGHTS: usize = O_ACTION_FORWARD_WEIGHTS + ENCODED_DIMENSION;
 
 // act_biases: [fwd_bias, turn_bias]
-pub const O_ACT_BIASES: usize = O_ACTION_TURN_WEIGHTS + ENCODED_DIMENSION; // 9833
-pub const O_EXPLORATION_RATE: usize = O_ACT_BIASES + 2; // 9835
+pub const O_ACT_BIASES: usize = O_ACTION_TURN_WEIGHTS + ENCODED_DIMENSION;
+pub const O_EXPLORATION_RATE: usize = O_ACT_BIASES + 2;
 pub const POS_RING_LEN: usize = 16;
-pub const O_POS_RING_X: usize = O_EXPLORATION_RATE + 1; // 9836
-pub const O_POS_RING_Z: usize = O_POS_RING_X + POS_RING_LEN; // 9852
-pub const O_POS_RING_CURSOR: usize = O_POS_RING_Z + POS_RING_LEN; // 9868
-pub const O_POS_RING_LEN: usize = O_POS_RING_CURSOR + 1; // 9869
-pub const O_ACCUM_FWD: usize = O_POS_RING_LEN + 1; // 9870
-pub const O_FATIGUE_FACTOR: usize = O_ACCUM_FWD + 1; // 9871
-pub const O_PREV_PREDICTION: usize = O_FATIGUE_FACTOR + 1; // 9872
+pub const O_POS_RING_X: usize = O_EXPLORATION_RATE + 1;
+pub const O_POS_RING_Z: usize = O_POS_RING_X + POS_RING_LEN;
+pub const O_POS_RING_CURSOR: usize = O_POS_RING_Z + POS_RING_LEN;
+pub const O_POS_RING_LEN: usize = O_POS_RING_CURSOR + 1;
+pub const O_ACCUM_FWD: usize = O_POS_RING_LEN + 1;
+pub const O_FATIGUE_FACTOR: usize = O_ACCUM_FWD + 1;
+pub const O_PREV_PREDICTION: usize = O_FATIGUE_FACTOR + 1;
 pub const O_TICK_COUNT: usize = O_PREV_PREDICTION + PREDICTOR_DIMENSION;
-pub const O_HAB_SENSITIVITY: usize = O_TICK_COUNT + 1; // 9905
-pub const O_HAB_MAX_CURIOSITY: usize = O_HAB_SENSITIVITY + 1; // 9906
-pub const O_FATIGUE_FLOOR: usize = O_HAB_MAX_CURIOSITY + 1; // 9907
-pub const O_MOVEMENT_SPEED: usize = O_FATIGUE_FLOOR + 1; // 9908
-pub const BRAIN_STRIDE: usize = O_MOVEMENT_SPEED + 1; // 9909
+pub const O_HAB_SENSITIVITY: usize = O_TICK_COUNT + 1;
+pub const O_HAB_MAX_CURIOSITY: usize = O_HAB_SENSITIVITY + 1;
+pub const O_FATIGUE_FLOOR: usize = O_HAB_MAX_CURIOSITY + 1;
+pub const O_MOVEMENT_SPEED: usize = O_FATIGUE_FLOOR + 1;
+pub const BRAIN_STRIDE: usize = O_MOVEMENT_SPEED + 1;
 
 /// Number of elements in `brain_state` from `O_PREDICTOR_CONTEXT_WEIGHT` (inclusive)
 /// to `BRAIN_STRIDE` (exclusive). This tail is layout-independent: it
 /// doesn't change with feature_count / vision dimensions.
-pub const FIXED_TAIL_SIZE: usize = BRAIN_STRIDE - O_PREDICTOR_CONTEXT_WEIGHT; // 373
+pub const FIXED_TAIL_SIZE: usize = BRAIN_STRIDE - O_PREDICTOR_CONTEXT_WEIGHT;
 
 // ── Pattern memory buffer offsets (per agent) ─────────────────────────
 
 pub const O_PAT_STATES: usize = 0;
-pub const O_PAT_NORMS: usize = O_PAT_STATES + MEMORY_CAP * ENCODED_DIMENSION; // 4096
-pub const O_PAT_REINF: usize = O_PAT_NORMS + MEMORY_CAP; // 4224
-pub const O_PAT_MOTOR: usize = O_PAT_REINF + MEMORY_CAP; // 4352
-                                                         // motor: [forward, turn, outcome_valence] × cap
-pub const O_PAT_META: usize = O_PAT_MOTOR + MEMORY_CAP * 3; // 4736
-                                                            // meta: [created_at, last_accessed, activation_count] × cap
-pub const O_PAT_ACTIVE: usize = O_PAT_META + MEMORY_CAP * 3; // 5120
-pub const O_ACTIVE_COUNT: usize = O_PAT_ACTIVE + MEMORY_CAP; // 5248
-pub const O_MIN_REINF_IDX: usize = O_ACTIVE_COUNT + 1; // 5249
-pub const O_LAST_STORED_IDX: usize = O_MIN_REINF_IDX + 1; // 5250
-pub const PATTERN_STRIDE: usize = O_LAST_STORED_IDX + 1; // 5251
+pub const O_PAT_NORMS: usize = O_PAT_STATES + MEMORY_CAP * ENCODED_DIMENSION;
+pub const O_PAT_REINF: usize = O_PAT_NORMS + MEMORY_CAP;
+pub const O_PAT_MOTOR: usize = O_PAT_REINF + MEMORY_CAP;
+// motor: [forward, turn, outcome_valence] × cap
+pub const O_PAT_META: usize = O_PAT_MOTOR + MEMORY_CAP * 3;
+// meta: [created_at, last_accessed, activation_count] × cap
+pub const O_PAT_ACTIVE: usize = O_PAT_META + MEMORY_CAP * 3;
+pub const O_ACTIVE_COUNT: usize = O_PAT_ACTIVE + MEMORY_CAP;
+pub const O_MIN_REINF_IDX: usize = O_ACTIVE_COUNT + 1;
+pub const O_LAST_STORED_IDX: usize = O_MIN_REINF_IDX + 1;
+pub const PATTERN_STRIDE: usize = O_LAST_STORED_IDX + 1;
 
 // ── Action history buffer offsets (per agent) ─────────────────────────
 
 pub const O_MOTOR_RING: usize = 0;
 // motor_ring: [forward, turn, tick, gradient, _pad] × ACTION_HISTORY_LEN
-pub const O_STATE_RING: usize = O_MOTOR_RING + ACTION_HISTORY_LEN * 5; // 320
-pub const O_HIST_CURSOR: usize = O_STATE_RING + ACTION_HISTORY_LEN * ENCODED_DIMENSION; // 2368
-pub const O_HIST_LEN: usize = O_HIST_CURSOR + 1; // 2369
-pub const HISTORY_STRIDE: usize = O_HIST_LEN + 1; // 2370
+pub const O_STATE_RING: usize = O_MOTOR_RING + ACTION_HISTORY_LEN * 5;
+pub const O_HIST_CURSOR: usize = O_STATE_RING + ACTION_HISTORY_LEN * ENCODED_DIMENSION;
+pub const O_HIST_LEN: usize = O_HIST_CURSOR + 1;
+pub const HISTORY_STRIDE: usize = O_HIST_LEN + 1;
 
 // ── Agent physics buffer layout (per agent, GPU-resident) ─────────────
 
@@ -210,9 +210,9 @@ pub const FOOD_STATE_STRIDE: usize = 4;
 
 pub const GRID_CELL_SIZE: f32 = 8.0;
 pub const FOOD_GRID_MAX_PER_CELL: usize = 16;
-pub const FOOD_GRID_CELL_STRIDE: usize = 1 + FOOD_GRID_MAX_PER_CELL; // 17
+pub const FOOD_GRID_CELL_STRIDE: usize = 1 + FOOD_GRID_MAX_PER_CELL;
 pub const AGENT_GRID_MAX_PER_CELL: usize = 32;
-pub const AGENT_GRID_CELL_STRIDE: usize = 1 + AGENT_GRID_MAX_PER_CELL; // 33
+pub const AGENT_GRID_CELL_STRIDE: usize = 1 + AGENT_GRID_MAX_PER_CELL;
 
 /// Compute grid width (cells per axis) for a given world size.
 pub fn grid_width(world_size: f32) -> usize {
@@ -249,11 +249,11 @@ pub const WORLD_CONFIG_SIZE: usize = 24; // padded to 6 × vec4
 
 // ── Transient buffer sizes (per agent) ────────────────────────────────
 
-pub const FEATURES_STRIDE: usize = FEATURE_COUNT; // 265
-pub const ENCODED_STRIDE: usize = ENCODED_DIMENSION; // 32
-pub const HABITUATED_STRIDE: usize = ENCODED_DIMENSION; // 32
+pub const FEATURES_STRIDE: usize = FEATURE_COUNT;
+pub const ENCODED_STRIDE: usize = ENCODED_DIMENSION;
+pub const HABITUATED_STRIDE: usize = ENCODED_DIMENSION;
 pub const HOMEO_OUT_STRIDE: usize = 6; // grad, raw_grad, urgency, grad_fast, grad_med, grad_slow
-pub const SIMILARITIES_STRIDE: usize = MEMORY_CAP; // 128
+pub const SIMILARITIES_STRIDE: usize = MEMORY_CAP;
 pub const RECALL_IDX_STRIDE: usize = RECALL_K + 1; // 16 indices + 1 count
 pub const DECISION_PREDICTION: usize = 0;
 pub const DECISION_CREDIT: usize = ENCODED_DIMENSION;

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -12,7 +12,8 @@ use xagent_shared::{BrainConfig, SensoryFrame, TouchContact};
 
 // ── Dimensions ───────────────────────────────────────────────────────
 
-pub const DIM: usize = 32;
+pub const ENCODED_DIMENSION: usize = 128;
+pub const PREDICTOR_DIMENSION: usize = ENCODED_DIMENSION;
 /// Feature count for the default 8×6 vision layout.
 /// Used to compute default brain state offsets (`O_ENC_BIASES`),
 /// `FEATURES_STRIDE`, and `FIXED_TAIL_SIZE`.
@@ -21,6 +22,7 @@ const FEATURE_COUNT: usize = 8 * 6 * 4 + 8 * 6 + 25; // 265
 pub const MEMORY_CAP: usize = 128;
 pub const RECALL_K: usize = 16;
 pub const ACTION_HISTORY_LEN: usize = 64;
+pub const INITIAL_FORWARD_BIAS: f32 = 0.3;
 pub const ERROR_HISTORY_LEN: usize = 128;
 pub const MAX_TOUCH_CONTACTS: usize = 4;
 pub const TOUCH_FEATURES: usize = 4; // dir_x, dir_z, intensity, tag/4
@@ -34,27 +36,28 @@ pub const NON_VISUAL_COUNT: usize = 3 + 3 + 1 + 1 + 1 + 1 + 1 + MAX_TOUCH_CONTAC
 // ── Brain state buffer offsets (default 8×6 layout) ──────────────────
 // These constants are valid for the default vision dimensions (8×6).
 // For other dimensions, use `BrainLayout` to compute dynamic offsets.
-// The *tail* offsets (from `O_PRED_CTX_WT` onward) are vision-independent:
-// `O_FOO - O_PRED_CTX_WT` is the same regardless of vision size.
+// The *tail* offsets (from `O_PREDICTOR_CONTEXT_WEIGHT` onward) are vision-independent:
+// `O_FOO - O_PREDICTOR_CONTEXT_WEIGHT` is the same regardless of vision size.
 
 pub const O_ENC_WEIGHTS: usize = 0;
-pub const O_ENC_BIASES: usize = O_ENC_WEIGHTS + FEATURE_COUNT * DIM; // 8480
-pub const O_PRED_WEIGHTS: usize = O_ENC_BIASES + DIM; // 8512
-pub const O_PRED_CTX_WT: usize = O_PRED_WEIGHTS + DIM * DIM; // 9536
-pub const O_PRED_ERR_RING: usize = O_PRED_CTX_WT + 1; // 9537
-pub const O_PRED_ERR_CURSOR: usize = O_PRED_ERR_RING + ERROR_HISTORY_LEN; // 9665
-pub const O_PRED_ERR_COUNT: usize = O_PRED_ERR_CURSOR + 1; // 9666
-pub const O_HAB_EMA: usize = O_PRED_ERR_COUNT + 1; // 9667
-pub const O_HAB_ATTEN: usize = O_HAB_EMA + DIM; // 9699
-pub const O_PREV_ENCODED: usize = O_HAB_ATTEN + DIM; // 9731
+pub const O_ENC_BIASES: usize = O_ENC_WEIGHTS + FEATURE_COUNT * ENCODED_DIMENSION; // 8480
+pub const O_PREDICTOR_WEIGHTS: usize = O_ENC_BIASES + ENCODED_DIMENSION; // 8512
+pub const O_PREDICTOR_CONTEXT_WEIGHT: usize =
+    O_PREDICTOR_WEIGHTS + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
+pub const O_PREDICTION_ERROR_RING: usize = O_PREDICTOR_CONTEXT_WEIGHT + 1; // 9537
+pub const O_PREDICTION_ERROR_CURSOR: usize = O_PREDICTION_ERROR_RING + ERROR_HISTORY_LEN; // 9665
+pub const O_PREDICTION_ERROR_COUNT: usize = O_PREDICTION_ERROR_CURSOR + 1; // 9666
+pub const O_HAB_EMA: usize = O_PREDICTION_ERROR_COUNT + 1; // 9667
+pub const O_HAB_ATTEN: usize = O_HAB_EMA + ENCODED_DIMENSION; // 9699
+pub const O_PREV_ENCODED: usize = O_HAB_ATTEN + ENCODED_DIMENSION; // 9731
 
 // homeo: [grad_fast, grad_med, grad_slow, urgency, prev_energy, prev_integrity]
-pub const O_HOMEO: usize = O_PREV_ENCODED + DIM; // 9763
-pub const O_ACT_FWD_WTS: usize = O_HOMEO + 6; // 9769
-pub const O_ACT_TURN_WTS: usize = O_ACT_FWD_WTS + DIM; // 9801
+pub const O_HOMEO: usize = O_PREV_ENCODED + ENCODED_DIMENSION; // 9763
+pub const O_ACTION_FORWARD_WEIGHTS: usize = O_HOMEO + 6; // 9769
+pub const O_ACTION_TURN_WEIGHTS: usize = O_ACTION_FORWARD_WEIGHTS + ENCODED_DIMENSION; // 9801
 
 // act_biases: [fwd_bias, turn_bias]
-pub const O_ACT_BIASES: usize = O_ACT_TURN_WTS + DIM; // 9833
+pub const O_ACT_BIASES: usize = O_ACTION_TURN_WEIGHTS + ENCODED_DIMENSION; // 9833
 pub const O_EXPLORATION_RATE: usize = O_ACT_BIASES + 2; // 9835
 pub const POS_RING_LEN: usize = 16;
 pub const O_POS_RING_X: usize = O_EXPLORATION_RATE + 1; // 9836
@@ -64,22 +67,22 @@ pub const O_POS_RING_LEN: usize = O_POS_RING_CURSOR + 1; // 9869
 pub const O_ACCUM_FWD: usize = O_POS_RING_LEN + 1; // 9870
 pub const O_FATIGUE_FACTOR: usize = O_ACCUM_FWD + 1; // 9871
 pub const O_PREV_PREDICTION: usize = O_FATIGUE_FACTOR + 1; // 9872
-pub const O_TICK_COUNT: usize = O_PREV_PREDICTION + DIM; // 9904
+pub const O_TICK_COUNT: usize = O_PREV_PREDICTION + PREDICTOR_DIMENSION;
 pub const O_HAB_SENSITIVITY: usize = O_TICK_COUNT + 1; // 9905
 pub const O_HAB_MAX_CURIOSITY: usize = O_HAB_SENSITIVITY + 1; // 9906
 pub const O_FATIGUE_FLOOR: usize = O_HAB_MAX_CURIOSITY + 1; // 9907
 pub const O_MOVEMENT_SPEED: usize = O_FATIGUE_FLOOR + 1; // 9908
 pub const BRAIN_STRIDE: usize = O_MOVEMENT_SPEED + 1; // 9909
 
-/// Number of elements in `brain_state` from `O_PRED_CTX_WT` (inclusive)
+/// Number of elements in `brain_state` from `O_PREDICTOR_CONTEXT_WEIGHT` (inclusive)
 /// to `BRAIN_STRIDE` (exclusive). This tail is layout-independent: it
 /// doesn't change with feature_count / vision dimensions.
-pub const FIXED_TAIL_SIZE: usize = BRAIN_STRIDE - O_PRED_CTX_WT; // 373
+pub const FIXED_TAIL_SIZE: usize = BRAIN_STRIDE - O_PREDICTOR_CONTEXT_WEIGHT; // 373
 
 // ── Pattern memory buffer offsets (per agent) ─────────────────────────
 
 pub const O_PAT_STATES: usize = 0;
-pub const O_PAT_NORMS: usize = O_PAT_STATES + MEMORY_CAP * DIM; // 4096
+pub const O_PAT_NORMS: usize = O_PAT_STATES + MEMORY_CAP * ENCODED_DIMENSION; // 4096
 pub const O_PAT_REINF: usize = O_PAT_NORMS + MEMORY_CAP; // 4224
 pub const O_PAT_MOTOR: usize = O_PAT_REINF + MEMORY_CAP; // 4352
                                                          // motor: [forward, turn, outcome_valence] × cap
@@ -96,7 +99,7 @@ pub const PATTERN_STRIDE: usize = O_LAST_STORED_IDX + 1; // 5251
 pub const O_MOTOR_RING: usize = 0;
 // motor_ring: [forward, turn, tick, gradient, _pad] × ACTION_HISTORY_LEN
 pub const O_STATE_RING: usize = O_MOTOR_RING + ACTION_HISTORY_LEN * 5; // 320
-pub const O_HIST_CURSOR: usize = O_STATE_RING + ACTION_HISTORY_LEN * DIM; // 2368
+pub const O_HIST_CURSOR: usize = O_STATE_RING + ACTION_HISTORY_LEN * ENCODED_DIMENSION; // 2368
 pub const O_HIST_LEN: usize = O_HIST_CURSOR + 1; // 2369
 pub const HISTORY_STRIDE: usize = O_HIST_LEN + 1; // 2370
 
@@ -169,12 +172,12 @@ impl BrainLayout {
             .checked_add(depth_count)
             .and_then(|v| v.checked_add(NON_VISUAL_COUNT))
             .expect("vision dimensions overflow sensory stride");
-        // brain_stride = feature_count * DIM + DIM + DIM*DIM + FIXED_TAIL_SIZE
-        // (FIXED_TAIL_SIZE = fixed fields starting at O_PRED_CTX_WT through O_MOVEMENT_SPEED, incl. position ring)
+        // brain_stride = feature_count * ENCODED_DIMENSION + ENCODED_DIMENSION + ENCODED_DIMENSION*ENCODED_DIMENSION + FIXED_TAIL_SIZE
+        // (FIXED_TAIL_SIZE = fixed fields starting at O_PREDICTOR_CONTEXT_WEIGHT through O_MOVEMENT_SPEED, incl. position ring)
         let brain_stride = feature_count
-            .checked_mul(DIM)
-            .and_then(|v| v.checked_add(DIM))
-            .and_then(|v| v.checked_add(DIM * DIM))
+            .checked_mul(ENCODED_DIMENSION)
+            .and_then(|v| v.checked_add(ENCODED_DIMENSION))
+            .and_then(|v| v.checked_add(PREDICTOR_DIMENSION * ENCODED_DIMENSION))
             .and_then(|v| v.checked_add(FIXED_TAIL_SIZE))
             .expect("vision dimensions overflow brain stride");
         Self {
@@ -247,12 +250,15 @@ pub const WORLD_CONFIG_SIZE: usize = 24; // padded to 6 × vec4
 // ── Transient buffer sizes (per agent) ────────────────────────────────
 
 pub const FEATURES_STRIDE: usize = FEATURE_COUNT; // 265
-pub const ENCODED_STRIDE: usize = DIM; // 32
-pub const HABITUATED_STRIDE: usize = DIM; // 32
+pub const ENCODED_STRIDE: usize = ENCODED_DIMENSION; // 32
+pub const HABITUATED_STRIDE: usize = ENCODED_DIMENSION; // 32
 pub const HOMEO_OUT_STRIDE: usize = 6; // grad, raw_grad, urgency, grad_fast, grad_med, grad_slow
 pub const SIMILARITIES_STRIDE: usize = MEMORY_CAP; // 128
 pub const RECALL_IDX_STRIDE: usize = RECALL_K + 1; // 16 indices + 1 count
-pub const DECISION_STRIDE: usize = DIM + DIM + 4; // prediction(32) + credit(32) + motor(4) = 68
+pub const DECISION_PREDICTION: usize = 0;
+pub const DECISION_CREDIT: usize = ENCODED_DIMENSION;
+pub const DECISION_MOTOR: usize = ENCODED_DIMENSION + ENCODED_DIMENSION;
+pub const DECISION_STRIDE: usize = DECISION_MOTOR + 4;
 
 // ── Config buffer layout ──────────────────────────────────────────────
 
@@ -441,35 +447,41 @@ pub fn init_brain_state_for(
 
     // Encoder weights: Xavier init (scale = 1/sqrt(feature_count))
     let scale = 1.0 / (fc as f32).sqrt();
-    for i in 0..(fc * DIM) {
+    for i in 0..(fc * ENCODED_DIMENSION) {
         state[i] = (rng.random::<f32>() * 2.0 - 1.0) * scale;
     }
 
-    // Compute dynamic offsets: O_PRED_CTX_WT = fc*DIM + DIM + DIM*DIM
-    let o_pred_weights = fc * DIM + DIM;
-    let o_pred_ctx_wt = o_pred_weights + DIM * DIM;
+    // Compute dynamic offsets: O_PREDICTOR_CONTEXT_WEIGHT = fc*ENCODED_DIMENSION + ENCODED_DIMENSION + PREDICTOR_DIMENSION*ENCODED_DIMENSION
+    let o_pred_weights = fc * ENCODED_DIMENSION + ENCODED_DIMENSION;
+    let o_pred_ctx_wt = o_pred_weights + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
 
     // Predictor weights: small random
-    for i in 0..(DIM * DIM) {
+    for i in 0..(PREDICTOR_DIMENSION * ENCODED_DIMENSION) {
         state[o_pred_weights + i] = (rng.random::<f32>() * 2.0 - 1.0) * 0.1;
     }
 
     // Predictor context weight: 0.15
     state[o_pred_ctx_wt] = 0.15;
 
-    // Fixed deltas from O_PRED_CTX_WT (same regardless of feature_count)
-    let delta_hab_atten = O_HAB_ATTEN - O_PRED_CTX_WT;
-    let delta_exploration = O_EXPLORATION_RATE - O_PRED_CTX_WT;
-    let delta_fatigue_factor = O_FATIGUE_FACTOR - O_PRED_CTX_WT;
-    let delta_hab_sens = O_HAB_SENSITIVITY - O_PRED_CTX_WT;
-    let delta_hab_curiosity = O_HAB_MAX_CURIOSITY - O_PRED_CTX_WT;
-    let delta_fatigue_floor = O_FATIGUE_FLOOR - O_PRED_CTX_WT;
-    let delta_movement_speed = O_MOVEMENT_SPEED - O_PRED_CTX_WT;
+    // Fixed deltas from O_PREDICTOR_CONTEXT_WEIGHT (same regardless of feature_count)
+    let delta_hab_atten = O_HAB_ATTEN - O_PREDICTOR_CONTEXT_WEIGHT;
+    let delta_exploration = O_EXPLORATION_RATE - O_PREDICTOR_CONTEXT_WEIGHT;
+    let delta_fatigue_factor = O_FATIGUE_FACTOR - O_PREDICTOR_CONTEXT_WEIGHT;
+    let delta_hab_sens = O_HAB_SENSITIVITY - O_PREDICTOR_CONTEXT_WEIGHT;
+    let delta_hab_curiosity = O_HAB_MAX_CURIOSITY - O_PREDICTOR_CONTEXT_WEIGHT;
+    let delta_fatigue_floor = O_FATIGUE_FLOOR - O_PREDICTOR_CONTEXT_WEIGHT;
+    let delta_movement_speed = O_MOVEMENT_SPEED - O_PREDICTOR_CONTEXT_WEIGHT;
 
     // Habituation attenuation: 1.0 (no attenuation initially)
-    for i in 0..DIM {
+    for i in 0..ENCODED_DIMENSION {
         state[o_pred_ctx_wt + delta_hab_atten + i] = 1.0;
     }
+
+    // Forward bias: agents default to moving forward so exploration
+    // covers ground instead of random-walking in place.  Learning
+    // adjusts this via credit assignment.
+    let delta_act_biases = O_ACT_BIASES - O_PREDICTOR_CONTEXT_WEIGHT;
+    state[o_pred_ctx_wt + delta_act_biases] = INITIAL_FORWARD_BIAS;
 
     // Exploration rate: 0.5 (balanced start)
     state[o_pred_ctx_wt + delta_exploration] = 0.5;
@@ -509,7 +521,7 @@ pub fn build_config(config: &BrainConfig) -> Vec<f32> {
 /// Build config buffer values with explicit layout.
 pub fn build_config_for(config: &BrainConfig, layout: &BrainLayout) -> Vec<f32> {
     let mut cfg = vec![0.0_f32; CONFIG_SIZE];
-    cfg[CFG_REPR_DIM] = DIM as f32;
+    cfg[CFG_REPR_DIM] = ENCODED_DIMENSION as f32;
     cfg[CFG_FEATURE_COUNT] = layout.feature_count as f32;
     cfg[CFG_MEMORY_CAP] = MEMORY_CAP as f32;
     cfg[CFG_RECALL_K] = RECALL_K as f32;
@@ -604,7 +616,9 @@ mod tests {
             );
             // Verify brain_stride matches the offset chain
             let fc = layout.feature_count;
-            let o_pred_ctx_wt = fc * DIM + DIM + DIM * DIM;
+            let o_pred_ctx_wt = fc * ENCODED_DIMENSION
+                + ENCODED_DIMENSION
+                + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
             assert_eq!(layout.brain_stride, o_pred_ctx_wt + FIXED_TAIL_SIZE);
         }
     }
@@ -615,7 +629,10 @@ mod tests {
         assert_eq!(layout.vision_color_count, 32 * 24 * 4);
         assert_eq!(layout.vision_depth_count, 32 * 24);
         assert_eq!(layout.sensory_stride, 32 * 24 * 5 + NON_VISUAL_COUNT);
-        let expected = layout.feature_count * DIM + DIM + DIM * DIM + FIXED_TAIL_SIZE;
+        let expected = layout.feature_count * ENCODED_DIMENSION
+            + ENCODED_DIMENSION
+            + PREDICTOR_DIMENSION * ENCODED_DIMENSION
+            + FIXED_TAIL_SIZE;
         assert_eq!(layout.brain_stride, expected);
     }
 
@@ -721,19 +738,22 @@ mod tests {
         let mut aos_offsets = std::collections::HashSet::new();
         let mut soa_offsets = std::collections::HashSet::new();
         for pat in 0..MEMORY_CAP {
-            for d in 0..DIM {
-                aos_offsets.insert(O_PAT_STATES + pat * DIM + d);
+            for d in 0..ENCODED_DIMENSION {
+                aos_offsets.insert(O_PAT_STATES + pat * ENCODED_DIMENSION + d);
                 soa_offsets.insert(O_PAT_STATES + d * MEMORY_CAP + pat);
             }
         }
-        assert_eq!(aos_offsets.len(), MEMORY_CAP * DIM);
-        assert_eq!(soa_offsets.len(), MEMORY_CAP * DIM);
+        assert_eq!(aos_offsets.len(), MEMORY_CAP * ENCODED_DIMENSION);
+        assert_eq!(soa_offsets.len(), MEMORY_CAP * ENCODED_DIMENSION);
         assert_eq!(
             aos_offsets, soa_offsets,
             "SoA and AoS must cover identical offsets"
         );
         assert_eq!(*aos_offsets.iter().min().unwrap(), 0);
-        assert_eq!(*aos_offsets.iter().max().unwrap(), MEMORY_CAP * DIM - 1);
+        assert_eq!(
+            *aos_offsets.iter().max().unwrap(),
+            MEMORY_CAP * ENCODED_DIMENSION - 1
+        );
     }
 
     #[test]

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -1620,10 +1620,19 @@ impl GpuKernel {
         // Use dynamic base so this works with any BrainLayout, not
         // just the default FEATURE_COUNT (see init_brain_state_for).
         let tail_base = bs - FIXED_TAIL_SIZE;
-        let first_delta = O_HAB_SENSITIVITY - O_PRED_CTX_WT;
-        debug_assert_eq!(O_HAB_MAX_CURIOSITY - O_PRED_CTX_WT, first_delta + 1);
-        debug_assert_eq!(O_FATIGUE_FLOOR - O_PRED_CTX_WT, first_delta + 2);
-        debug_assert_eq!(O_MOVEMENT_SPEED - O_PRED_CTX_WT, first_delta + 3);
+        let first_delta = O_HAB_SENSITIVITY - O_PREDICTOR_CONTEXT_WEIGHT;
+        debug_assert_eq!(
+            O_HAB_MAX_CURIOSITY - O_PREDICTOR_CONTEXT_WEIGHT,
+            first_delta + 1
+        );
+        debug_assert_eq!(
+            O_FATIGUE_FLOOR - O_PREDICTOR_CONTEXT_WEIGHT,
+            first_delta + 2
+        );
+        debug_assert_eq!(
+            O_MOVEMENT_SPEED - O_PREDICTOR_CONTEXT_WEIGHT,
+            first_delta + 3
+        );
 
         let values = [
             config.habituation_sensitivity,
@@ -1996,7 +2005,7 @@ impl GpuKernel {
         let dec_size = (DECISION_STRIDE * 4) as u64;
         let mut decision = Vec::with_capacity(DECISION_STRIDE);
         self.read_buffer_range(&self.decision_buffer, dec_offset, dec_size, &mut decision);
-        let motor_base = DIM + DIM; // prediction(32) + credit(32)
+        let motor_base = DECISION_MOTOR;
         let motor_fwd = decision[motor_base];
         let motor_turn = decision[motor_base + 1];
 
@@ -2013,13 +2022,16 @@ impl GpuKernel {
         );
 
         // Compute dynamic brain-state offsets from layout's feature_count
-        let dyn_pred_ctx_wt = fc * DIM + DIM + DIM * DIM;
-        let dyn_hab_atten = dyn_pred_ctx_wt + (O_HAB_ATTEN - O_PRED_CTX_WT);
-        let dyn_fatigue_factor = dyn_pred_ctx_wt + (O_FATIGUE_FACTOR - O_PRED_CTX_WT);
-        let dyn_fatigue_floor = dyn_pred_ctx_wt + (O_FATIGUE_FLOOR - O_PRED_CTX_WT);
-        // Habituation: mean of attenuation values (DIM floats)
-        let atten_sum: f32 = brain[dyn_hab_atten..dyn_hab_atten + DIM].iter().sum();
-        let mean_attenuation = atten_sum / DIM as f32;
+        let dyn_pred_ctx_wt =
+            fc * ENCODED_DIMENSION + ENCODED_DIMENSION + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
+        let dyn_hab_atten = dyn_pred_ctx_wt + (O_HAB_ATTEN - O_PREDICTOR_CONTEXT_WEIGHT);
+        let dyn_fatigue_factor = dyn_pred_ctx_wt + (O_FATIGUE_FACTOR - O_PREDICTOR_CONTEXT_WEIGHT);
+        let dyn_fatigue_floor = dyn_pred_ctx_wt + (O_FATIGUE_FLOOR - O_PREDICTOR_CONTEXT_WEIGHT);
+        // Habituation: mean of attenuation values (ENCODED_DIMENSION floats)
+        let atten_sum: f32 = brain[dyn_hab_atten..dyn_hab_atten + ENCODED_DIMENSION]
+            .iter()
+            .sum();
+        let mean_attenuation = atten_sum / ENCODED_DIMENSION as f32;
 
         // Curiosity bonus: 1.0 - mean_attenuation (higher attenuation = less curious)
         let curiosity_bonus = (1.0 - mean_attenuation).max(0.0);
@@ -2196,12 +2208,13 @@ impl GpuKernel {
         let _pending = self.pending_telemetry.take().unwrap();
 
         // Compute dynamic brain-state offsets from layout's feature_count.
-        // All offsets past O_PRED_CTX_WT have a fixed delta from that anchor.
+        // All offsets past O_PREDICTOR_CONTEXT_WEIGHT have a fixed delta from that anchor.
         let fc = self.layout.feature_count;
-        let dyn_pred_ctx_wt = fc * DIM + DIM + DIM * DIM;
-        let dyn_hab_atten = dyn_pred_ctx_wt + (O_HAB_ATTEN - O_PRED_CTX_WT);
-        let dyn_fatigue_factor = dyn_pred_ctx_wt + (O_FATIGUE_FACTOR - O_PRED_CTX_WT);
-        let dyn_fatigue_floor = dyn_pred_ctx_wt + (O_FATIGUE_FLOOR - O_PRED_CTX_WT);
+        let dyn_pred_ctx_wt =
+            fc * ENCODED_DIMENSION + ENCODED_DIMENSION + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
+        let dyn_hab_atten = dyn_pred_ctx_wt + (O_HAB_ATTEN - O_PREDICTOR_CONTEXT_WEIGHT);
+        let dyn_fatigue_factor = dyn_pred_ctx_wt + (O_FATIGUE_FACTOR - O_PREDICTOR_CONTEXT_WEIGHT);
+        let dyn_fatigue_floor = dyn_pred_ctx_wt + (O_FATIGUE_FLOOR - O_PREDICTOR_CONTEXT_WEIGHT);
         // Sensory
         let sensory_data = self.telemetry_staging.sensory.slice(..).get_mapped_range();
         let sensory: &[f32] = bytemuck::cast_slice(&sensory_data);
@@ -2212,7 +2225,7 @@ impl GpuKernel {
         // Decision
         let decision_data = self.telemetry_staging.decision.slice(..).get_mapped_range();
         let decision: &[f32] = bytemuck::cast_slice(&decision_data);
-        let motor_base = DIM + DIM;
+        let motor_base = ENCODED_DIMENSION + ENCODED_DIMENSION;
         let motor_fwd = decision[motor_base];
         let motor_turn = decision[motor_base + 1];
         drop(decision_data);
@@ -2222,8 +2235,10 @@ impl GpuKernel {
         let brain_data = self.telemetry_staging.brain.slice(..).get_mapped_range();
         let brain: &[f32] = bytemuck::cast_slice(&brain_data);
 
-        let atten_sum: f32 = brain[dyn_hab_atten..dyn_hab_atten + DIM].iter().sum();
-        let mean_attenuation = atten_sum / DIM as f32;
+        let atten_sum: f32 = brain[dyn_hab_atten..dyn_hab_atten + ENCODED_DIMENSION]
+            .iter()
+            .sum();
+        let mean_attenuation = atten_sum / ENCODED_DIMENSION as f32;
         let curiosity_bonus = (1.0 - mean_attenuation).max(0.0);
         let fatigue_factor = brain[dyn_fatigue_factor];
         let fatigue_floor = brain[dyn_fatigue_floor];

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -2225,7 +2225,7 @@ impl GpuKernel {
         // Decision
         let decision_data = self.telemetry_staging.decision.slice(..).get_mapped_range();
         let decision: &[f32] = bytemuck::cast_slice(&decision_data);
-        let motor_base = ENCODED_DIMENSION + ENCODED_DIMENSION;
+        let motor_base = DECISION_MOTOR;
         let motor_fwd = decision[motor_base];
         let motor_turn = decision[motor_base + 1];
         drop(decision_data);

--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -415,7 +415,10 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
             brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + d] *= (1.0 - ACTION_WEIGHT_DECAY);
             brain_state[brain_base + O_ACTION_TURN_WEIGHTS + d] *= (1.0 - ACTION_WEIGHT_DECAY);
         }
+        brain_state[brain_base + O_ACT_BIASES] *= (1.0 - ACTION_WEIGHT_DECAY);
         brain_state[brain_base + O_ACT_BIASES + 1u] *= (1.0 - ACTION_WEIGHT_DECAY);
+        brain_state[brain_base + O_ACT_BIASES] = clamp(brain_state[brain_base + O_ACT_BIASES], -MAX_WEIGHT_NORM, MAX_WEIGHT_NORM);
+        brain_state[brain_base + O_ACT_BIASES + 1u] = clamp(brain_state[brain_base + O_ACT_BIASES + 1u], -MAX_WEIGHT_NORM, MAX_WEIGHT_NORM);
         var fwd_norm_sq: f32 = 0.0;
         var trn_norm_sq: f32 = 0.0;
         for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {

--- a/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_tick.wgsl
@@ -7,14 +7,14 @@ const BRAIN_WORKGROUP_SIZE: u32 = 256u;
 // ── Shared memory (~2.5 KB at default 8×6; scales with FEATURE_COUNT) ──────
 
 var<workgroup> s_features: array<f32, FEATURE_COUNT>;
-var<workgroup> s_encoded: array<f32, 32>;
-var<workgroup> s_habituated: array<f32, 32>;
+var<workgroup> s_encoded: array<f32, ENCODED_DIMENSION>;
+var<workgroup> s_habituated: array<f32, ENCODED_DIMENSION>;
 var<workgroup> s_homeo: array<f32, 6>;
-var<workgroup> s_similarities: array<f32, 128>;  // reused for decay tracking in pass 7
-var<workgroup> shared_sort_indices: array<u32, 128>;   // multipurpose: bitonic sort indices (pass 5), credit motor cache (pass 6)
+var<workgroup> s_similarities: array<f32, MEMORY_CAP>;
+var<workgroup> shared_sort_indices: array<u32, MEMORY_CAP>;
 var<workgroup> s_recall: array<f32, 17>;
-var<workgroup> s_prediction: array<f32, 32>;
-var<workgroup> s_credit: array<f32, 32>;
+var<workgroup> s_prediction: array<f32, PREDICTOR_DIMENSION>;
+var<workgroup> s_credit: array<f32, ENCODED_DIMENSION>;
 var<workgroup> s_pred_error: f32;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -26,17 +26,17 @@ fn rand_f32_brain(seed: u32) -> f32 {
 // Cosine similarity using shared encoded state (pre-habituation)
 // for memory operations — avoids attenuation silencing recall.
 fn cosine_sim_pat_s(agent_id: u32, idx: u32) -> f32 {
-    let p_base = agent_id * PATTERN_STRIDE;
+    let pattern_base = agent_id * PATTERN_STRIDE;
     var dot_val: f32 = 0.0;
     var e_norm_sq: f32 = 0.0;
-    for (var d: u32 = 0u; d < DIM; d = d + 1u) {
+    for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
         let e = s_encoded[d];
-        let p = pattern_buf[p_base + d * MEMORY_CAP + idx];
+        let p = pattern_buffer[pattern_base + d * MEMORY_CAP + idx];
         dot_val += e * p;
         e_norm_sq += e * e;
     }
     let e_norm = sqrt(e_norm_sq);
-    let p_norm = pattern_buf[p_base + O_PAT_NORMS + idx];
+    let p_norm = pattern_buffer[pattern_base + O_PAT_NORMS + idx];
     if (e_norm < 1e-8 || p_norm < 1e-8) { return 0.0; }
     return clamp(dot_val / (e_norm * p_norm), -1.0, 1.0);
 }
@@ -53,12 +53,12 @@ fn coop_feature_extract(agent_id: u32, tid: u32) {
     let s_base = agent_id * SENSORY_STRIDE;
 
     // All threads cooperatively copy vision color + depth into s_features.
-    // sensory_buf layout: [color(VISION_COLOR_COUNT) | depth(VISION_DEPTH_COUNT) | non-visual]
+    // sensory_buffer layout: [color(VISION_COLOR_COUNT) | depth(VISION_DEPTH_COUNT) | non-visual]
     // s_features layout:  [color(VISION_COLOR_COUNT) | depth(VISION_DEPTH_COUNT) | non-visual(25)]
     // The vision portion maps 1:1 between the two buffers.
     let vision_count = VISION_COLOR_COUNT + VISION_DEPTH_COUNT;
     for (var i = tid; i < vision_count; i += BRAIN_WORKGROUP_SIZE) {
-        s_features[i] = sensory_buf[s_base + i];
+        s_features[i] = sensory_buffer[s_base + i];
     }
 
     // Non-visual features (25 values) — thread 0 only.
@@ -66,27 +66,27 @@ fn coop_feature_extract(agent_id: u32, tid: u32) {
     if (tid == 0u) {
         var fi = vision_count;
         let vel_offset = vision_count;
-        let vx = sensory_buf[s_base + vel_offset];
-        let vy = sensory_buf[s_base + vel_offset + 1u];
-        let vz = sensory_buf[s_base + vel_offset + 2u];
+        let vx = sensory_buffer[s_base + vel_offset];
+        let vy = sensory_buffer[s_base + vel_offset + 1u];
+        let vz = sensory_buffer[s_base + vel_offset + 2u];
         s_features[fi] = sqrt(vx * vx + vy * vy + vz * vz); fi = fi + 1u;
         let fac_offset = vel_offset + 3u;
-        s_features[fi] = sensory_buf[s_base + fac_offset]; fi = fi + 1u;
-        s_features[fi] = sensory_buf[s_base + fac_offset + 1u]; fi = fi + 1u;
-        s_features[fi] = sensory_buf[s_base + fac_offset + 2u]; fi = fi + 1u;
+        s_features[fi] = sensory_buffer[s_base + fac_offset]; fi = fi + 1u;
+        s_features[fi] = sensory_buffer[s_base + fac_offset + 1u]; fi = fi + 1u;
+        s_features[fi] = sensory_buffer[s_base + fac_offset + 2u]; fi = fi + 1u;
         let ang_offset = fac_offset + 3u;
-        s_features[fi] = sensory_buf[s_base + ang_offset]; fi = fi + 1u;
-        s_features[fi] = sensory_buf[s_base + ang_offset + 1u]; fi = fi + 1u;
-        s_features[fi] = sensory_buf[s_base + ang_offset + 2u]; fi = fi + 1u;
-        s_features[fi] = sensory_buf[s_base + ang_offset + 3u]; fi = fi + 1u;
-        s_features[fi] = sensory_buf[s_base + ang_offset + 4u]; fi = fi + 1u;
+        s_features[fi] = sensory_buffer[s_base + ang_offset]; fi = fi + 1u;
+        s_features[fi] = sensory_buffer[s_base + ang_offset + 1u]; fi = fi + 1u;
+        s_features[fi] = sensory_buffer[s_base + ang_offset + 2u]; fi = fi + 1u;
+        s_features[fi] = sensory_buffer[s_base + ang_offset + 3u]; fi = fi + 1u;
+        s_features[fi] = sensory_buffer[s_base + ang_offset + 4u]; fi = fi + 1u;
         let touch_offset = ang_offset + 5u;
         for (var t: u32 = 0u; t < 4u; t = t + 1u) {
             let to = touch_offset + t * 4u;
-            s_features[fi] = sensory_buf[s_base + to]; fi = fi + 1u;
-            s_features[fi] = sensory_buf[s_base + to + 1u]; fi = fi + 1u;
-            s_features[fi] = sensory_buf[s_base + to + 2u]; fi = fi + 1u;
-            s_features[fi] = sensory_buf[s_base + to + 3u]; fi = fi + 1u;
+            s_features[fi] = sensory_buffer[s_base + to]; fi = fi + 1u;
+            s_features[fi] = sensory_buffer[s_base + to + 1u]; fi = fi + 1u;
+            s_features[fi] = sensory_buffer[s_base + to + 2u]; fi = fi + 1u;
+            s_features[fi] = sensory_buffer[s_base + to + 3u]; fi = fi + 1u;
         }
     }
 }
@@ -96,11 +96,11 @@ fn coop_feature_extract(agent_id: u32, tid: u32) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 fn coop_encode(agent_id: u32, tid: u32) {
-    if (tid < DIM) {
-        let b_base = agent_id * BRAIN_STRIDE;
-        var sum: f32 = brain_state[b_base + O_ENC_BIASES + tid];
+    if (tid < ENCODED_DIMENSION) {
+        let brain_base = agent_id * BRAIN_STRIDE;
+        var sum: f32 = brain_state[brain_base + O_ENC_BIASES + tid];
         for (var f: u32 = 0u; f < FEATURE_COUNT; f = f + 1u) {
-            sum += s_features[f] * brain_state[b_base + O_ENC_WEIGHTS + f * DIM + tid];
+            sum += s_features[f] * brain_state[brain_base + O_ENC_WEIGHTS + f * ENCODED_DIMENSION + tid];
         }
         s_encoded[tid] = fast_tanh(sum);
     }
@@ -111,56 +111,57 @@ fn coop_encode(agent_id: u32, tid: u32) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 fn coop_habituate_homeo(agent_id: u32, tid: u32) {
-    let b = agent_id * BRAIN_STRIDE;
+    let brain_base = agent_id * BRAIN_STRIDE;
 
-    if (tid < DIM) {
+    if (tid < ENCODED_DIMENSION) {
         let enc = s_encoded[tid];
-        let prev = brain_state[b + O_PREV_ENCODED + tid];
+        let prev = brain_state[brain_base + O_PREV_ENCODED + tid];
         let delta = abs(enc - prev);
-        let sensitivity = brain_state[b + O_HAB_SENSITIVITY];
-        let old_ema = brain_state[b + O_HAB_EMA + tid];
+        let sensitivity = brain_state[brain_base + O_HAB_SENSITIVITY];
+        let old_ema = brain_state[brain_base + O_HAB_EMA + tid];
         let new_ema = (1.0 - HAB_EMA_ALPHA) * old_ema + HAB_EMA_ALPHA * delta;
-        brain_state[b + O_HAB_EMA + tid] = new_ema;
+        brain_state[brain_base + O_HAB_EMA + tid] = new_ema;
         let atten = clamp(new_ema * sensitivity, ATTEN_FLOOR, 1.0);
-        brain_state[b + O_HAB_ATTEN + tid] = atten;
+        brain_state[brain_base + O_HAB_ATTEN + tid] = atten;
         s_habituated[tid] = enc * atten;
-        brain_state[b + O_PREV_ENCODED + tid] = enc;
+        brain_state[brain_base + O_PREV_ENCODED + tid] = enc;
     }
 
     if (tid == 0u) {
-        let s_base = agent_id * SENSORY_STRIDE;
-        let vel_offset = VISION_COLOR_COUNT + VISION_DEPTH_COUNT;
-        let energy = sensory_buf[s_base + vel_offset + 7u];
-        let integrity = sensory_buf[s_base + vel_offset + 8u];
-        let prev_energy = brain_state[b + O_HOMEO + 4u];
-        let prev_integrity = brain_state[b + O_HOMEO + 5u];
-        let energy_delta = energy - prev_energy;
-        let integrity_delta = integrity - prev_integrity;
-        let raw_grad = energy_delta * ENERGY_WEIGHT + integrity_delta * INTEGRITY_WEIGHT;
-        let grad_fast = brain_state[b + O_HOMEO + 0u] * (1.0 - FAST_ALPHA) + raw_grad * FAST_ALPHA;
-        let grad_med = brain_state[b + O_HOMEO + 1u] * (1.0 - MED_ALPHA) + raw_grad * MED_ALPHA;
-        let grad_slow = brain_state[b + O_HOMEO + 2u] * (1.0 - SLOW_ALPHA) + raw_grad * SLOW_ALPHA;
-        brain_state[b + O_HOMEO + 0u] = grad_fast;
-        brain_state[b + O_HOMEO + 1u] = grad_med;
-        brain_state[b + O_HOMEO + 2u] = grad_slow;
+        let phys_base_homeo = agent_id * PHYS_STRIDE;
+        let max_energy = physics_state[phys_base_homeo + P_MAX_ENERGY];
+        let max_integrity = physics_state[phys_base_homeo + P_MAX_INTEGRITY];
+        let energy = physics_state[phys_base_homeo + P_ENERGY] / max(max_energy, 1e-6);
+        let integrity = physics_state[phys_base_homeo + P_INTEGRITY] / max(max_integrity, 1e-6);
+        let prev_energy = brain_state[brain_base + O_HOMEO + 4u];
+        let prev_integrity = brain_state[brain_base + O_HOMEO + 5u];
+        let energy_delta = clamp(energy - prev_energy, -MAX_HOMEOSTATIC_DELTA, MAX_HOMEOSTATIC_DELTA);
+        let integrity_delta = clamp(integrity - prev_integrity, -MAX_HOMEOSTATIC_DELTA, MAX_HOMEOSTATIC_DELTA);
+        let raw_gradient = energy_delta * ENERGY_WEIGHT + integrity_delta * INTEGRITY_WEIGHT;
+        let gradient_fast = brain_state[brain_base + O_HOMEO + 0u] * (1.0 - GRADIENT_FAST_BLEND) + raw_gradient * GRADIENT_FAST_BLEND;
+        let gradient_medium = brain_state[brain_base + O_HOMEO + 1u] * (1.0 - GRADIENT_MEDIUM_BLEND) + raw_gradient * GRADIENT_MEDIUM_BLEND;
+        let gradient_slow = brain_state[brain_base + O_HOMEO + 2u] * (1.0 - GRADIENT_SLOW_BLEND) + raw_gradient * GRADIENT_SLOW_BLEND;
+        brain_state[brain_base + O_HOMEO + 0u] = gradient_fast;
+        brain_state[brain_base + O_HOMEO + 1u] = gradient_medium;
+        brain_state[brain_base + O_HOMEO + 2u] = gradient_slow;
         let distress_exp = brain_config[CFG_DISTRESS_EXP / 4u][CFG_DISTRESS_EXP % 4u];
         let e_clamped = clamp(energy, 0.01, 1.0);
         let i_clamped = clamp(integrity, 0.01, 1.0);
         let e_distress = min(pow(1.0 - e_clamped, distress_exp) * DISTRESS_SCALE, MAX_DISTRESS);
         let i_distress = min(pow(1.0 - i_clamped, distress_exp) * DISTRESS_SCALE, MAX_DISTRESS);
         let urgency = (e_distress + i_distress) * 0.5;
-        brain_state[b + O_HOMEO + 3u] = urgency;
-        brain_state[b + O_HOMEO + 4u] = energy;
-        brain_state[b + O_HOMEO + 5u] = integrity;
-        let base_grad = grad_fast * GRAD_BLEND_FAST + grad_med * GRAD_BLEND_MED + grad_slow * GRAD_BLEND_SLOW;
-        let gradient = base_grad * (1.0 + urgency);
-        let raw_gradient_amplified = raw_grad * (1.0 + urgency);
+        brain_state[brain_base + O_HOMEO + 3u] = urgency;
+        brain_state[brain_base + O_HOMEO + 4u] = energy;
+        brain_state[brain_base + O_HOMEO + 5u] = integrity;
+        let blended_gradient = gradient_fast * GRADIENT_WEIGHT_FAST + gradient_medium * GRADIENT_WEIGHT_MEDIUM + gradient_slow * GRADIENT_WEIGHT_SLOW;
+        let gradient = blended_gradient * (1.0 + urgency);
+        let raw_gradient_amplified = raw_gradient * (1.0 + urgency);
         s_homeo[0u] = gradient;
         s_homeo[1u] = raw_gradient_amplified;
         s_homeo[2u] = urgency;
-        s_homeo[3u] = grad_fast;
-        s_homeo[4u] = grad_med;
-        s_homeo[5u] = grad_slow;
+        s_homeo[3u] = gradient_fast;
+        s_homeo[4u] = gradient_medium;
+        s_homeo[5u] = gradient_slow;
     }
 }
 
@@ -170,26 +171,26 @@ fn coop_habituate_homeo(agent_id: u32, tid: u32) {
 
 fn coop_recall_score(agent_id: u32, tid: u32) {
     if (tid < MEMORY_CAP) {
-        let p_base = agent_id * PATTERN_STRIDE;
+        let pattern_base = agent_id * PATTERN_STRIDE;
 
         // Each thread computes query norm independently (32 shared reads — fast)
         // Uses encoded (pre-habituation) state for memory queries.
         var q_norm_sq: f32 = 0.0;
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
             let v = s_encoded[d];
             q_norm_sq += v * v;
         }
         let q_norm = sqrt(q_norm_sq);
 
-        let is_active = pattern_buf[p_base + O_PAT_ACTIVE + tid];
+        let is_active = pattern_buffer[pattern_base + O_PAT_ACTIVE + tid];
         if (is_active < 0.5) {
             s_similarities[tid] = -2.0;
         } else {
             var dot: f32 = 0.0;
-            for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-                dot += s_encoded[d] * pattern_buf[p_base + d * MEMORY_CAP + tid];
+            for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+                dot += s_encoded[d] * pattern_buffer[pattern_base + d * MEMORY_CAP + tid];
             }
-            let p_norm = pattern_buf[p_base + O_PAT_NORMS + tid];
+            let p_norm = pattern_buffer[pattern_base + O_PAT_NORMS + tid];
             if (q_norm < 1e-8 || p_norm < 1e-8) {
                 s_similarities[tid] = 0.0;
             } else {
@@ -204,9 +205,9 @@ fn coop_recall_score(agent_id: u32, tid: u32) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 fn coop_recall_topk(agent_id: u32, tid: u32 /* SUBGROUP_TOPK_PARAMS */) {
-    let p_base = agent_id * PATTERN_STRIDE;
-    let b_base = agent_id * BRAIN_STRIDE;
-    let tick = brain_state[b_base + O_TICK_COUNT];
+    let pattern_base = agent_id * PATTERN_STRIDE;
+    let brain_base = agent_id * BRAIN_STRIDE;
+    let tick = brain_state[brain_base + O_TICK_COUNT];
 
     // Initialize sort index: threads 0..127
     if (tid < MEMORY_CAP) {
@@ -254,8 +255,8 @@ fn coop_recall_topk(agent_id: u32, tid: u32 /* SUBGROUP_TOPK_PARAMS */) {
             let idx = shared_sort_indices[k];
             s_recall[k] = f32(idx);
             count = count + 1u;
-            pattern_buf[p_base + O_PAT_META + idx * 3u + 1u] = tick;
-            pattern_buf[p_base + O_PAT_META + idx * 3u + 2u] += 1.0;
+            pattern_buffer[pattern_base + O_PAT_META + idx * 3u + 1u] = tick;
+            pattern_buffer[pattern_base + O_PAT_META + idx * 3u + 2u] += 1.0;
         }
         for (var k: u32 = count; k < RECALL_K; k = k + 1u) { s_recall[k] = 0.0; }
         s_recall[RECALL_K] = f32(count);
@@ -268,18 +269,18 @@ fn coop_recall_topk(agent_id: u32, tid: u32 /* SUBGROUP_TOPK_PARAMS */) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 fn coop_predict_and_act(agent_id: u32, tid: u32) {
-    let b = agent_id * BRAIN_STRIDE;
-    let p_base = agent_id * PATTERN_STRIDE;
-    let hi_base = agent_id * HISTORY_STRIDE;
-    let d_base = agent_id * DECISION_STRIDE;
-    let tick_count = brain_state[b + O_TICK_COUNT];
+    let brain_base = agent_id * BRAIN_STRIDE;
+    let pattern_base = agent_id * PATTERN_STRIDE;
+    let history_base = agent_id * HISTORY_STRIDE;
+    let decision_base = agent_id * DECISION_STRIDE;
+    let tick_count = brain_state[brain_base + O_TICK_COUNT];
     let recall_count = u32(s_recall[RECALL_K]);
 
-    // ── Predictor matmul: threads 0..31 ────────────────────────────────
-    if (tid < DIM) {
+    // ── Predictor matmul: threads 0..PREDICTOR_DIMENSION ────────────────
+    if (tid < PREDICTOR_DIMENSION) {
         var s: f32 = 0.0;
-        for (var j: u32 = 0u; j < DIM; j = j + 1u) {
-            s += s_habituated[j] * brain_state[b + O_PRED_WEIGHTS + tid * DIM + j];
+        for (var j: u32 = 0u; j < ENCODED_DIMENSION; j = j + 1u) {
+            s += s_habituated[j] * brain_state[brain_base + O_PREDICTOR_WEIGHTS + tid * ENCODED_DIMENSION + j];
         }
         s_prediction[tid] = s;
     }
@@ -290,27 +291,27 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         let gradient = s_homeo[0u];
         let urgency = s_homeo[2u];
 
-        // Prediction error
+        // Prediction error (computed in predictor space)
         var err_sum: f32 = 0.0;
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-            let prev_pred = brain_state[b + O_PREV_PREDICTION + d];
-            let e = prev_pred - s_habituated[d];
+        for (var d: u32 = 0u; d < PREDICTOR_DIMENSION; d = d + 1u) {
+            let previous_prediction = brain_state[brain_base + O_PREV_PREDICTION + d];
+            let e = previous_prediction - s_habituated[d];
             err_sum += e * e;
         }
-        let pred_error = sqrt(err_sum / f32(DIM));
+        let prediction_error = sqrt(err_sum / f32(PREDICTOR_DIMENSION));
 
         // Error ring
-        let err_cursor = u32(brain_state[b + O_PRED_ERR_CURSOR]);
-        brain_state[b + O_PRED_ERR_RING + err_cursor] = pred_error;
-        brain_state[b + O_PRED_ERR_CURSOR] = f32((err_cursor + 1u) % ERROR_HISTORY_LEN);
-        let err_count = brain_state[b + O_PRED_ERR_COUNT];
+        let err_cursor = u32(brain_state[brain_base + O_PREDICTION_ERROR_CURSOR]);
+        brain_state[brain_base + O_PREDICTION_ERROR_RING + err_cursor] = prediction_error;
+        brain_state[brain_base + O_PREDICTION_ERROR_CURSOR] = f32((err_cursor + 1u) % ERROR_HISTORY_LEN);
+        let err_count = brain_state[brain_base + O_PREDICTION_ERROR_COUNT];
         if (err_count < f32(ERROR_HISTORY_LEN)) {
-            brain_state[b + O_PRED_ERR_COUNT] = err_count + 1.0;
+            brain_state[brain_base + O_PREDICTION_ERROR_COUNT] = err_count + 1.0;
         }
 
         // Recalled context blend
         if (recall_count > 0u) {
-            let context_weight = brain_state[b + O_PRED_CTX_WT];
+            let context_weight = brain_state[brain_base + O_PREDICTOR_CONTEXT_WEIGHT];
             var total_sim: f32 = 0.0;
             for (var k: u32 = 0u; k < recall_count; k = k + 1u) {
                 let idx = u32(s_recall[k]);
@@ -321,41 +322,41 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
                     let idx = u32(s_recall[k]);
                     let sim = cosine_sim_pat_s(agent_id, idx);
                     let w = context_weight * max(sim, 0.0) / total_sim;
-                    for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-                        s_prediction[d] += pattern_buf[p_base + d * MEMORY_CAP + idx] * w;
+                    for (var d: u32 = 0u; d < PREDICTOR_DIMENSION; d = d + 1u) {
+                        s_prediction[d] += pattern_buffer[pattern_base + d * MEMORY_CAP + idx] * w;
                     }
                 }
             }
         }
 
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
+        for (var d: u32 = 0u; d < PREDICTOR_DIMENSION; d = d + 1u) {
             s_prediction[d] = fast_tanh(s_prediction[d]);
         }
-        // Pass pred_error to the post-credit block via shared memory.
+        // Pass prediction_error to the post-credit block via shared memory.
         // s_pred_error is later overwritten for pass 7.
-        s_pred_error = pred_error;
+        s_pred_error = prediction_error;
     }
     workgroupBarrier();
 
     // ── Credit assignment: cooperative across threads 0..31 ────────────
     // Thread 0 computes per-entry credit scalars → s_similarities[0..N].
     // Threads 0..31 then apply all credits to their dimension in
-    // parallel, eliminating the serial DIM-loop bottleneck that was
+    // parallel, eliminating the serial ENCODED_DIMENSION-loop bottleneck that was
     // blocking 255 threads at the barrier while thread 0 looped over
     // 64 entries × 32 dimensions.
     {
         let gradient = s_homeo[0u];
         let urgency = s_homeo[2u];
-        let hist_len = u32(history_buf[hi_base + O_HIST_LEN]);
+        let hist_len = u32(history_buffer[history_base + O_HIST_LEN]);
 
         // Phase 1: thread 0 computes credit scalar for each history entry
         if (tid == 0u) {
             for (var i: u32 = 0u; i < hist_len; i = i + 1u) {
                 let h_off = i * 5u;
-                let rec_fwd = history_buf[hi_base + O_MOTOR_RING + h_off];
-                let rec_turn = history_buf[hi_base + O_MOTOR_RING + h_off + 1u];
-                let rec_tick = history_buf[hi_base + O_MOTOR_RING + h_off + 2u];
-                let rec_grad = history_buf[hi_base + O_MOTOR_RING + h_off + 3u];
+                let recorded_forward = history_buffer[history_base + O_MOTOR_RING + h_off];
+                let recorded_turn = history_buffer[history_base + O_MOTOR_RING + h_off + 1u];
+                let rec_tick = history_buffer[history_base + O_MOTOR_RING + h_off + 2u];
+                let rec_grad = history_buffer[history_base + O_MOTOR_RING + h_off + 3u];
                 let age = tick_count - rec_tick;
                 let temporal = exp(-age * CREDIT_DECAY);
                 var credit: f32 = 0.0;
@@ -365,38 +366,38 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
                     if (abs(improvement) < DEADZONE) {
                         credit_input = gradient * urgency * TONIC_CREDIT_SCALE;
                     }
-                    if (abs(credit_input) >= 1e-6) {
+                    if (abs(credit_input) >= CREDIT_EPSILON) {
                         var effective: f32;
                         if (credit_input < 0.0) { effective = credit_input * PAIN_AMP; }
                         else { effective = credit_input; }
                         credit = effective * temporal;
-                        brain_state[b + O_ACT_BIASES] += WEIGHT_LR * credit * rec_fwd * 0.1;
-                        brain_state[b + O_ACT_BIASES + 1u] += WEIGHT_LR * credit * rec_turn * 0.1;
+                        brain_state[brain_base + O_ACT_BIASES] += ACTION_WEIGHT_LEARNING_RATE * credit * recorded_forward * 0.1;
+                        brain_state[brain_base + O_ACT_BIASES + 1u] += ACTION_WEIGHT_LEARNING_RATE * credit * recorded_turn * 0.1;
                     }
                 }
                 s_similarities[i] = credit;
                 // Cache motor values in shared memory so phase 2 threads
                 // read from workgroup memory instead of storage.
-                shared_sort_indices[i * 2u] = bitcast<u32>(rec_fwd);
-                shared_sort_indices[i * 2u + 1u] = bitcast<u32>(rec_turn);
+                shared_sort_indices[i * 2u] = bitcast<u32>(recorded_forward);
+                shared_sort_indices[i * 2u + 1u] = bitcast<u32>(recorded_turn);
             }
         }
         workgroupBarrier();
 
         // Phase 2: threads 0..31 apply all credits to their dimension
-        if (tid < DIM) {
+        if (tid < ENCODED_DIMENSION) {
             s_credit[tid] = 0.0;
             for (var i: u32 = 0u; i < hist_len; i = i + 1u) {
                 let credit = s_similarities[i];
                 if (abs(credit) > 0.0) {
-                    let rec_fwd = bitcast<f32>(shared_sort_indices[i * 2u]);
-                    let rec_turn = bitcast<f32>(shared_sort_indices[i * 2u + 1u]);
-                    let feat = history_buf[hi_base + O_STATE_RING + i * DIM + tid];
-                    let fwd_wt_update = WEIGHT_LR * credit * rec_fwd * feat;
-                    let trn_wt_update = WEIGHT_LR * credit * rec_turn * feat;
-                    brain_state[b + O_ACT_FWD_WTS + tid] += fwd_wt_update;
-                    brain_state[b + O_ACT_TURN_WTS + tid] += trn_wt_update;
-                    s_credit[tid] += credit * rec_fwd * feat + credit * rec_turn * feat;
+                    let recorded_forward = bitcast<f32>(shared_sort_indices[i * 2u]);
+                    let recorded_turn = bitcast<f32>(shared_sort_indices[i * 2u + 1u]);
+                    let feat = history_buffer[history_base + O_STATE_RING + i * ENCODED_DIMENSION + tid];
+                    let forward_weight_update = ACTION_WEIGHT_LEARNING_RATE * credit * recorded_forward * feat;
+                    let turn_weight_update = ACTION_WEIGHT_LEARNING_RATE * credit * recorded_turn * feat;
+                    brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + tid] += forward_weight_update;
+                    brain_state[brain_base + O_ACTION_TURN_WEIGHTS + tid] += turn_weight_update;
+                    s_credit[tid] += credit * recorded_forward * feat + credit * recorded_turn * feat;
                 }
             }
         }
@@ -407,115 +408,123 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
     if (tid == 0u) {
         let gradient = s_homeo[0u];
         let urgency = s_homeo[2u];
-        let pred_error = s_pred_error;
+        let prediction_error = s_pred_error;
 
-        // Weight normalization
+        // Weight decay + normalization
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+            brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + d] *= (1.0 - ACTION_WEIGHT_DECAY);
+            brain_state[brain_base + O_ACTION_TURN_WEIGHTS + d] *= (1.0 - ACTION_WEIGHT_DECAY);
+        }
+        brain_state[brain_base + O_ACT_BIASES + 1u] *= (1.0 - ACTION_WEIGHT_DECAY);
         var fwd_norm_sq: f32 = 0.0;
         var trn_norm_sq: f32 = 0.0;
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-            let fw = brain_state[b + O_ACT_FWD_WTS + d];
-            let tw = brain_state[b + O_ACT_TURN_WTS + d];
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+            let fw = brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + d];
+            let tw = brain_state[brain_base + O_ACTION_TURN_WEIGHTS + d];
             fwd_norm_sq += fw * fw;
             trn_norm_sq += tw * tw;
         }
         let fwd_norm = sqrt(fwd_norm_sq);
         if (fwd_norm > MAX_WEIGHT_NORM) {
             let scale = MAX_WEIGHT_NORM / fwd_norm;
-            for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-                brain_state[b + O_ACT_FWD_WTS + d] *= scale;
+            for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+                brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + d] *= scale;
             }
         }
         let trn_norm = sqrt(trn_norm_sq);
         if (trn_norm > MAX_WEIGHT_NORM) {
             let scale = MAX_WEIGHT_NORM / trn_norm;
-            for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-                brain_state[b + O_ACT_TURN_WTS + d] *= scale;
+            for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+                brain_state[brain_base + O_ACTION_TURN_WEIGHTS + d] *= scale;
             }
         }
 
         // Policy evaluation
-        var fwd: f32 = brain_state[b + O_ACT_BIASES];
-        var trn: f32 = brain_state[b + O_ACT_BIASES + 1u];
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-            fwd += brain_state[b + O_ACT_FWD_WTS + d] * s_encoded[d];
-            trn += brain_state[b + O_ACT_TURN_WTS + d] * s_encoded[d];
+        var forward: f32 = brain_state[brain_base + O_ACT_BIASES];
+        var turn: f32 = brain_state[brain_base + O_ACT_BIASES + 1u];
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+            forward += brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + d] * s_encoded[d];
+            turn += brain_state[brain_base + O_ACTION_TURN_WEIGHTS + d] * s_encoded[d];
         }
 
-        // Memory blend
+        // Memory blend: recalled experiences influence motor output via valence.
+        // Positive valence (food memory) + similar state → reproduce approach action.
+        // Negative valence (danger memory) + similar state → negate approach → escape.
         if (recall_count > 0u) {
-            var mem_fwd: f32 = 0.0;
-            var mem_trn: f32 = 0.0;
-            var total_w: f32 = 0.0;
+            var mem_forward: f32 = 0.0;
+            var mem_turn: f32 = 0.0;
+            var total_weight: f32 = 0.0;
             for (var k: u32 = 0u; k < recall_count; k = k + 1u) {
                 let idx = u32(s_recall[k]);
                 let sim = cosine_sim_pat_s(agent_id, idx);
-                let motor_base = p_base + O_PAT_MOTOR + idx * 3u;
-                let valence = pattern_buf[motor_base + 2u];
-                let w = sim * valence;
-                mem_fwd += w * pattern_buf[motor_base];
-                mem_trn += w * pattern_buf[motor_base + 1u];
-                total_w += abs(w);
+                let motor_base = pattern_base + O_PAT_MOTOR + idx * 3u;
+                let valence = pattern_buffer[motor_base + 2u];
+                let weight = sim * valence;
+                mem_forward += weight * pattern_buffer[motor_base];
+                mem_turn += weight * pattern_buffer[motor_base + 1u];
+                total_weight += abs(weight);
             }
-            if (total_w > 1e-6) {
-                mem_fwd /= total_w;
-                mem_trn /= total_w;
-                let strength = clamp(total_w / max(f32(recall_count), 1.0), 0.0, 1.0);
-                let mix_val = strength * 0.4;
-                fwd = fwd * (1.0 - mix_val) + mem_fwd * mix_val;
-                trn = trn * (1.0 - mix_val) + mem_trn * mix_val;
+            if (total_weight > CREDIT_EPSILON) {
+                mem_forward /= total_weight;
+                mem_turn /= total_weight;
+                let strength = clamp(total_weight / max(f32(recall_count), 1.0), 0.0, 1.0);
+                let mix = strength * MEMORY_BLEND_STRENGTH;
+                forward = forward * (1.0 - mix) + mem_forward * mix;
+                turn = turn * (1.0 - mix) + mem_turn * mix;
             }
         }
 
         // Exploration
-        let max_curiosity = brain_state[b + O_HAB_MAX_CURIOSITY];
+        let max_curiosity = brain_state[brain_base + O_HAB_MAX_CURIOSITY];
         var atten_sum: f32 = 0.0;
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-            atten_sum += brain_state[b + O_HAB_ATTEN + d];
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+            atten_sum += brain_state[brain_base + O_HAB_ATTEN + d];
         }
-        let mean_atten = atten_sum / f32(DIM);
+        let mean_atten = atten_sum / f32(ENCODED_DIMENSION);
         let curiosity = (1.0 - mean_atten) * max_curiosity;
-        let novelty_bonus = min(pred_error * 2.0, 0.4);
+        let novelty_bonus = min(prediction_error * 2.0, 0.4);
         let urgency_penalty = min(urgency * 0.4, 0.5);
-        let raw_signal = abs(fwd) + abs(trn);
+        let raw_signal = abs(forward) + abs(turn);
         let policy_confidence = clamp(raw_signal / 2.0, 0.0, 1.0);
+
         let exploration_rate = clamp(
             0.5 - policy_confidence * 0.25 + novelty_bonus + curiosity - urgency_penalty,
             0.10, 0.85
         );
-        brain_state[b + O_EXPLORATION_RATE] = exploration_rate;
+        brain_state[brain_base + O_EXPLORATION_RATE] = exploration_rate;
 
-        fwd = fast_tanh(fwd);
-        trn = fast_tanh(trn);
+        forward = fast_tanh(forward);
+        turn = fast_tanh(turn);
 
         // Position-based staleness: record current XZ position and
         // accumulated forward output, then compare displacement against
         // expected travel to detect agents that aren't making progress.
         let phys_base_fat = agent_id * PHYS_STRIDE;
-        let cur_x = agent_phys[phys_base_fat + P_POS_X];
-        let cur_z = agent_phys[phys_base_fat + P_POS_Z];
-        let pos_cursor = u32(brain_state[b + O_POS_RING_CURSOR]);
-        brain_state[b + O_POS_RING_X + pos_cursor] = cur_x;
-        brain_state[b + O_POS_RING_Z + pos_cursor] = cur_z;
-        let pos_len_val = brain_state[b + O_POS_RING_LEN];
+        let cur_x = physics_state[phys_base_fat + P_POS_X];
+        let cur_z = physics_state[phys_base_fat + P_POS_Z];
+        let pos_cursor = u32(brain_state[brain_base + O_POS_RING_CURSOR]);
+        brain_state[brain_base + O_POS_RING_X + pos_cursor] = cur_x;
+        brain_state[brain_base + O_POS_RING_Z + pos_cursor] = cur_z;
+        let pos_len_val = brain_state[brain_base + O_POS_RING_LEN];
         let new_pos_len = min(pos_len_val + 1.0, f32(POS_RING_LEN));
-        brain_state[b + O_POS_RING_LEN] = new_pos_len;
-        brain_state[b + O_POS_RING_CURSOR] = f32((pos_cursor + 1u) % POS_RING_LEN);
+        brain_state[brain_base + O_POS_RING_LEN] = new_pos_len;
+        brain_state[brain_base + O_POS_RING_CURSOR] = f32((pos_cursor + 1u) % POS_RING_LEN);
 
         // Accumulate forward motor output (pre-noise) for expected displacement.
         // This is an approximate running total: when the position ring is full,
         // we do not subtract the overwritten slot's exact forward contribution.
-        let old_accum = brain_state[b + O_ACCUM_FWD];
-        var new_accum = old_accum + max(fwd, 0.0);
+        let old_accum = brain_state[brain_base + O_ACCUM_FWD];
+        var new_accum = old_accum + max(forward, 0.0);
         if (new_pos_len >= f32(POS_RING_LEN)) {
             // We do not track per-slot forward values, so approximate a bounded
             // window by decaying the accumulator proportionally each overwrite.
             new_accum *= (f32(POS_RING_LEN) - 1.0) / f32(POS_RING_LEN);
         }
-        brain_state[b + O_ACCUM_FWD] = new_accum;
+        brain_state[brain_base + O_ACCUM_FWD] = new_accum;
 
         // Compute staleness: compare actual displacement to expected
         let p_len = u32(new_pos_len);
-        let floor_val = brain_state[b + O_FATIGUE_FLOOR];
+        let floor_val = brain_state[brain_base + O_FATIGUE_FLOOR];
         var fatigue_factor: f32 = 1.0;
         if (p_len >= 4u) {
             // Oldest valid entry in the ring. When the ring is not yet full,
@@ -523,15 +532,15 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
             // oldest sample, so compute from the current valid length instead.
             let cursor_new = (pos_cursor + 1u) % POS_RING_LEN;
             let oldest_idx = (cursor_new + POS_RING_LEN - p_len) % POS_RING_LEN;
-            let old_x = brain_state[b + O_POS_RING_X + oldest_idx];
-            let old_z = brain_state[b + O_POS_RING_Z + oldest_idx];
+            let old_x = brain_state[brain_base + O_POS_RING_X + oldest_idx];
+            let old_z = brain_state[brain_base + O_POS_RING_Z + oldest_idx];
             let dx = cur_x - old_x;
             let dz = cur_z - old_z;
             let displacement = sqrt(dx * dx + dz * dz);
 
             // Expected displacement: accumulated forward * move_speed * DT * stride
-            // Each brain tick, the agent moves fwd * move_speed * DT * stride units
-            let move_speed = brain_state[b + O_MOVEMENT_SPEED];
+            // Each brain tick, the agent moves forward * move_speed * DT * stride units
+            let move_speed = brain_state[brain_base + O_MOVEMENT_SPEED];
             let expected = new_accum * move_speed * wc_f32(WC_DT) * f32(wc_u32(WC_BRAIN_TICK_STRIDE));
             // Only penalize when the agent is actually trying to move;
             // idle agents (expected ≈ 0) keep fatigue_factor = 1.0.
@@ -544,7 +553,7 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
                 fatigue_factor = clamp(fatigue_factor, floor_val, 1.0);
             }
         }
-        brain_state[b + O_FATIGUE_FACTOR] = fatigue_factor;
+        brain_state[brain_base + O_FATIGUE_FACTOR] = fatigue_factor;
 
         // Exploration noise — constant amplitude, independent of habituation.
         // Scaling noise by mean_atten (as done previously) created a death
@@ -552,70 +561,79 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         // smaller → agents moved even less.  Exploration must stay vigorous
         // regardless of habituation state to drive REINFORCE-style learning.
         let tick_u = u32(tick_count);
-        let seed_base = agent_id * 1000u + tick_u;
-        let noise_fwd = (rand_f32_brain(seed_base) * 2.0 - 1.0) * 0.5;
-        let noise_trn = (rand_f32_brain(seed_base + 1u) * 2.0 - 1.0) * 0.5;
-        fwd = clamp(fwd + noise_fwd * exploration_rate, -1.0, 1.0);
-        trn = clamp(trn + noise_trn * exploration_rate, -1.0, 1.0);
+        let exploration_seed = pcg_hash(agent_id ^ (tick_u * 747796405u));
+        let noise_forward = (hash_to_float(exploration_seed) * 2.0 - 1.0) * 0.5;
+        let noise_turn = (hash_to_float(pcg_hash(exploration_seed)) * 2.0 - 1.0) * 0.5;
+        forward = clamp(forward + noise_forward * exploration_rate, -1.0, 1.0);
+        turn = clamp(turn + noise_turn * exploration_rate, -1.0, 1.0);
 
-        // Apply staleness-based fatigue to the final motor output (post-noise)
-        // so that fatigue reliably limits actual movement, not just policy.
-        fwd *= fatigue_factor;
-        trn *= fatigue_factor;
+        forward *= fatigue_factor;
+        turn *= fatigue_factor;
 
-        // History recording — stores the actual motor command (post-noise,
-        // post-fatigue) so credit assignment can correlate taken actions with
-        // outcomes.  The noise component serves as the exploration signal for
-        // REINFORCE-style learning: when weights are zero the policy output is
-        // zero, and multiplying credit by zero would create a zero-gradient
-        // trap.  The post-noise motor is non-zero even at initialization,
-        // allowing bootstrap learning.
-        let hist_cursor = u32(history_buf[hi_base + O_HIST_CURSOR]);
+        // Klinotaxis: use fast-vs-medium gradient deviation.
+        // Fast responds in ~2 ticks and recovers in ~5. Medium responds in ~25.
+        //   Entry (ticks 0-2): fast spikes, medium hasn't moved → amplify turns → change direction
+        //   Sustained (ticks 4+): fast recovered, medium still shifted → suppress turns → go straight → escape
+        // This produces the biological escape sequence: brief reorientation then straight-line flight.
+        let gradient_deviation = s_homeo[3u] - s_homeo[4u];
+        let klinotaxis_factor = clamp(1.0 - gradient_deviation * KLINOTAXIS_SENSITIVITY, 0.3, 3.0);
+        turn *= klinotaxis_factor;
+
+        // History records the exploration noise, not the full motor.
+        // Credit × noise is the proper REINFORCE gradient: noise is zero-mean,
+        // so only noise directions that correlate with outcomes get reinforced.
+        // Using the full motor (policy + noise) creates a feedback loop where
+        // any turn bias gets reinforced by every positive credit event.
+        let exploration_forward = noise_forward * exploration_rate;
+        let exploration_turn = noise_turn * exploration_rate;
+        let hist_cursor = u32(history_buffer[history_base + O_HIST_CURSOR]);
         let hist_off = hist_cursor * 5u;
-        history_buf[hi_base + O_MOTOR_RING + hist_off] = fwd;
-        history_buf[hi_base + O_MOTOR_RING + hist_off + 1u] = trn;
-        history_buf[hi_base + O_MOTOR_RING + hist_off + 2u] = tick_count;
-        history_buf[hi_base + O_MOTOR_RING + hist_off + 3u] = gradient;
-        history_buf[hi_base + O_MOTOR_RING + hist_off + 4u] = 0.0;
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-            history_buf[hi_base + O_STATE_RING + hist_cursor * DIM + d] = s_encoded[d];
+        history_buffer[history_base + O_MOTOR_RING + hist_off] = exploration_forward;
+        history_buffer[history_base + O_MOTOR_RING + hist_off + 1u] = exploration_turn;
+        history_buffer[history_base + O_MOTOR_RING + hist_off + 2u] = tick_count;
+        history_buffer[history_base + O_MOTOR_RING + hist_off + 3u] = gradient;
+        history_buffer[history_base + O_MOTOR_RING + hist_off + 4u] = 0.0;
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+            history_buffer[history_base + O_STATE_RING + hist_cursor * ENCODED_DIMENSION + d] = s_encoded[d];
         }
-        history_buf[hi_base + O_HIST_CURSOR] = f32((hist_cursor + 1u) % ACTION_HISTORY_LEN);
-        let hist_len_val = history_buf[hi_base + O_HIST_LEN];
-        history_buf[hi_base + O_HIST_LEN] = min(hist_len_val + 1.0, f32(ACTION_HISTORY_LEN));
+        history_buffer[history_base + O_HIST_CURSOR] = f32((hist_cursor + 1u) % ACTION_HISTORY_LEN);
+        let hist_len_val = history_buffer[history_base + O_HIST_LEN];
+        history_buffer[history_base + O_HIST_LEN] = min(hist_len_val + 1.0, f32(ACTION_HISTORY_LEN));
 
         // Save prediction + tick + decision buffer
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-            brain_state[b + O_PREV_PREDICTION + d] = s_prediction[d];
+        for (var d: u32 = 0u; d < PREDICTOR_DIMENSION; d = d + 1u) {
+            brain_state[brain_base + O_PREV_PREDICTION + d] = s_prediction[d];
         }
-        brain_state[b + O_TICK_COUNT] = tick_count + 1.0;
+        brain_state[brain_base + O_TICK_COUNT] = tick_count + 1.0;
 
-        // Store pred_error for pass 7 (shared scalar)
-        var err_sq_sum: f32 = 0.0;
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
+        // Store prediction_error for pass 7 (shared scalar)
+        var error_squared_sum: f32 = 0.0;
+        for (var d: u32 = 0u; d < PREDICTOR_DIMENSION; d = d + 1u) {
             let e = s_prediction[d] - s_habituated[d];
-            err_sq_sum += e * e;
+            error_squared_sum += e * e;
         }
-        s_pred_error = clamp(sqrt(err_sq_sum), 0.0, 1.0);
+        s_pred_error = clamp(sqrt(error_squared_sum), 0.0, 1.0);
 
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-            decision_buf[d_base + d] = s_prediction[d];
-            decision_buf[d_base + DIM + d] = s_credit[d];
+        for (var d: u32 = 0u; d < PREDICTOR_DIMENSION; d = d + 1u) {
+            decision_buffer[decision_base + DECISION_PREDICTION + d] = s_prediction[d];
         }
-        decision_buf[d_base + DIM + DIM] = fwd;
-        decision_buf[d_base + DIM + DIM + 1u] = trn;
-        decision_buf[d_base + DIM + DIM + 2u] = 0.0;
-        decision_buf[d_base + DIM + DIM + 3u] = 0.0;
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+            decision_buffer[decision_base + DECISION_CREDIT + d] = s_credit[d];
+        }
+        decision_buffer[decision_base + DECISION_MOTOR] = forward;
+        decision_buffer[decision_base + DECISION_MOTOR + 1u] = turn;
+        decision_buffer[decision_base + DECISION_MOTOR + 2u] = 0.0;
+        decision_buffer[decision_base + DECISION_MOTOR + 3u] = 0.0;
 
         // Write telemetry to physics buffer for CPU readback
         let phys_base = agent_id * PHYS_STRIDE;
-        agent_phys[phys_base + P_PREDICTION_ERROR] = s_pred_error;
-        agent_phys[phys_base + P_EXPLORATION_RATE_OUT] = exploration_rate;
-        agent_phys[phys_base + P_FATIGUE_FACTOR_OUT] = fatigue_factor;
-        agent_phys[phys_base + P_MOTOR_FWD_OUT] = fwd;
-        agent_phys[phys_base + P_MOTOR_TURN_OUT] = trn;
-        agent_phys[phys_base + P_GRADIENT_OUT] = gradient;
-        agent_phys[phys_base + P_URGENCY_OUT] = urgency;
+        physics_state[phys_base + P_PREDICTION_ERROR] = s_pred_error;
+        physics_state[phys_base + P_EXPLORATION_RATE_OUT] = exploration_rate;
+        physics_state[phys_base + P_FATIGUE_FACTOR_OUT] = fatigue_factor;
+        physics_state[phys_base + P_MOTOR_FWD_OUT] = forward;
+        physics_state[phys_base + P_MOTOR_TURN_OUT] = turn;
+        physics_state[phys_base + P_GRADIENT_OUT] = gradient;
+        physics_state[phys_base + P_URGENCY_OUT] = urgency;
     }
 }
 
@@ -626,49 +644,49 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 fn coop_learn_and_store(agent_id: u32, tid: u32) {
-    let b = agent_id * BRAIN_STRIDE;
-    let p_base = agent_id * PATTERN_STRIDE;
-    let d_base = agent_id * DECISION_STRIDE;
+    let brain_base = agent_id * BRAIN_STRIDE;
+    let pattern_base = agent_id * PATTERN_STRIDE;
+    let decision_base = agent_id * DECISION_STRIDE;
 
     let learning_rate = brain_config[1].x;
     let decay_rate = brain_config[1].y;
-    let tick = brain_state[b + O_TICK_COUNT];
+    let tick = brain_state[brain_base + O_TICK_COUNT];
     let raw_gradient = s_homeo[1u];
 
-    // ── 7a. Predictor learning: threads 0..31 ──────────────────────────
-    if (tid < DIM) {
-        let pred_d = decision_buf[d_base + tid];
-        let error_d = pred_d - s_habituated[tid];
-        let tanh_deriv = 1.0 - pred_d * pred_d;
-        for (var j: u32 = 0u; j < DIM; j = j + 1u) {
-            let grad = clamp(error_d * tanh_deriv * s_habituated[j], -1.0, 1.0);
-            var w = brain_state[b + O_PRED_WEIGHTS + tid * DIM + j] - learning_rate * grad;
+    // ── 7a. Predictor learning: threads 0..PREDICTOR_DIMENSION ──────────
+    if (tid < PREDICTOR_DIMENSION) {
+        let predicted_dimension = decision_buffer[decision_base + DECISION_PREDICTION + tid];
+        let error_dimension = predicted_dimension - s_habituated[tid];
+        let tanh_deriv = 1.0 - predicted_dimension * predicted_dimension;
+        for (var j: u32 = 0u; j < ENCODED_DIMENSION; j = j + 1u) {
+            let grad = clamp(error_dimension * tanh_deriv * s_habituated[j], -1.0, 1.0);
+            var w = brain_state[brain_base + O_PREDICTOR_WEIGHTS + tid * ENCODED_DIMENSION + j] - learning_rate * grad;
             w = clamp(w, -3.0, 3.0);
-            brain_state[b + O_PRED_WEIGHTS + tid * DIM + j] = w;
+            brain_state[brain_base + O_PREDICTOR_WEIGHTS + tid * ENCODED_DIMENSION + j] = w;
         }
     }
 
     // Thread 0: context weight adaptation
     if (tid == 0u) {
-        var error_sq_sum: f32 = 0.0;
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
-            let e = decision_buf[d_base + d] - s_habituated[d];
-            error_sq_sum += e * e;
+        var error_squared_sum: f32 = 0.0;
+        for (var d: u32 = 0u; d < PREDICTOR_DIMENSION; d = d + 1u) {
+            let e = decision_buffer[decision_base + DECISION_PREDICTION + d] - s_habituated[d];
+            error_squared_sum += e * e;
         }
-        let error_mag = sqrt(error_sq_sum);
-        brain_state[b + O_PRED_CTX_WT] += learning_rate * 0.01 * (error_mag - 0.5);
-        brain_state[b + O_PRED_CTX_WT] = clamp(brain_state[b + O_PRED_CTX_WT], 0.05, 0.5);
+        let error_mag = sqrt(error_squared_sum);
+        brain_state[brain_base + O_PREDICTOR_CONTEXT_WEIGHT] += learning_rate * 0.01 * (error_mag - 0.5);
+        brain_state[brain_base + O_PREDICTOR_CONTEXT_WEIGHT] = clamp(brain_state[brain_base + O_PREDICTOR_CONTEXT_WEIGHT], 0.05, 0.5);
     }
 
     // ── 7b. Encoder credit: threads 0..31 ──────────────────────────────
-    if (tid < DIM) {
-        let credit_d = decision_buf[d_base + DIM + tid];
-        if (abs(credit_d) >= 1e-6) {
-            let scale = learning_rate * credit_d * 0.01;
+    if (tid < ENCODED_DIMENSION) {
+        let action_credit = decision_buffer[decision_base + DECISION_CREDIT + tid];
+        if (abs(action_credit) >= CREDIT_EPSILON) {
+            let scale = learning_rate * action_credit * ENCODER_CREDIT_SCALE;
             for (var j: u32 = 0u; j < FEATURE_COUNT; j = j + 1u) {
-                var w = brain_state[b + O_ENC_WEIGHTS + j * DIM + tid] + scale * s_features[j];
+                var w = brain_state[brain_base + O_ENC_WEIGHTS + j * ENCODED_DIMENSION + tid] + scale * s_features[j];
                 w = clamp(w, -2.0, 2.0);
-                brain_state[b + O_ENC_WEIGHTS + j * DIM + tid] = w;
+                brain_state[brain_base + O_ENC_WEIGHTS + j * ENCODED_DIMENSION + tid] = w;
             }
         }
     }
@@ -676,25 +694,25 @@ fn coop_learn_and_store(agent_id: u32, tid: u32) {
     // ── 7c. Memory reinforcement: threads 0..127 ──────────────────────
     // Uses encoded (pre-habituation) state for memory similarity.
     if (tid < MEMORY_CAP) {
-        if (pattern_buf[p_base + O_PAT_ACTIVE + tid] >= 0.5) {
+        if (pattern_buffer[pattern_base + O_PAT_ACTIVE + tid] >= 0.5) {
             var e_norm_sq: f32 = 0.0;
             var dot_val: f32 = 0.0;
-            for (var d: u32 = 0u; d < DIM; d = d + 1u) {
+            for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
                 let e = s_encoded[d];
                 e_norm_sq += e * e;
-                dot_val += e * pattern_buf[p_base + d * MEMORY_CAP + tid];
+                dot_val += e * pattern_buffer[pattern_base + d * MEMORY_CAP + tid];
             }
             let e_norm = sqrt(e_norm_sq);
-            let p_norm = pattern_buf[p_base + O_PAT_NORMS + tid];
+            let p_norm = pattern_buffer[pattern_base + O_PAT_NORMS + tid];
             if (e_norm >= 1e-8 && p_norm >= 1e-8) {
                 let sim = clamp(dot_val / (e_norm * p_norm), -1.0, 1.0);
                 if (sim > 0.3) {
-                    pattern_buf[p_base + O_PAT_REINF + tid] += sim * learning_rate * (1.0 - s_pred_error);
-                    pattern_buf[p_base + O_PAT_REINF + tid] = clamp(
-                        pattern_buf[p_base + O_PAT_REINF + tid], 0.0, 20.0);
+                    pattern_buffer[pattern_base + O_PAT_REINF + tid] += sim * learning_rate * (1.0 - s_pred_error);
+                    pattern_buffer[pattern_base + O_PAT_REINF + tid] = clamp(
+                        pattern_buffer[pattern_base + O_PAT_REINF + tid], 0.0, 20.0);
                     let valence_lr = learning_rate * 0.3;
-                    let old_valence = pattern_buf[p_base + O_PAT_MOTOR + tid * 3u + 2u];
-                    pattern_buf[p_base + O_PAT_MOTOR + tid * 3u + 2u] +=
+                    let old_valence = pattern_buffer[pattern_base + O_PAT_MOTOR + tid * 3u + 2u];
+                    pattern_buffer[pattern_base + O_PAT_MOTOR + tid * 3u + 2u] +=
                         sim * valence_lr * (raw_gradient - old_valence);
                 }
             }
@@ -705,69 +723,46 @@ fn coop_learn_and_store(agent_id: u32, tid: u32) {
     // ── 7d. Memory store: thread 0 ─────────────────────────────────────
     // Stores encoded (pre-habituation) state for consistent memory keys.
     if (tid == 0u) {
-        let min_idx = u32(pattern_buf[p_base + O_MIN_REINF_IDX]);
+        let min_idx = u32(pattern_buffer[pattern_base + O_MIN_REINF_IDX]);
 
-        // Store the *approach action* (motor from ~2 ticks ago) instead of the
-        // current motor.  Negative-valence recall then negates the approach
-        // action → directed escape, not freeze.  Uses the history ring buffer
-        // which records post-noise commands; acceptable since staleness-based
-        // fatigue doesn't distort the motor signal like variance-based did.
-        let hi_base_mem = agent_id * HISTORY_STRIDE;
-        let hist_len_u = u32(history_buf[hi_base_mem + O_HIST_LEN]);
-        let hist_cur_u = u32(history_buf[hi_base_mem + O_HIST_CURSOR]);
-        var motor_fwd: f32;
-        var motor_trn: f32;
-        if (hist_len_u >= 3u) {
-            // cursor already advanced past current tick's write, so:
-            //   cursor-1 = this tick, cursor-2 = 1 ago, cursor-3 = 2 ago.
-            let ring_idx = (hist_cur_u + ACTION_HISTORY_LEN - 3u) % ACTION_HISTORY_LEN;
-            motor_fwd = history_buf[hi_base_mem + O_MOTOR_RING + ring_idx * 5u];
-            motor_trn = history_buf[hi_base_mem + O_MOTOR_RING + ring_idx * 5u + 1u];
-        } else if (hist_len_u >= 1u) {
-            // Use oldest available entry.
-            let lookback = min(hist_len_u, 2u);
-            let ring_idx = (hist_cur_u + ACTION_HISTORY_LEN - lookback) % ACTION_HISTORY_LEN;
-            motor_fwd = history_buf[hi_base_mem + O_MOTOR_RING + ring_idx * 5u];
-            motor_trn = history_buf[hi_base_mem + O_MOTOR_RING + ring_idx * 5u + 1u];
-        } else {
-            // History empty; fall back to decision buffer.
-            motor_fwd = decision_buf[d_base + DIM + DIM];
-            motor_trn = decision_buf[d_base + DIM + DIM + 1u];
-        }
+        // Store the actual motor command from the decision buffer.
+        // Negative-valence recall negates this → directed escape.
+        let motor_forward = decision_buffer[decision_base + DECISION_MOTOR];
+        let motor_turn = decision_buffer[decision_base + DECISION_MOTOR + 1u];
         var e_norm_sq: f32 = 0.0;
-        for (var d: u32 = 0u; d < DIM; d = d + 1u) {
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
             let e = s_encoded[d];
             e_norm_sq += e * e;
-            pattern_buf[p_base + d * MEMORY_CAP + min_idx] = e;
+            pattern_buffer[pattern_base + d * MEMORY_CAP + min_idx] = e;
         }
-        pattern_buf[p_base + O_PAT_NORMS + min_idx] = sqrt(e_norm_sq);
-        pattern_buf[p_base + O_PAT_REINF + min_idx] = 1.0;
-        pattern_buf[p_base + O_PAT_MOTOR + min_idx * 3u] = motor_fwd;
-        pattern_buf[p_base + O_PAT_MOTOR + min_idx * 3u + 1u] = motor_trn;
-        pattern_buf[p_base + O_PAT_MOTOR + min_idx * 3u + 2u] = raw_gradient;
-        pattern_buf[p_base + O_PAT_META + min_idx * 3u] = tick;
-        pattern_buf[p_base + O_PAT_META + min_idx * 3u + 1u] = tick;
-        pattern_buf[p_base + O_PAT_META + min_idx * 3u + 2u] = 1.0;
-        pattern_buf[p_base + O_PAT_ACTIVE + min_idx] = 1.0;
-        pattern_buf[p_base + O_LAST_STORED_IDX] = f32(min_idx);
+        pattern_buffer[pattern_base + O_PAT_NORMS + min_idx] = sqrt(e_norm_sq);
+        pattern_buffer[pattern_base + O_PAT_REINF + min_idx] = 1.0;
+        pattern_buffer[pattern_base + O_PAT_MOTOR + min_idx * 3u] = motor_forward;
+        pattern_buffer[pattern_base + O_PAT_MOTOR + min_idx * 3u + 1u] = motor_turn;
+        pattern_buffer[pattern_base + O_PAT_MOTOR + min_idx * 3u + 2u] = raw_gradient;
+        pattern_buffer[pattern_base + O_PAT_META + min_idx * 3u] = tick;
+        pattern_buffer[pattern_base + O_PAT_META + min_idx * 3u + 1u] = tick;
+        pattern_buffer[pattern_base + O_PAT_META + min_idx * 3u + 2u] = 1.0;
+        pattern_buffer[pattern_base + O_PAT_ACTIVE + min_idx] = 1.0;
+        pattern_buffer[pattern_base + O_LAST_STORED_IDX] = f32(min_idx);
     }
     storageBarrier(); workgroupBarrier();
 
     // ── 7e. Memory decay: threads 0..127 ───────────────────────────────
     // Reuse s_similarities for per-thread reinforcement tracking
     if (tid < MEMORY_CAP) {
-        if (pattern_buf[p_base + O_PAT_ACTIVE + tid] >= 0.5) {
-            let recency = tick - pattern_buf[p_base + O_PAT_META + tid * 3u + 1u];
-            let act_count = pattern_buf[p_base + O_PAT_META + tid * 3u + 2u];
+        if (pattern_buffer[pattern_base + O_PAT_ACTIVE + tid] >= 0.5) {
+            let recency = tick - pattern_buffer[pattern_base + O_PAT_META + tid * 3u + 1u];
+            let act_count = pattern_buffer[pattern_base + O_PAT_META + tid * 3u + 2u];
             let freq_factor = 1.0 / (1.0 + act_count * 0.2);
             let recency_factor = min(recency / 100.0, 3.0);
             let effective_rate = decay_rate * freq_factor * (0.2 + recency_factor);
-            pattern_buf[p_base + O_PAT_REINF + tid] -= effective_rate;
-            if (pattern_buf[p_base + O_PAT_REINF + tid] <= 0.0) {
-                pattern_buf[p_base + O_PAT_ACTIVE + tid] = 0.0;
+            pattern_buffer[pattern_base + O_PAT_REINF + tid] -= effective_rate;
+            if (pattern_buffer[pattern_base + O_PAT_REINF + tid] <= 0.0) {
+                pattern_buffer[pattern_base + O_PAT_ACTIVE + tid] = 0.0;
                 s_similarities[tid] = 999.0;
             } else {
-                s_similarities[tid] = pattern_buf[p_base + O_PAT_REINF + tid];
+                s_similarities[tid] = pattern_buffer[pattern_base + O_PAT_REINF + tid];
             }
         } else {
             s_similarities[tid] = 999.0;
@@ -789,8 +784,8 @@ fn coop_learn_and_store(agent_id: u32, tid: u32) {
                 }
             }
         }
-        pattern_buf[p_base + O_MIN_REINF_IDX] = f32(min_reinf_idx);
-        pattern_buf[p_base + O_ACTIVE_COUNT] = f32(active_count);
+        pattern_buffer[pattern_base + O_MIN_REINF_IDX] = f32(min_reinf_idx);
+        pattern_buffer[pattern_base + O_ACTIVE_COUNT] = f32(active_count);
     }
 }
 
@@ -808,7 +803,7 @@ fn brain_tick(
     let tid = lid.x;
 
     // All threads check same agent — uniform control flow, safe for barriers
-    if (agent_phys[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
+    if (physics_state[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
 
     coop_feature_extract(agent_id, tid);
     workgroupBarrier();

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -60,8 +60,8 @@ const O_MOVEMENT_SPEED: u32 = O_FATIGUE_FLOOR + 1u;
 // ── Per-agent buffer strides ────────────────────────────────────────────────
 
 const BRAIN_STRIDE: u32 = O_MOVEMENT_SPEED + 1u;
-const PATTERN_STRIDE: u32 = 5251u;
-const HISTORY_STRIDE: u32 = 2370u;
+const PATTERN_STRIDE: u32 = O_LAST_STORED_IDX + 1u;
+const HISTORY_STRIDE: u32 = O_HIST_LEN + 1u;
 const FEATURES_STRIDE: u32 = FEATURE_COUNT;
 const DECISION_PREDICTION: u32 = 0u;
 const DECISION_CREDIT: u32 = ENCODED_DIMENSION;
@@ -77,21 +77,21 @@ const RECALL_IDX_STRIDE: u32 = 17u;    // 16 indices + 1 count
 // Other regions (norms, reinf, motor, meta, active) remain AoS.
 
 const O_PAT_STATES: u32 = 0u;
-const O_PAT_NORMS: u32 = 4096u;
-const O_PAT_REINF: u32 = 4224u;
-const O_PAT_MOTOR: u32 = 4352u;
-const O_PAT_META: u32 = 4736u;
-const O_PAT_ACTIVE: u32 = 5120u;
-const O_ACTIVE_COUNT: u32 = 5248u;
-const O_MIN_REINF_IDX: u32 = 5249u;
-const O_LAST_STORED_IDX: u32 = 5250u;
+const O_PAT_NORMS: u32 = MEMORY_CAP * ENCODED_DIMENSION;
+const O_PAT_REINF: u32 = O_PAT_NORMS + MEMORY_CAP;
+const O_PAT_MOTOR: u32 = O_PAT_REINF + MEMORY_CAP;
+const O_PAT_META: u32 = O_PAT_MOTOR + MEMORY_CAP * 3u;
+const O_PAT_ACTIVE: u32 = O_PAT_META + MEMORY_CAP * 3u;
+const O_ACTIVE_COUNT: u32 = O_PAT_ACTIVE + MEMORY_CAP;
+const O_MIN_REINF_IDX: u32 = O_ACTIVE_COUNT + 1u;
+const O_LAST_STORED_IDX: u32 = O_MIN_REINF_IDX + 1u;
 
 // ── Action history offsets ──────────────────────────────────────────────────
 
 const O_MOTOR_RING: u32 = 0u;
-const O_STATE_RING: u32 = 320u;
-const O_HIST_CURSOR: u32 = 2368u;
-const O_HIST_LEN: u32 = 2369u;
+const O_STATE_RING: u32 = ACTION_HISTORY_LEN * 5u;
+const O_HIST_CURSOR: u32 = O_STATE_RING + ACTION_HISTORY_LEN * ENCODED_DIMENSION;
+const O_HIST_LEN: u32 = O_HIST_CURSOR + 1u;
 
 // ── Config buffer offsets ───────────────────────────────────────────────────
 

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -144,6 +144,11 @@ const F_POS_Y: u32 = 1u;
 const F_POS_Z: u32 = 2u;
 const F_RESPAWN_TIMER: u32 = 3u;
 
+// ── Math constants ─────────────────────────────────────────────────────────
+
+const PI: f32 = 3.14159265;
+const TWO_PI: f32 = 6.28318530;
+
 // ── Physics constants ───────────────────────────────────────────────────────
 
 const GRAVITY: f32 = 20.0;
@@ -182,7 +187,7 @@ const FOOD_RESPAWN_ATTEMPTS: u32 = 64u;
 
 // ── Vision constants ────────────────────────────────────────────────────────
 
-const VISION_FOV_HALF: f32 = 0.7853982;   // PI/4 = 45 degrees half-FOV
+const VISION_FOV_HALF: f32 = PI / 4.0;   // PI/4 = 45 degrees half-FOV
 const VISION_MAX_DIST: f32 = 30.0;
 const VISION_STEP_SIZE: f32 = 1.2;
 const VISION_NUM_STEPS: u32 = 25u;

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -18,7 +18,8 @@ const SENSORY_STRIDE: u32 = VISION_COLOR_COUNT + VISION_DEPTH_COUNT + 27u;
 
 // ── Brain dimensions ────────────────────────────────────────────────────────
 
-const DIM: u32 = 32u;
+const ENCODED_DIMENSION: u32 = 128u;
+const PREDICTOR_DIMENSION: u32 = ENCODED_DIMENSION;
 const FEATURE_COUNT: u32 = VISION_COLOR_COUNT + VISION_DEPTH_COUNT + 25u;
 const MEMORY_CAP: u32 = 128u;
 const RECALL_K: u32 = 16u;
@@ -28,19 +29,19 @@ const ERROR_HISTORY_LEN: u32 = 128u;
 // ── Brain state offsets (derived from FEATURE_COUNT) ────────────────────────
 
 const O_ENC_WEIGHTS: u32 = 0u;
-const O_ENC_BIASES: u32 = FEATURE_COUNT * DIM;
-const O_PRED_WEIGHTS: u32 = O_ENC_BIASES + DIM;
-const O_PRED_CTX_WT: u32 = O_PRED_WEIGHTS + DIM * DIM;
-const O_PRED_ERR_RING: u32 = O_PRED_CTX_WT + 1u;
-const O_PRED_ERR_CURSOR: u32 = O_PRED_ERR_RING + ERROR_HISTORY_LEN;
-const O_PRED_ERR_COUNT: u32 = O_PRED_ERR_CURSOR + 1u;
-const O_HAB_EMA: u32 = O_PRED_ERR_COUNT + 1u;
-const O_HAB_ATTEN: u32 = O_HAB_EMA + DIM;
-const O_PREV_ENCODED: u32 = O_HAB_ATTEN + DIM;
-const O_HOMEO: u32 = O_PREV_ENCODED + DIM;
-const O_ACT_FWD_WTS: u32 = O_HOMEO + 6u;
-const O_ACT_TURN_WTS: u32 = O_ACT_FWD_WTS + DIM;
-const O_ACT_BIASES: u32 = O_ACT_TURN_WTS + DIM;
+const O_ENC_BIASES: u32 = FEATURE_COUNT * ENCODED_DIMENSION;
+const O_PREDICTOR_WEIGHTS: u32 = O_ENC_BIASES + ENCODED_DIMENSION;
+const O_PREDICTOR_CONTEXT_WEIGHT: u32 = O_PREDICTOR_WEIGHTS + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
+const O_PREDICTION_ERROR_RING: u32 = O_PREDICTOR_CONTEXT_WEIGHT + 1u;
+const O_PREDICTION_ERROR_CURSOR: u32 = O_PREDICTION_ERROR_RING + ERROR_HISTORY_LEN;
+const O_PREDICTION_ERROR_COUNT: u32 = O_PREDICTION_ERROR_CURSOR + 1u;
+const O_HAB_EMA: u32 = O_PREDICTION_ERROR_COUNT + 1u;
+const O_HAB_ATTEN: u32 = O_HAB_EMA + ENCODED_DIMENSION;
+const O_PREV_ENCODED: u32 = O_HAB_ATTEN + ENCODED_DIMENSION;
+const O_HOMEO: u32 = O_PREV_ENCODED + ENCODED_DIMENSION;
+const O_ACTION_FORWARD_WEIGHTS: u32 = O_HOMEO + 6u;
+const O_ACTION_TURN_WEIGHTS: u32 = O_ACTION_FORWARD_WEIGHTS + ENCODED_DIMENSION;
+const O_ACT_BIASES: u32 = O_ACTION_TURN_WEIGHTS + ENCODED_DIMENSION;
 const O_EXPLORATION_RATE: u32 = O_ACT_BIASES + 2u;
 const POS_RING_LEN: u32 = 16u;
 const O_POS_RING_X: u32 = O_EXPLORATION_RATE + 1u;
@@ -50,7 +51,7 @@ const O_POS_RING_LEN: u32 = O_POS_RING_CURSOR + 1u;
 const O_ACCUM_FWD: u32 = O_POS_RING_LEN + 1u;
 const O_FATIGUE_FACTOR: u32 = O_ACCUM_FWD + 1u;
 const O_PREV_PREDICTION: u32 = O_FATIGUE_FACTOR + 1u;
-const O_TICK_COUNT: u32 = O_PREV_PREDICTION + DIM;
+const O_TICK_COUNT: u32 = O_PREV_PREDICTION + PREDICTOR_DIMENSION;
 const O_HAB_SENSITIVITY: u32 = O_TICK_COUNT + 1u;
 const O_HAB_MAX_CURIOSITY: u32 = O_HAB_SENSITIVITY + 1u;
 const O_FATIGUE_FLOOR: u32 = O_HAB_MAX_CURIOSITY + 1u;
@@ -62,13 +63,16 @@ const BRAIN_STRIDE: u32 = O_MOVEMENT_SPEED + 1u;
 const PATTERN_STRIDE: u32 = 5251u;
 const HISTORY_STRIDE: u32 = 2370u;
 const FEATURES_STRIDE: u32 = FEATURE_COUNT;
-const DECISION_STRIDE: u32 = 68u;      // prediction(32) + credit(32) + motor(4)
+const DECISION_PREDICTION: u32 = 0u;
+const DECISION_CREDIT: u32 = ENCODED_DIMENSION;
+const DECISION_MOTOR: u32 = ENCODED_DIMENSION + ENCODED_DIMENSION;
+const DECISION_STRIDE: u32 = DECISION_MOTOR + 4u;
 const HOMEO_OUT_STRIDE: u32 = 6u;
 const RECALL_IDX_STRIDE: u32 = 17u;    // 16 indices + 1 count
 
 // ── Pattern memory offsets ──────────────────────────────────────────────────
 // O_PAT_STATES uses SoA (Structure-of-Arrays) layout: [dim][pattern]
-// Index as: p_base + d * MEMORY_CAP + pattern_idx
+// Index as: pattern_base + d * MEMORY_CAP + pattern_idx
 // This gives coalesced reads when 128 threads each read one pattern.
 // Other regions (norms, reinf, motor, meta, active) remain AoS.
 
@@ -232,33 +236,39 @@ const WC_BRAIN_TICK_STRIDE: u32 = 23u;
 
 const HAB_EMA_ALPHA: f32 = 0.02;
 const ATTEN_FLOOR: f32 = 0.1;
+const MAX_HOMEOSTATIC_DELTA: f32 = 0.3;
 const ENERGY_WEIGHT: f32 = 0.6;
 const INTEGRITY_WEIGHT: f32 = 0.4;
-const FAST_ALPHA: f32 = 0.6;
-const MED_ALPHA: f32 = 0.04;
-const SLOW_ALPHA: f32 = 0.004;
+const GRADIENT_FAST_BLEND: f32 = 0.6;
+const GRADIENT_MEDIUM_BLEND: f32 = 0.04;
+const GRADIENT_SLOW_BLEND: f32 = 0.004;
 const DISTRESS_SCALE: f32 = 10.0;
 const MAX_DISTRESS: f32 = 10.0;
-const GRAD_BLEND_FAST: f32 = 0.5;
-const GRAD_BLEND_MED: f32 = 0.35;
-const GRAD_BLEND_SLOW: f32 = 0.15;
+const GRADIENT_WEIGHT_FAST: f32 = 0.5;
+const GRADIENT_WEIGHT_MEDIUM: f32 = 0.35;
+const GRADIENT_WEIGHT_SLOW: f32 = 0.15;
 
 // ── Predict-and-act constants ───────────────────────────────────────────────
 
-const CREDIT_DECAY: f32 = 0.04;
-const WEIGHT_LR: f32 = 0.10;
+const CREDIT_DECAY: f32 = 0.3;
+const ACTION_WEIGHT_LEARNING_RATE: f32 = 0.10;
 const PAIN_AMP: f32 = 3.0;
 const DEADZONE: f32 = 0.005;
 const MAX_WEIGHT_NORM: f32 = 2.0;
+const ACTION_WEIGHT_DECAY: f32 = 0.01;
 const ANTICIPATION_WEIGHT: f32 = 0.5;
 const TONIC_CREDIT_SCALE: f32 = 0.5;
+const ENCODER_CREDIT_SCALE: f32 = 0.1;
+const CREDIT_EPSILON: f32 = 1e-6;
+const KLINOTAXIS_SENSITIVITY: f32 = 500.0;
+const MEMORY_BLEND_STRENGTH: f32 = 0.4;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Buffer bindings — 15 storage + 2 uniform, single bind group
 // ═══════════════════════════════════════════════════════════════════════════
 
-@group(0) @binding(0)  var<storage, read_write> agent_phys:        array<f32>;
-@group(0) @binding(1)  var<storage, read_write> decision_buf:      array<f32>;
+@group(0) @binding(0)  var<storage, read_write> physics_state:        array<f32>;
+@group(0) @binding(1)  var<storage, read_write> decision_buffer:      array<f32>;
 @group(0) @binding(2)  var<storage, read>       heightmap:         array<f32>;
 @group(0) @binding(3)  var<storage, read>       biome_grid:        array<u32>;
 @group(0) @binding(4)  var<uniform>             wconfig:           array<vec4<f32>, 6>;
@@ -267,10 +277,10 @@ const TONIC_CREDIT_SCALE: f32 = 0.5;
 @group(0) @binding(7)  var<storage, read_write> food_grid:         array<atomic<u32>>;
 @group(0) @binding(8)  var<storage, read_write> agent_grid:        array<atomic<u32>>;
 @group(0) @binding(9)  var<storage, read_write> collision_scratch: array<atomic<i32>>;
-@group(0) @binding(10) var<storage, read_write> sensory_buf:       array<f32>;
+@group(0) @binding(10) var<storage, read_write> sensory_buffer:       array<f32>;
 @group(0) @binding(11) var<storage, read_write> brain_state:       array<f32>;
-@group(0) @binding(12) var<storage, read_write> pattern_buf:       array<f32>;
-@group(0) @binding(13) var<storage, read_write> history_buf:       array<f32>;
+@group(0) @binding(12) var<storage, read_write> pattern_buffer:       array<f32>;
+@group(0) @binding(13) var<storage, read_write> history_buffer:       array<f32>;
 @group(0) @binding(14) var<uniform>             brain_config:      array<vec4<f32>, 3>;
 @group(0) @binding(15) var<storage, read_write> dispatch_args:     array<u32, 6>;
 

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -22,95 +22,111 @@ fn agent_physics(agent_id: u32, tick: u32) {
 
     // Safe to early-return: one workgroup == one agent, so all threads agree.
     // See top-of-file invariant re: barrier uniformity.
-    let alive = agent_phys[b + P_ALIVE];
+    let alive = physics_state[b + P_ALIVE];
     if alive < 0.5 { return; }
 
     let dt = wc_f32(WC_DT);
     let world_half = wc_f32(WC_WORLD_HALF_BOUND);
 
     // Snapshot prev energy/integrity
-    agent_phys[b + P_PREV_ENERGY] = agent_phys[b + P_ENERGY];
-    agent_phys[b + P_PREV_INTEGRITY] = agent_phys[b + P_INTEGRITY];
+    physics_state[b + P_PREV_ENERGY] = physics_state[b + P_ENERGY];
+    physics_state[b + P_PREV_INTEGRITY] = physics_state[b + P_INTEGRITY];
 
     // Save last-good position/velocity for NaN recovery
-    let last_pos = vec3<f32>(agent_phys[b + P_POS_X], agent_phys[b + P_POS_Y], agent_phys[b + P_POS_Z]);
-    let last_vel = vec3<f32>(agent_phys[b + P_VEL_X], agent_phys[b + P_VEL_Y], agent_phys[b + P_VEL_Z]);
+    let last_pos = vec3<f32>(physics_state[b + P_POS_X], physics_state[b + P_POS_Y], physics_state[b + P_POS_Z]);
+    let last_vel = vec3<f32>(physics_state[b + P_VEL_X], physics_state[b + P_VEL_Y], physics_state[b + P_VEL_Z]);
 
-    // Read motor commands from decision_buf
-    let dec_base = agent_id * DECISION_STRIDE;
-    let motor_offset = dec_base + DIM + DIM;
-    var motor_fwd = decision_buf[motor_offset];
-    var motor_turn = decision_buf[motor_offset + 1u];
-    var motor_strafe = decision_buf[motor_offset + 2u];
+    // Read motor commands from decision_buffer
+    let decision_base = agent_id * DECISION_STRIDE;
+    let motor_offset = decision_base + DECISION_MOTOR;
+    var motor_forward = decision_buffer[motor_offset];
+    var motor_turn = decision_buffer[motor_offset + 1u];
+    var motor_strafe = decision_buffer[motor_offset + 2u];
 
     // Sanitize motor: clamp [-1,1], NaN -> 0
-    if !is_finite(motor_fwd) { motor_fwd = 0.0; }
+    if !is_finite(motor_forward) { motor_forward = 0.0; }
     if !is_finite(motor_turn) { motor_turn = 0.0; }
     if !is_finite(motor_strafe) { motor_strafe = 0.0; }
-    motor_fwd = clamp(motor_fwd, -1.0, 1.0);
+    motor_forward = clamp(motor_forward, -1.0, 1.0);
     motor_turn = clamp(motor_turn, -1.0, 1.0);
     motor_strafe = clamp(motor_strafe, -1.0, 1.0);
 
     // Turning
-    var yaw = agent_phys[b + P_YAW];
+    var yaw = physics_state[b + P_YAW];
     let prev_yaw = yaw;
     yaw += motor_turn * TURN_SPEED * dt;
-    agent_phys[b + P_YAW] = yaw;
-    agent_phys[b + P_ANGULAR_VEL] = (yaw - prev_yaw) / max(dt, 1e-6);
+    physics_state[b + P_YAW] = yaw;
+    physics_state[b + P_ANGULAR_VEL] = (yaw - prev_yaw) / max(dt, 1e-6);
     let facing = normalize(vec3<f32>(sin(yaw), 0.0, cos(yaw)));
-    agent_phys[b + P_FACING_X] = facing.x;
-    agent_phys[b + P_FACING_Y] = 0.0;
-    agent_phys[b + P_FACING_Z] = facing.z;
+    physics_state[b + P_FACING_X] = facing.x;
+    physics_state[b + P_FACING_Y] = 0.0;
+    physics_state[b + P_FACING_Z] = facing.z;
 
     // Locomotion
     let right = vec3<f32>(facing.z, 0.0, -facing.x);
-    var desired = facing * motor_fwd + right * motor_strafe;
+    var desired = facing * motor_forward + right * motor_strafe;
     let desired_sq = dot(desired, desired);
     if desired_sq > 1.0 {
         desired = desired / sqrt(desired_sq);
     }
     let move_speed = brain_state[agent_id * BRAIN_STRIDE + O_MOVEMENT_SPEED];
-    agent_phys[b + P_VEL_X] = desired.x * move_speed;
-    agent_phys[b + P_VEL_Z] = desired.z * move_speed;
+    physics_state[b + P_VEL_X] = desired.x * move_speed;
+    physics_state[b + P_VEL_Z] = desired.z * move_speed;
 
     // Gravity
-    agent_phys[b + P_VEL_Y] = agent_phys[b + P_VEL_Y] - GRAVITY * dt;
+    physics_state[b + P_VEL_Y] = physics_state[b + P_VEL_Y] - GRAVITY * dt;
 
     // Integrate position
     var pos = vec3<f32>(
-        agent_phys[b + P_POS_X] + agent_phys[b + P_VEL_X] * dt,
-        agent_phys[b + P_POS_Y] + agent_phys[b + P_VEL_Y] * dt,
-        agent_phys[b + P_POS_Z] + agent_phys[b + P_VEL_Z] * dt,
+        physics_state[b + P_POS_X] + physics_state[b + P_VEL_X] * dt,
+        physics_state[b + P_POS_Y] + physics_state[b + P_VEL_Y] * dt,
+        physics_state[b + P_POS_Z] + physics_state[b + P_VEL_Z] * dt,
     );
 
-    // Clamp to world bounds
+    // Bounce off world bounds: clamp position and reflect velocity/facing
+    let pre_clamp_x = pos.x;
+    let pre_clamp_z = pos.z;
     pos.x = clamp(pos.x, -world_half, world_half);
     pos.z = clamp(pos.z, -world_half, world_half);
+    if (pos.x != pre_clamp_x) {
+        physics_state[b + P_VEL_X] *= -1.0;
+        yaw = -yaw;
+        physics_state[b + P_YAW] = yaw;
+        physics_state[b + P_FACING_X] = sin(yaw);
+        physics_state[b + P_FACING_Z] = cos(yaw);
+    }
+    if (pos.z != pre_clamp_z) {
+        physics_state[b + P_VEL_Z] *= -1.0;
+        yaw = 3.14159265 - yaw;
+        physics_state[b + P_YAW] = yaw;
+        physics_state[b + P_FACING_X] = sin(yaw);
+        physics_state[b + P_FACING_Z] = cos(yaw);
+    }
 
     // Ground collision
     let ground = sample_height(pos.x, pos.z);
     if pos.y < ground + AGENT_HALF_HEIGHT {
         pos.y = ground + AGENT_HALF_HEIGHT;
-        agent_phys[b + P_VEL_Y] = 0.0;
+        physics_state[b + P_VEL_Y] = 0.0;
     }
 
     // NaN recovery
     if !is_finite(pos.x) || !is_finite(pos.y) || !is_finite(pos.z) {
         pos = last_pos;
-        agent_phys[b + P_VEL_X] = last_vel.x;
-        agent_phys[b + P_VEL_Y] = last_vel.y;
-        agent_phys[b + P_VEL_Z] = last_vel.z;
+        physics_state[b + P_VEL_X] = last_vel.x;
+        physics_state[b + P_VEL_Y] = last_vel.y;
+        physics_state[b + P_VEL_Z] = last_vel.z;
     }
 
-    agent_phys[b + P_POS_X] = pos.x;
-    agent_phys[b + P_POS_Y] = pos.y;
-    agent_phys[b + P_POS_Z] = pos.z;
+    physics_state[b + P_POS_X] = pos.x;
+    physics_state[b + P_POS_Y] = pos.y;
+    physics_state[b + P_POS_Z] = pos.z;
 
     // Energy depletion
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
     // Normalize by default speed (20.0) so baseline energy drain is unchanged.
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 20.0);
-    var energy = agent_phys[b + P_ENERGY];
+    let movement_mag = min(abs(motor_forward) + abs(motor_strafe), 1.414) * (move_speed / 20.0);
+    var energy = physics_state[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;
 
@@ -118,33 +134,33 @@ fn agent_physics(agent_id: u32, tick: u32) {
     let integrity_scale = bc_f32(CFG_INTEGRITY_SCALE);
     let biome_type = sample_biome(pos.x, pos.z);
     if biome_type == BIOME_DANGER {
-        agent_phys[b + P_INTEGRITY] = agent_phys[b + P_INTEGRITY] - wc_f32(WC_HAZARD_DAMAGE) * integrity_scale;
+        physics_state[b + P_INTEGRITY] = physics_state[b + P_INTEGRITY] - wc_f32(WC_HAZARD_DAMAGE) * integrity_scale;
     }
 
     // Integrity regen when energy > 50%
-    let max_e = agent_phys[b + P_MAX_ENERGY];
-    var integrity = agent_phys[b + P_INTEGRITY];
-    let max_i = agent_phys[b + P_MAX_INTEGRITY];
+    let max_e = physics_state[b + P_MAX_ENERGY];
+    var integrity = physics_state[b + P_INTEGRITY];
+    let max_i = physics_state[b + P_MAX_INTEGRITY];
     if energy / max_e > 0.5 && integrity < max_i {
         integrity = min(integrity + wc_f32(WC_INTEGRITY_REGEN) * integrity_scale, max_i);
     }
 
     // Metabolic brain drain
-    let mem_cap = agent_phys[b + P_MEMORY_CAP];
-    let proc_slots = agent_phys[b + P_PROCESSING_SLOTS];
+    let mem_cap = physics_state[b + P_MEMORY_CAP];
+    let proc_slots = physics_state[b + P_PROCESSING_SLOTS];
     energy -= (METABOLIC_BASE_COST + mem_cap * METABOLIC_MEMORY_COST + proc_slots * METABOLIC_PROCESSING_COST) * metabolic_rate;
 
     // Clamp and death check
     energy = max(energy, 0.0);
     integrity = max(integrity, 0.0);
-    agent_phys[b + P_ENERGY] = energy;
-    agent_phys[b + P_INTEGRITY] = integrity;
+    physics_state[b + P_ENERGY] = energy;
+    physics_state[b + P_INTEGRITY] = integrity;
 
     if energy <= 0.0 || integrity <= 0.0 {
-        agent_phys[b + P_ALIVE] = 0.0;
-        agent_phys[b + P_DIED_FLAG] = 1.0;
+        physics_state[b + P_ALIVE] = 0.0;
+        physics_state[b + P_DIED_FLAG] = 1.0;
     } else {
-        agent_phys[b + P_TICKS_ALIVE] = agent_phys[b + P_TICKS_ALIVE] + 1.0;
+        physics_state[b + P_TICKS_ALIVE] = physics_state[b + P_TICKS_ALIVE] + 1.0;
     }
 }
 
@@ -157,12 +173,12 @@ fn agent_food_detect(agent_id: u32, tid: u32) {
 
     // Safe to early-return: one workgroup == one agent, so all threads agree.
     // See top-of-file invariant re: barrier uniformity.
-    if agent_phys[b + P_ALIVE] < 0.5 { return; }
+    if physics_state[b + P_ALIVE] < 0.5 { return; }
 
     let pos = vec3f(
-        agent_phys[b + P_POS_X],
-        agent_phys[b + P_POS_Y],
-        agent_phys[b + P_POS_Z]);
+        physics_state[b + P_POS_X],
+        physics_state[b + P_POS_Y],
+        physics_state[b + P_POS_Z]);
     let food_count = wc_u32(WC_FOOD_COUNT);
     let eat_radius = wc_f32(WC_FOOD_RADIUS);
     let eat_radius_sq = eat_radius * eat_radius;
@@ -214,8 +230,8 @@ fn agent_food_detect(agent_id: u32, tid: u32) {
             let result = atomicCompareExchangeWeak(&food_flags[best_idx], 0u, 1u);
             if (result.exchanged) {
                 let food_energy = wc_f32(WC_FOOD_ENERGY);
-                agent_phys[b + P_ENERGY] += food_energy;
-                agent_phys[b + P_FOOD_COUNT] += 1.0;
+                physics_state[b + P_ENERGY] += food_energy;
+                physics_state[b + P_FOOD_COUNT] += 1.0;
             }
         }
     }
@@ -227,7 +243,7 @@ fn agent_food_detect(agent_id: u32, tid: u32) {
 
 fn agent_death_respawn(agent_id: u32, tick: u32) {
     let base = agent_id * PHYS_STRIDE;
-    if (agent_phys[base + P_DIED_FLAG] < 0.5) { return; }
+    if (physics_state[base + P_DIED_FLAG] < 0.5) { return; }
 
     // 1. Pick a safe spawn position
     let world_half = wc_f32(WC_WORLD_HALF_BOUND);
@@ -257,41 +273,41 @@ fn agent_death_respawn(agent_id: u32, tick: u32) {
     let spawn_y = sample_height(spawn_x, spawn_z) + AGENT_HALF_HEIGHT;
 
     // 2. Preserve fitness fields
-    let saved_food_count   = agent_phys[base + P_FOOD_COUNT];
-    let saved_ticks_alive  = agent_phys[base + P_TICKS_ALIVE];
-    let saved_death_count  = agent_phys[base + P_DEATH_COUNT] + 1.0;
-    let max_energy         = agent_phys[base + P_MAX_ENERGY];
-    let max_integrity      = agent_phys[base + P_MAX_INTEGRITY];
-    let memory_cap         = agent_phys[base + P_MEMORY_CAP];
-    let processing_slots   = agent_phys[base + P_PROCESSING_SLOTS];
+    let saved_food_count   = physics_state[base + P_FOOD_COUNT];
+    let saved_ticks_alive  = physics_state[base + P_TICKS_ALIVE];
+    let saved_death_count  = physics_state[base + P_DEATH_COUNT] + 1.0;
+    let max_energy         = physics_state[base + P_MAX_ENERGY];
+    let max_integrity      = physics_state[base + P_MAX_INTEGRITY];
+    let memory_cap         = physics_state[base + P_MEMORY_CAP];
+    let processing_slots   = physics_state[base + P_PROCESSING_SLOTS];
 
     // 3. Reset physics state
     for (var i = 0u; i < PHYS_STRIDE; i++) {
-        agent_phys[base + i] = 0.0;
+        physics_state[base + i] = 0.0;
     }
-    agent_phys[base + P_POS_X]           = spawn_x;
-    agent_phys[base + P_POS_Y]           = spawn_y;
-    agent_phys[base + P_POS_Z]           = spawn_z;
-    agent_phys[base + P_FACING_Z]        = 1.0;
-    agent_phys[base + P_ENERGY]          = max_energy;
-    agent_phys[base + P_MAX_ENERGY]      = max_energy;
-    agent_phys[base + P_INTEGRITY]       = max_integrity;
-    agent_phys[base + P_MAX_INTEGRITY]   = max_integrity;
-    agent_phys[base + P_PREV_ENERGY]     = max_energy;
-    agent_phys[base + P_PREV_INTEGRITY]  = max_integrity;
-    agent_phys[base + P_ALIVE]           = 1.0;
-    agent_phys[base + P_MEMORY_CAP]      = memory_cap;
-    agent_phys[base + P_PROCESSING_SLOTS] = processing_slots;
-    agent_phys[base + P_FOOD_COUNT]      = saved_food_count;
-    agent_phys[base + P_TICKS_ALIVE]     = saved_ticks_alive;
-    agent_phys[base + P_DEATH_COUNT]     = saved_death_count;
+    physics_state[base + P_POS_X]           = spawn_x;
+    physics_state[base + P_POS_Y]           = spawn_y;
+    physics_state[base + P_POS_Z]           = spawn_z;
+    physics_state[base + P_FACING_Z]        = 1.0;
+    physics_state[base + P_ENERGY]          = max_energy;
+    physics_state[base + P_MAX_ENERGY]      = max_energy;
+    physics_state[base + P_INTEGRITY]       = max_integrity;
+    physics_state[base + P_MAX_INTEGRITY]   = max_integrity;
+    physics_state[base + P_PREV_ENERGY]     = max_energy;
+    physics_state[base + P_PREV_INTEGRITY]  = max_integrity;
+    physics_state[base + P_ALIVE]           = 1.0;
+    physics_state[base + P_MEMORY_CAP]      = memory_cap;
+    physics_state[base + P_PROCESSING_SLOTS] = processing_slots;
+    physics_state[base + P_FOOD_COUNT]      = saved_food_count;
+    physics_state[base + P_TICKS_ALIVE]     = saved_ticks_alive;
+    physics_state[base + P_DEATH_COUNT]     = saved_death_count;
 
     // 4. Reset brain state
     let brain_base = agent_id * BRAIN_STRIDE;
 
-    let pat_base = agent_id * PATTERN_STRIDE;
+    let pattern_base = agent_id * PATTERN_STRIDE;
     for (var i = 0u; i < MEMORY_CAP; i++) {
-        pattern_buf[pat_base + O_PAT_REINF + i] *= 0.5;
+        pattern_buffer[pattern_base + O_PAT_REINF + i] *= 0.5;
     }
 
     for (var i = 0u; i < 6u; i++) {
@@ -309,15 +325,15 @@ fn agent_death_respawn(agent_id: u32, tick: u32) {
     brain_state[brain_base + O_ACCUM_FWD] = 0.0;
     brain_state[brain_base + O_FATIGUE_FACTOR] = 1.0;
 
-    for (var i = 0u; i < DIM; i++) {
+    for (var i = 0u; i < ENCODED_DIMENSION; i++) {
         brain_state[brain_base + O_HAB_EMA + i] = 0.0;
         brain_state[brain_base + O_HAB_ATTEN + i] = 1.0;
         brain_state[brain_base + O_PREV_ENCODED + i] = 0.0;
     }
 
-    let hist_base = agent_id * HISTORY_STRIDE;
+    let history_base = agent_id * HISTORY_STRIDE;
     for (var i = 0u; i < HISTORY_STRIDE; i++) {
-        history_buf[hist_base + i] = 0.0;
+        history_buffer[history_base + i] = 0.0;
     }
 }
 
@@ -328,7 +344,7 @@ fn agent_death_respawn(agent_id: u32, tick: u32) {
 fn brain_tick_inner(agent_id: u32, tid: u32 /* KERNEL_SUBGROUP_TOPK_PARAMS */) {
     // Safe to early-return: one workgroup == one agent, so all threads agree.
     // See top-of-file invariant re: barrier uniformity.
-    if (agent_phys[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
+    if (physics_state[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
 
     coop_feature_extract(agent_id, tid);
     workgroupBarrier();
@@ -361,13 +377,13 @@ fn brain_tick_inner(agent_id: u32, tid: u32 /* KERNEL_SUBGROUP_TOPK_PARAMS */) {
 // earlier kernel phases, but it does NOT mean all brain inputs are from the
 // same cycle.
 //
-// Vision data (sensory_buf) is written by the external vision pass, which
+// Vision data (sensory_buffer) is written by the external vision pass, which
 // runs in the same GPU command encoder AFTER this kernel dispatch.  The
-// brain therefore reads sensory_buf written by the *previous* batch's vision
+// brain therefore reads sensory_buffer written by the *previous* batch's vision
 // pass — a one-batch lag that is consistent regardless of stride values.
 // Non-visual proprioception (velocity, energy, etc.) follows the same lag
-// because it is also packed into sensory_buf by that vision pass.  In this
-// function, the only physics state read directly from agent_phys before
+// because it is also packed into sensory_buffer by that vision pass.  In this
+// function, the only physics state read directly from physics_state before
 // feature extraction is the same-cycle P_ALIVE flag used for the early-out.
 //
 // When brain_tick_stride == vision_stride the batch covers exactly
@@ -410,9 +426,9 @@ fn kernel_tick(
         workgroupBarrier();
 
         // Brain: all 256 threads, 7 cooperative passes.
-        // Reads sensory_buf (vision + proprioception) from the previous batch's
+        // Reads sensory_buffer (vision + proprioception) from the previous batch's
         // vision pass.  Physics state updated in this cycle is NOT yet in
-        // sensory_buf — that update happens in the vision pass at the end of
+        // sensory_buffer — that update happens in the vision pass at the end of
         // this batch, making it available for the following batch.
         brain_tick_inner(agent_id, tid /* KERNEL_SUBGROUP_TOPK_INNER_ARGS */);
         workgroupBarrier();

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -88,19 +88,22 @@ fn agent_physics(agent_id: u32, tick: u32) {
     let pre_clamp_z = pos.z;
     pos.x = clamp(pos.x, -world_half, world_half);
     pos.z = clamp(pos.z, -world_half, world_half);
+    var bounced = false;
     if (pos.x != pre_clamp_x) {
         physics_state[b + P_VEL_X] *= -1.0;
         yaw = -yaw;
-        physics_state[b + P_YAW] = yaw;
-        physics_state[b + P_FACING_X] = sin(yaw);
-        physics_state[b + P_FACING_Z] = cos(yaw);
+        bounced = true;
     }
     if (pos.z != pre_clamp_z) {
         physics_state[b + P_VEL_Z] *= -1.0;
         yaw = 3.14159265 - yaw;
+        bounced = true;
+    }
+    if (bounced) {
         physics_state[b + P_YAW] = yaw;
         physics_state[b + P_FACING_X] = sin(yaw);
         physics_state[b + P_FACING_Z] = cos(yaw);
+        physics_state[b + P_ANGULAR_VEL] = (yaw - prev_yaw) / max(dt, 1e-6);
     }
 
     // Ground collision

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -96,14 +96,17 @@ fn agent_physics(agent_id: u32, tick: u32) {
     }
     if (pos.z != pre_clamp_z) {
         physics_state[b + P_VEL_Z] *= -1.0;
-        yaw = 3.14159265 - yaw;
+        yaw = PI - yaw;
         bounced = true;
     }
     if (bounced) {
         physics_state[b + P_YAW] = yaw;
         physics_state[b + P_FACING_X] = sin(yaw);
         physics_state[b + P_FACING_Z] = cos(yaw);
-        physics_state[b + P_ANGULAR_VEL] = (yaw - prev_yaw) / max(dt, 1e-6);
+        var yaw_delta = yaw - prev_yaw;
+        if (yaw_delta > PI) { yaw_delta -= TWO_PI; }
+        if (yaw_delta < -PI) { yaw_delta += TWO_PI; }
+        physics_state[b + P_ANGULAR_VEL] = yaw_delta / max(dt, 1e-6);
     }
 
     // Ground collision

--- a/crates/xagent-brain/src/shaders/kernel/phase_agent_grid.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_agent_grid.wgsl
@@ -9,11 +9,11 @@ fn phase_agent_grid(tid: u32) {
     let b = agent * PHYS_STRIDE;
 
     // Skip dead agents
-    if agent_phys[b + P_ALIVE] < 0.5 { return; }
+    if physics_state[b + P_ALIVE] < 0.5 { return; }
 
     // Read position
-    let px = agent_phys[b + P_POS_X];
-    let pz = agent_phys[b + P_POS_Z];
+    let px = physics_state[b + P_POS_X];
+    let pz = physics_state[b + P_POS_Z];
 
     // Compute cell with offset
     let grid_offset = i32(wc_u32(WC_GRID_OFFSET));

--- a/crates/xagent-brain/src/shaders/kernel/phase_collision.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_collision.wgsl
@@ -10,12 +10,12 @@ fn phase_collision_accumulate(tid: u32) {
     let b = agent * PHYS_STRIDE;
 
     // Skip dead agents
-    if agent_phys[b + P_ALIVE] < 0.5 { return; }
+    if physics_state[b + P_ALIVE] < 0.5 { return; }
 
     // Read self position
-    let self_x = agent_phys[b + P_POS_X];
-    let self_y = agent_phys[b + P_POS_Y];
-    let self_z = agent_phys[b + P_POS_Z];
+    let self_x = physics_state[b + P_POS_X];
+    let self_y = physics_state[b + P_POS_Y];
+    let self_z = physics_state[b + P_POS_Z];
 
     // Compute cell with offset
     let grid_offset = i32(wc_u32(WC_GRID_OFFSET));
@@ -49,12 +49,12 @@ fn phase_collision_accumulate(tid: u32) {
                 let ob = other * PHYS_STRIDE;
 
                 // Skip dead other
-                if agent_phys[ob + P_ALIVE] < 0.5 { continue; }
+                if physics_state[ob + P_ALIVE] < 0.5 { continue; }
 
                 // Compute displacement from self to other
-                let diff_x = agent_phys[ob + P_POS_X] - self_x;
-                let diff_y = agent_phys[ob + P_POS_Y] - self_y;
-                let diff_z = agent_phys[ob + P_POS_Z] - self_z;
+                let diff_x = physics_state[ob + P_POS_X] - self_x;
+                let diff_y = physics_state[ob + P_POS_Y] - self_y;
+                let diff_z = physics_state[ob + P_POS_Z] - self_z;
                 let dist_sq = diff_x * diff_x + diff_y * diff_y + diff_z * diff_z;
 
                 if dist_sq < COLLISION_MIN_DIST_SQ && dist_sq > 0.001 {
@@ -98,10 +98,10 @@ fn phase_collision_apply(tid: u32) {
     let b = agent * PHYS_STRIDE;
 
     // Skip dead agents (but scratch was already cleared above)
-    if agent_phys[b + P_ALIVE] < 0.5 { return; }
+    if physics_state[b + P_ALIVE] < 0.5 { return; }
 
     // Apply accumulated push
-    agent_phys[b + P_POS_X] += f32(ipx) / COLLISION_FIXED_SCALE;
-    agent_phys[b + P_POS_Y] += f32(ipy) / COLLISION_FIXED_SCALE;
-    agent_phys[b + P_POS_Z] += f32(ipz) / COLLISION_FIXED_SCALE;
+    physics_state[b + P_POS_X] += f32(ipx) / COLLISION_FIXED_SCALE;
+    physics_state[b + P_POS_Y] += f32(ipy) / COLLISION_FIXED_SCALE;
+    physics_state[b + P_POS_Z] += f32(ipz) / COLLISION_FIXED_SCALE;
 }

--- a/crates/xagent-brain/src/shaders/kernel/phase_death.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_death.wgsl
@@ -5,7 +5,7 @@
 
 fn phase_death_respawn(tid: u32, tick: u32) {
     let base = tid * PHYS_STRIDE;
-    if (agent_phys[base + P_DIED_FLAG] < 0.5) { return; }
+    if (physics_state[base + P_DIED_FLAG] < 0.5) { return; }
 
     // ── 1. Pick a safe spawn position ──────────────────────────────────────
     let world_half = wc_f32(WC_WORLD_HALF_BOUND);
@@ -36,40 +36,40 @@ fn phase_death_respawn(tid: u32, tick: u32) {
     let spawn_y = sample_height(spawn_x, spawn_z) + AGENT_HALF_HEIGHT;
 
     // ── 2. Preserve fitness fields before reset ────────────────────────────
-    let saved_food_count   = agent_phys[base + P_FOOD_COUNT];
-    let saved_ticks_alive  = agent_phys[base + P_TICKS_ALIVE];
-    let saved_death_count  = agent_phys[base + P_DEATH_COUNT] + 1.0;
-    let max_energy         = agent_phys[base + P_MAX_ENERGY];
-    let max_integrity      = agent_phys[base + P_MAX_INTEGRITY];
-    let memory_cap         = agent_phys[base + P_MEMORY_CAP];
-    let processing_slots   = agent_phys[base + P_PROCESSING_SLOTS];
+    let saved_food_count   = physics_state[base + P_FOOD_COUNT];
+    let saved_ticks_alive  = physics_state[base + P_TICKS_ALIVE];
+    let saved_death_count  = physics_state[base + P_DEATH_COUNT] + 1.0;
+    let max_energy         = physics_state[base + P_MAX_ENERGY];
+    let max_integrity      = physics_state[base + P_MAX_INTEGRITY];
+    let memory_cap         = physics_state[base + P_MEMORY_CAP];
+    let processing_slots   = physics_state[base + P_PROCESSING_SLOTS];
 
     // ── 3. Reset physics state ─────────────────────────────────────────────
     // Zero the full stride first, then write specific values.
     for (var i = 0u; i < PHYS_STRIDE; i++) {
-        agent_phys[base + i] = 0.0;
+        physics_state[base + i] = 0.0;
     }
-    agent_phys[base + P_POS_X]           = spawn_x;
-    agent_phys[base + P_POS_Y]           = spawn_y;
-    agent_phys[base + P_POS_Z]           = spawn_z;
+    physics_state[base + P_POS_X]           = spawn_x;
+    physics_state[base + P_POS_Y]           = spawn_y;
+    physics_state[base + P_POS_Z]           = spawn_z;
     // velocity: already zero from the loop
     // facing: (0, 0, 1)
-    agent_phys[base + P_FACING_Z]        = 1.0;
+    physics_state[base + P_FACING_Z]        = 1.0;
     // yaw, angular_vel: already zero
-    agent_phys[base + P_ENERGY]          = max_energy;
-    agent_phys[base + P_MAX_ENERGY]      = max_energy;
-    agent_phys[base + P_INTEGRITY]       = max_integrity;
-    agent_phys[base + P_MAX_INTEGRITY]   = max_integrity;
-    agent_phys[base + P_PREV_ENERGY]     = max_energy;
-    agent_phys[base + P_PREV_INTEGRITY]  = max_integrity;
-    agent_phys[base + P_ALIVE]           = 1.0;
+    physics_state[base + P_ENERGY]          = max_energy;
+    physics_state[base + P_MAX_ENERGY]      = max_energy;
+    physics_state[base + P_INTEGRITY]       = max_integrity;
+    physics_state[base + P_MAX_INTEGRITY]   = max_integrity;
+    physics_state[base + P_PREV_ENERGY]     = max_energy;
+    physics_state[base + P_PREV_INTEGRITY]  = max_integrity;
+    physics_state[base + P_ALIVE]           = 1.0;
     // died_flag: already zero
-    agent_phys[base + P_MEMORY_CAP]      = memory_cap;
-    agent_phys[base + P_PROCESSING_SLOTS] = processing_slots;
+    physics_state[base + P_MEMORY_CAP]      = memory_cap;
+    physics_state[base + P_PROCESSING_SLOTS] = processing_slots;
     // Restore fitness fields
-    agent_phys[base + P_FOOD_COUNT]      = saved_food_count;
-    agent_phys[base + P_TICKS_ALIVE]     = saved_ticks_alive;
-    agent_phys[base + P_DEATH_COUNT]     = saved_death_count;
+    physics_state[base + P_FOOD_COUNT]      = saved_food_count;
+    physics_state[base + P_TICKS_ALIVE]     = saved_ticks_alive;
+    physics_state[base + P_DEATH_COUNT]     = saved_death_count;
 
     // ── 4. Reset brain state ───────────────────────────────────────────────
     let brain_base = tid * BRAIN_STRIDE;
@@ -77,7 +77,7 @@ fn phase_death_respawn(tid: u32, tick: u32) {
     // Halve reinforcement values
     let pat_base = tid * PATTERN_STRIDE;
     for (var i = 0u; i < MEMORY_CAP; i++) {
-        pattern_buf[pat_base + O_PAT_REINF + i] *= 0.5;
+        pattern_buffer[pat_base + O_PAT_REINF + i] *= 0.5;
     }
 
     // Zero homeostasis EMAs (6 values)
@@ -99,7 +99,7 @@ fn phase_death_respawn(tid: u32, tick: u32) {
     brain_state[brain_base + O_FATIGUE_FACTOR] = 1.0;
 
     // Reset habituation (fresh start for new life's perceptual context)
-    for (var i = 0u; i < DIM; i++) {
+    for (var i = 0u; i < ENCODED_DIMENSION; i++) {
         brain_state[brain_base + O_HAB_EMA + i] = 0.0;
         brain_state[brain_base + O_HAB_ATTEN + i] = 1.0;
         brain_state[brain_base + O_PREV_ENCODED + i] = 0.0;
@@ -108,6 +108,6 @@ fn phase_death_respawn(tid: u32, tick: u32) {
     // Zero action history
     let hist_base = tid * HISTORY_STRIDE;
     for (var i = 0u; i < HISTORY_STRIDE; i++) {
-        history_buf[hist_base + i] = 0.0;
+        history_buffer[hist_base + i] = 0.0;
     }
 }

--- a/crates/xagent-brain/src/shaders/kernel/phase_food_detect.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_food_detect.wgsl
@@ -9,12 +9,12 @@ fn phase_food_detect(tid: u32) {
     let b = agent * PHYS_STRIDE;
 
     // Skip dead agents
-    let alive = agent_phys[b + P_ALIVE];
+    let alive = physics_state[b + P_ALIVE];
     if alive < 0.5 { return; }
 
     // Agent position
-    let ax = agent_phys[b + P_POS_X];
-    let az = agent_phys[b + P_POS_Z];
+    let ax = physics_state[b + P_POS_X];
+    let az = physics_state[b + P_POS_Z];
 
     // Search 3x3 neighborhood
     let grid_offset = i32(wc_u32(WC_GRID_OFFSET));
@@ -71,8 +71,8 @@ fn phase_food_detect(tid: u32) {
         if result.exchanged {
             // Winner: award energy and increment food count
             let food_energy = wc_f32(WC_FOOD_ENERGY);
-            agent_phys[b + P_ENERGY] = agent_phys[b + P_ENERGY] + food_energy;
-            agent_phys[b + P_FOOD_COUNT] = agent_phys[b + P_FOOD_COUNT] + 1.0;
+            physics_state[b + P_ENERGY] = physics_state[b + P_ENERGY] + food_energy;
+            physics_state[b + P_FOOD_COUNT] = physics_state[b + P_FOOD_COUNT] + 1.0;
         }
     }
 }

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -73,19 +73,22 @@ fn phase_physics(tid: u32, tick: u32) {
     let pre_clamp_z = pos.z;
     pos.x = clamp(pos.x, -world_half, world_half);
     pos.z = clamp(pos.z, -world_half, world_half);
+    var bounced = false;
     if (pos.x != pre_clamp_x) {
         physics_state[b + P_VEL_X] *= -1.0;
         yaw = -yaw;
-        physics_state[b + P_YAW] = yaw;
-        physics_state[b + P_FACING_X] = sin(yaw);
-        physics_state[b + P_FACING_Z] = cos(yaw);
+        bounced = true;
     }
     if (pos.z != pre_clamp_z) {
         physics_state[b + P_VEL_Z] *= -1.0;
         yaw = 3.14159265 - yaw;
+        bounced = true;
+    }
+    if (bounced) {
         physics_state[b + P_YAW] = yaw;
         physics_state[b + P_FACING_X] = sin(yaw);
         physics_state[b + P_FACING_Z] = cos(yaw);
+        physics_state[b + P_ANGULAR_VEL] = (yaw - prev_yaw) / max(dt, 1e-6);
     }
 
     // Ground collision (use sample_height from common.wgsl)

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -7,97 +7,112 @@ fn phase_physics(tid: u32, tick: u32) {
     if agent >= agent_count { return; }
     let b = agent * PHYS_STRIDE;
 
-    let alive = agent_phys[b + P_ALIVE];
+    let alive = physics_state[b + P_ALIVE];
     if alive < 0.5 { return; }
 
     let dt = wc_f32(WC_DT);
     let world_half = wc_f32(WC_WORLD_HALF_BOUND);
 
     // Snapshot prev energy/integrity
-    agent_phys[b + P_PREV_ENERGY] = agent_phys[b + P_ENERGY];
-    agent_phys[b + P_PREV_INTEGRITY] = agent_phys[b + P_INTEGRITY];
+    physics_state[b + P_PREV_ENERGY] = physics_state[b + P_ENERGY];
+    physics_state[b + P_PREV_INTEGRITY] = physics_state[b + P_INTEGRITY];
 
     // Save last-good position/velocity for NaN recovery
-    let last_pos = vec3<f32>(agent_phys[b + P_POS_X], agent_phys[b + P_POS_Y], agent_phys[b + P_POS_Z]);
-    let last_vel = vec3<f32>(agent_phys[b + P_VEL_X], agent_phys[b + P_VEL_Y], agent_phys[b + P_VEL_Z]);
+    let last_pos = vec3<f32>(physics_state[b + P_POS_X], physics_state[b + P_POS_Y], physics_state[b + P_POS_Z]);
+    let last_vel = vec3<f32>(physics_state[b + P_VEL_X], physics_state[b + P_VEL_Y], physics_state[b + P_VEL_Z]);
 
-    // Read motor commands from decision_buf
-    // Motor layout in decision_buf: offset DIM+DIM within DECISION_STRIDE per agent
-    let dec_base = agent * DECISION_STRIDE;
-    let motor_offset = dec_base + DIM + DIM;
-    var motor_fwd = decision_buf[motor_offset];
-    var motor_turn = decision_buf[motor_offset + 1u];
-    var motor_strafe = decision_buf[motor_offset + 2u];
+    // Read motor commands from decision_buffer
+    let decision_base = agent * DECISION_STRIDE;
+    let motor_offset = decision_base + DECISION_MOTOR;
+    var motor_forward = decision_buffer[motor_offset];
+    var motor_turn = decision_buffer[motor_offset + 1u];
+    var motor_strafe = decision_buffer[motor_offset + 2u];
 
     // Sanitize motor: clamp [-1,1], NaN -> 0
-    if !is_finite(motor_fwd) { motor_fwd = 0.0; }
+    if !is_finite(motor_forward) { motor_forward = 0.0; }
     if !is_finite(motor_turn) { motor_turn = 0.0; }
     if !is_finite(motor_strafe) { motor_strafe = 0.0; }
-    motor_fwd = clamp(motor_fwd, -1.0, 1.0);
+    motor_forward = clamp(motor_forward, -1.0, 1.0);
     motor_turn = clamp(motor_turn, -1.0, 1.0);
     motor_strafe = clamp(motor_strafe, -1.0, 1.0);
 
     // Turning
-    var yaw = agent_phys[b + P_YAW];
+    var yaw = physics_state[b + P_YAW];
     let prev_yaw = yaw;
     yaw += motor_turn * TURN_SPEED * dt;
-    agent_phys[b + P_YAW] = yaw;
-    agent_phys[b + P_ANGULAR_VEL] = (yaw - prev_yaw) / max(dt, 1e-6);
+    physics_state[b + P_YAW] = yaw;
+    physics_state[b + P_ANGULAR_VEL] = (yaw - prev_yaw) / max(dt, 1e-6);
     let facing = normalize(vec3<f32>(sin(yaw), 0.0, cos(yaw)));
-    agent_phys[b + P_FACING_X] = facing.x;
-    agent_phys[b + P_FACING_Y] = 0.0;
-    agent_phys[b + P_FACING_Z] = facing.z;
+    physics_state[b + P_FACING_X] = facing.x;
+    physics_state[b + P_FACING_Y] = 0.0;
+    physics_state[b + P_FACING_Z] = facing.z;
 
     // Locomotion
     let right = vec3<f32>(facing.z, 0.0, -facing.x);
-    var desired = facing * motor_fwd + right * motor_strafe;
+    var desired = facing * motor_forward + right * motor_strafe;
     let desired_sq = dot(desired, desired);
     if desired_sq > 1.0 {
         desired = desired / sqrt(desired_sq);
     }
     let move_speed = brain_state[agent * BRAIN_STRIDE + O_MOVEMENT_SPEED];
-    agent_phys[b + P_VEL_X] = desired.x * move_speed;
-    agent_phys[b + P_VEL_Z] = desired.z * move_speed;
+    physics_state[b + P_VEL_X] = desired.x * move_speed;
+    physics_state[b + P_VEL_Z] = desired.z * move_speed;
 
     // Gravity
-    agent_phys[b + P_VEL_Y] = agent_phys[b + P_VEL_Y] - GRAVITY * dt;
+    physics_state[b + P_VEL_Y] = physics_state[b + P_VEL_Y] - GRAVITY * dt;
 
     // Integrate position
     var pos = vec3<f32>(
-        agent_phys[b + P_POS_X] + agent_phys[b + P_VEL_X] * dt,
-        agent_phys[b + P_POS_Y] + agent_phys[b + P_VEL_Y] * dt,
-        agent_phys[b + P_POS_Z] + agent_phys[b + P_VEL_Z] * dt,
+        physics_state[b + P_POS_X] + physics_state[b + P_VEL_X] * dt,
+        physics_state[b + P_POS_Y] + physics_state[b + P_VEL_Y] * dt,
+        physics_state[b + P_POS_Z] + physics_state[b + P_VEL_Z] * dt,
     );
 
-    // Clamp to world bounds
+    // Bounce off world bounds: clamp position and reflect velocity/facing
+    let pre_clamp_x = pos.x;
+    let pre_clamp_z = pos.z;
     pos.x = clamp(pos.x, -world_half, world_half);
     pos.z = clamp(pos.z, -world_half, world_half);
+    if (pos.x != pre_clamp_x) {
+        physics_state[b + P_VEL_X] *= -1.0;
+        yaw = -yaw;
+        physics_state[b + P_YAW] = yaw;
+        physics_state[b + P_FACING_X] = sin(yaw);
+        physics_state[b + P_FACING_Z] = cos(yaw);
+    }
+    if (pos.z != pre_clamp_z) {
+        physics_state[b + P_VEL_Z] *= -1.0;
+        yaw = 3.14159265 - yaw;
+        physics_state[b + P_YAW] = yaw;
+        physics_state[b + P_FACING_X] = sin(yaw);
+        physics_state[b + P_FACING_Z] = cos(yaw);
+    }
 
     // Ground collision (use sample_height from common.wgsl)
     let ground = sample_height(pos.x, pos.z);
     if pos.y < ground + AGENT_HALF_HEIGHT {
         pos.y = ground + AGENT_HALF_HEIGHT;
-        agent_phys[b + P_VEL_Y] = 0.0;
+        physics_state[b + P_VEL_Y] = 0.0;
     }
 
     // NaN recovery
     if !is_finite(pos.x) || !is_finite(pos.y) || !is_finite(pos.z) {
         pos = last_pos;
-        agent_phys[b + P_VEL_X] = last_vel.x;
-        agent_phys[b + P_VEL_Y] = last_vel.y;
-        agent_phys[b + P_VEL_Z] = last_vel.z;
+        physics_state[b + P_VEL_X] = last_vel.x;
+        physics_state[b + P_VEL_Y] = last_vel.y;
+        physics_state[b + P_VEL_Z] = last_vel.z;
     }
 
-    agent_phys[b + P_POS_X] = pos.x;
-    agent_phys[b + P_POS_Y] = pos.y;
-    agent_phys[b + P_POS_Z] = pos.z;
+    physics_state[b + P_POS_X] = pos.x;
+    physics_state[b + P_POS_Y] = pos.y;
+    physics_state[b + P_POS_Z] = pos.z;
 
     // Energy depletion (scaled by metabolic_rate from brain config)
     let metabolic_rate = bc_f32(CFG_METABOLIC_RATE);
     // Normalize by default speed (20.0) so baseline energy drain is unchanged;
     // faster agents pay proportionally more, slower agents pay less.
-    let movement_mag = min(abs(motor_fwd) + abs(motor_strafe), 1.414) * (move_speed / 20.0);
-    var energy = agent_phys[b + P_ENERGY];
+    let movement_mag = min(abs(motor_forward) + abs(motor_strafe), 1.414) * (move_speed / 20.0);
+    var energy = physics_state[b + P_ENERGY];
     energy -= wc_f32(WC_ENERGY_DEPLETION) * metabolic_rate;
     energy -= movement_mag * wc_f32(WC_MOVEMENT_COST) * metabolic_rate;
 
@@ -105,33 +120,33 @@ fn phase_physics(tid: u32, tick: u32) {
     let integrity_scale = bc_f32(CFG_INTEGRITY_SCALE);
     let biome_type = sample_biome(pos.x, pos.z);
     if biome_type == BIOME_DANGER {
-        agent_phys[b + P_INTEGRITY] = agent_phys[b + P_INTEGRITY] - wc_f32(WC_HAZARD_DAMAGE) * integrity_scale;
+        physics_state[b + P_INTEGRITY] = physics_state[b + P_INTEGRITY] - wc_f32(WC_HAZARD_DAMAGE) * integrity_scale;
     }
 
     // Integrity regen when energy > 50%
-    let max_e = agent_phys[b + P_MAX_ENERGY];
-    var integrity = agent_phys[b + P_INTEGRITY];
-    let max_i = agent_phys[b + P_MAX_INTEGRITY];
+    let max_e = physics_state[b + P_MAX_ENERGY];
+    var integrity = physics_state[b + P_INTEGRITY];
+    let max_i = physics_state[b + P_MAX_INTEGRITY];
     if energy / max_e > 0.5 && integrity < max_i {
         integrity = min(integrity + wc_f32(WC_INTEGRITY_REGEN) * integrity_scale, max_i);
     }
 
     // Metabolic brain drain
-    let mem_cap = agent_phys[b + P_MEMORY_CAP];
-    let proc_slots = agent_phys[b + P_PROCESSING_SLOTS];
+    let mem_cap = physics_state[b + P_MEMORY_CAP];
+    let proc_slots = physics_state[b + P_PROCESSING_SLOTS];
     energy -= (METABOLIC_BASE_COST + mem_cap * METABOLIC_MEMORY_COST + proc_slots * METABOLIC_PROCESSING_COST) * metabolic_rate;
 
     // Clamp and death check
     energy = max(energy, 0.0);
     integrity = max(integrity, 0.0);
-    agent_phys[b + P_ENERGY] = energy;
-    agent_phys[b + P_INTEGRITY] = integrity;
+    physics_state[b + P_ENERGY] = energy;
+    physics_state[b + P_INTEGRITY] = integrity;
 
     if energy <= 0.0 || integrity <= 0.0 {
-        agent_phys[b + P_ALIVE] = 0.0;
-        agent_phys[b + P_DIED_FLAG] = 1.0;
+        physics_state[b + P_ALIVE] = 0.0;
+        physics_state[b + P_DIED_FLAG] = 1.0;
     } else {
         // Increment ticks alive (stored as f32, safe for integers up to 2^24)
-        agent_phys[b + P_TICKS_ALIVE] = agent_phys[b + P_TICKS_ALIVE] + 1.0;
+        physics_state[b + P_TICKS_ALIVE] = physics_state[b + P_TICKS_ALIVE] + 1.0;
     }
 }

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -81,14 +81,17 @@ fn phase_physics(tid: u32, tick: u32) {
     }
     if (pos.z != pre_clamp_z) {
         physics_state[b + P_VEL_Z] *= -1.0;
-        yaw = 3.14159265 - yaw;
+        yaw = PI - yaw;
         bounced = true;
     }
     if (bounced) {
         physics_state[b + P_YAW] = yaw;
         physics_state[b + P_FACING_X] = sin(yaw);
         physics_state[b + P_FACING_Z] = cos(yaw);
-        physics_state[b + P_ANGULAR_VEL] = (yaw - prev_yaw) / max(dt, 1e-6);
+        var yaw_delta = yaw - prev_yaw;
+        if (yaw_delta > PI) { yaw_delta -= TWO_PI; }
+        if (yaw_delta < -PI) { yaw_delta += TWO_PI; }
+        physics_state[b + P_ANGULAR_VEL] = yaw_delta / max(dt, 1e-6);
     }
 
     // Ground collision (use sample_height from common.wgsl)

--- a/crates/xagent-brain/src/shaders/kernel/phase_vision.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_vision.wgsl
@@ -9,19 +9,19 @@
 
 fn vision_single_ray(agent_id: u32, ray_idx: u32) {
     let base = agent_id * PHYS_STRIDE;
-    if (agent_phys[base + P_ALIVE] < 0.5) { return; }
+    if (physics_state[base + P_ALIVE] < 0.5) { return; }
 
     let s_base = agent_id * SENSORY_STRIDE;
 
     let pos = vec3<f32>(
-        agent_phys[base + P_POS_X],
-        agent_phys[base + P_POS_Y],
-        agent_phys[base + P_POS_Z],
+        physics_state[base + P_POS_X],
+        physics_state[base + P_POS_Y],
+        physics_state[base + P_POS_Z],
     );
     let facing = vec3<f32>(
-        agent_phys[base + P_FACING_X],
-        agent_phys[base + P_FACING_Y],
-        agent_phys[base + P_FACING_Z],
+        physics_state[base + P_FACING_X],
+        physics_state[base + P_FACING_Y],
+        physics_state[base + P_FACING_Z],
     );
 
     let grid_width  = wc_u32(WC_GRID_WIDTH);
@@ -115,11 +115,11 @@ fn vision_single_ray(agent_id: u32, ray_idx: u32) {
                     if other == agent_id { continue; }
 
                     let ob = other * PHYS_STRIDE;
-                    if agent_phys[ob + P_ALIVE] < 0.5 { continue; }
+                    if physics_state[ob + P_ALIVE] < 0.5 { continue; }
 
-                    let ox = agent_phys[ob + P_POS_X];
-                    let oy = agent_phys[ob + P_POS_Y];
-                    let oz = agent_phys[ob + P_POS_Z];
+                    let ox = physics_state[ob + P_POS_X];
+                    let oy = physics_state[ob + P_POS_Y];
+                    let oz = physics_state[ob + P_POS_Z];
 
                     let dx = ray_pos.x - ox;
                     let dy = ray_pos.y - oy;
@@ -161,18 +161,18 @@ fn vision_single_ray(agent_id: u32, ray_idx: u32) {
 
     // ── Write vision results ──────────────────────────────────────────
     let ci = s_base + ray_idx * 4u;
-    sensory_buf[ci]      = hit_color.x;
-    sensory_buf[ci + 1u] = hit_color.y;
-    sensory_buf[ci + 2u] = hit_color.z;
-    sensory_buf[ci + 3u] = hit_color.w;
-    sensory_buf[s_base + VISION_COLOR_COUNT + ray_idx] = hit_depth / VISION_MAX_DIST;
+    sensory_buffer[ci]      = hit_color.x;
+    sensory_buffer[ci + 1u] = hit_color.y;
+    sensory_buffer[ci + 2u] = hit_color.z;
+    sensory_buffer[ci + 3u] = hit_color.w;
+    sensory_buffer[s_base + VISION_COLOR_COUNT + ray_idx] = hit_depth / VISION_MAX_DIST;
 }
 
 // ── Per-agent non-visual senses ───────────────────────────────────────────
 
 fn phase_vision_senses(tid: u32) {
     let base = tid * PHYS_STRIDE;
-    if (agent_phys[base + P_ALIVE] < 0.5) { return; }
+    if (physics_state[base + P_ALIVE] < 0.5) { return; }
 
     let agent_count = wc_u32(WC_AGENT_COUNT);
     if tid >= agent_count { return; }
@@ -182,43 +182,43 @@ fn phase_vision_senses(tid: u32) {
     let grid_offset = i32(wc_u32(WC_GRID_OFFSET));
 
     let pos = vec3<f32>(
-        agent_phys[base + P_POS_X],
-        agent_phys[base + P_POS_Y],
-        agent_phys[base + P_POS_Z],
+        physics_state[base + P_POS_X],
+        physics_state[base + P_POS_Y],
+        physics_state[base + P_POS_Z],
     );
 
     let nv_base = s_base + VISION_COLOR_COUNT + VISION_DEPTH_COUNT;
     var off = nv_base;
 
-    sensory_buf[off]      = agent_phys[base + P_VEL_X];
-    sensory_buf[off + 1u] = agent_phys[base + P_VEL_Y];
-    sensory_buf[off + 2u] = agent_phys[base + P_VEL_Z];
+    sensory_buffer[off]      = physics_state[base + P_VEL_X];
+    sensory_buffer[off + 1u] = physics_state[base + P_VEL_Y];
+    sensory_buffer[off + 2u] = physics_state[base + P_VEL_Z];
     off += 3u;
 
-    sensory_buf[off]      = agent_phys[base + P_FACING_X];
-    sensory_buf[off + 1u] = agent_phys[base + P_FACING_Y];
-    sensory_buf[off + 2u] = agent_phys[base + P_FACING_Z];
+    sensory_buffer[off]      = physics_state[base + P_FACING_X];
+    sensory_buffer[off + 1u] = physics_state[base + P_FACING_Y];
+    sensory_buffer[off + 2u] = physics_state[base + P_FACING_Z];
     off += 3u;
 
-    sensory_buf[off] = agent_phys[base + P_ANGULAR_VEL];
+    sensory_buffer[off] = physics_state[base + P_ANGULAR_VEL];
     off += 1u;
 
-    let energy = agent_phys[base + P_ENERGY];
-    let max_energy = agent_phys[base + P_MAX_ENERGY];
-    sensory_buf[off] = energy / max(max_energy, 1e-6);
+    let energy = physics_state[base + P_ENERGY];
+    let max_energy = physics_state[base + P_MAX_ENERGY];
+    sensory_buffer[off] = energy / max(max_energy, 1e-6);
     off += 1u;
 
-    let integrity = agent_phys[base + P_INTEGRITY];
-    let max_integrity = agent_phys[base + P_MAX_INTEGRITY];
-    sensory_buf[off] = integrity / max(max_integrity, 1e-6);
+    let integrity = physics_state[base + P_INTEGRITY];
+    let max_integrity = physics_state[base + P_MAX_INTEGRITY];
+    sensory_buffer[off] = integrity / max(max_integrity, 1e-6);
     off += 1u;
 
-    let prev_energy = agent_phys[base + P_PREV_ENERGY];
-    sensory_buf[off] = energy - prev_energy;
+    let prev_energy = physics_state[base + P_PREV_ENERGY];
+    sensory_buffer[off] = energy - prev_energy;
     off += 1u;
 
-    let prev_integrity = agent_phys[base + P_PREV_INTEGRITY];
-    sensory_buf[off] = integrity - prev_integrity;
+    let prev_integrity = physics_state[base + P_PREV_INTEGRITY];
+    sensory_buffer[off] = integrity - prev_integrity;
     off += 1u;
 
     // ── Touch contacts ────────────────────────────────────────────────
@@ -226,7 +226,7 @@ fn phase_vision_senses(tid: u32) {
     let touch_base = off;
 
     for (var i: u32 = 0u; i < MAX_TOUCH_CONTACTS * 4u; i++) {
-        sensory_buf[touch_base + i] = 0.0;
+        sensory_buffer[touch_base + i] = 0.0;
     }
 
     let self_cx = cell_coord(pos.x) + grid_offset;
@@ -259,10 +259,10 @@ fn phase_vision_senses(tid: u32) {
                 if dist < TOUCH_FOOD_RANGE {
                     let slot = touch_base + touch_count * 4u;
                     let inv_dist = 1.0 / max(dist, 1e-6);
-                    sensory_buf[slot]      = fdx * inv_dist;
-                    sensory_buf[slot + 1u] = fdz * inv_dist;
-                    sensory_buf[slot + 2u] = 1.0 - dist / TOUCH_FOOD_RANGE;
-                    sensory_buf[slot + 3u] = f32(TOUCH_FOOD) / 4.0;
+                    sensory_buffer[slot]      = fdx * inv_dist;
+                    sensory_buffer[slot + 1u] = fdz * inv_dist;
+                    sensory_buffer[slot + 2u] = 1.0 - dist / TOUCH_FOOD_RANGE;
+                    sensory_buffer[slot + 3u] = f32(TOUCH_FOOD) / 4.0;
                     touch_count += 1u;
                 }
             }
@@ -290,19 +290,19 @@ fn phase_vision_senses(tid: u32) {
                 if other == tid { continue; }
 
                 let ob = other * PHYS_STRIDE;
-                if agent_phys[ob + P_ALIVE] < 0.5 { continue; }
+                if physics_state[ob + P_ALIVE] < 0.5 { continue; }
 
-                let adx = agent_phys[ob + P_POS_X] - pos.x;
-                let adz = agent_phys[ob + P_POS_Z] - pos.z;
+                let adx = physics_state[ob + P_POS_X] - pos.x;
+                let adz = physics_state[ob + P_POS_Z] - pos.z;
                 let dist = sqrt(adx * adx + adz * adz);
 
                 if dist < TOUCH_AGENT_RANGE {
                     let slot = touch_base + touch_count * 4u;
                     let inv_dist = 1.0 / max(dist, 1e-6);
-                    sensory_buf[slot]      = adx * inv_dist;
-                    sensory_buf[slot + 1u] = adz * inv_dist;
-                    sensory_buf[slot + 2u] = 1.0 - dist / TOUCH_AGENT_RANGE;
-                    sensory_buf[slot + 3u] = f32(TOUCH_AGENT) / 4.0;
+                    sensory_buffer[slot]      = adx * inv_dist;
+                    sensory_buffer[slot + 1u] = adz * inv_dist;
+                    sensory_buffer[slot + 2u] = 1.0 - dist / TOUCH_AGENT_RANGE;
+                    sensory_buffer[slot + 3u] = f32(TOUCH_AGENT) / 4.0;
                     touch_count += 1u;
                 }
             }

--- a/crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/vision_tick.wgsl
@@ -2,7 +2,7 @@
 // dispatch(agent_count, 1, 1) — each workgroup's WORKGROUP_SIZE threads
 // cooperatively cast all VISION_RAYS rays (looping when VISION_RAYS >
 // WORKGROUP_SIZE), then thread 0 packs proprioception/interoception/touch
-// into sensory_buf.
+// into sensory_buffer.
 
 const WORKGROUP_SIZE: u32 = 256u;
 
@@ -14,7 +14,7 @@ fn vision_tick(
     let agent_id = wgid.x;
     let tid = lid.x;
 
-    if (agent_phys[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
+    if (physics_state[agent_id * PHYS_STRIDE + P_ALIVE] < 0.5) { return; }
 
     // Each thread casts rays in a strided loop (handles VISION_RAYS > WORKGROUP_SIZE)
     for (var ray = tid; ray < VISION_RAYS; ray += WORKGROUP_SIZE) {

--- a/crates/xagent-sandbox/README.md
+++ b/crates/xagent-sandbox/README.md
@@ -606,7 +606,7 @@ When enabled, `agent.can_reproduce(tick)` is true (alive, age ≥ 5000 ticks) an
      clamped to ≥ 0.0001.
    - Integers (`memory_capacity`, `processing_slots`):
      multiplied by [0.9, 1.1], rounded, clamped to ≥ 1.
-   - `visual_encoding_size` and `representation_dim` are **not mutated** (visual_encoding_size must match the sensory pipeline; representation_dim is locked to prevent weight inheritance breakage across generations).
+   - `visual_encoding_size` and `representation_dimension` are **not mutated** (visual_encoding_size must match the sensory pipeline; representation_dimension is locked to prevent weight inheritance breakage across generations).
 3. Child spawns near parent (±5 units offset), generation = parent generation + 1.
 4. Child gets a fresh brain with the mutated config.
 
@@ -665,7 +665,7 @@ On death the agent is respawned with a **fresh brain** (no persistence in headle
 | `memory_capacity` | 24 | 128 | 512 | Max stored patterns |
 | `processing_slots` | 8 | 16 | 32 | Max patterns recalled per tick |
 | `visual_encoding_size` | 32 | 64 | 128 | Downsampled visual vector size |
-| `representation_dim` | 16 | 32 | 64 | Internal representation length |
+| `representation_dimension` | 128 | 128 | 128 | Internal representation length |
 | `learning_rate` | 0.08 | 0.05 | 0.03 | Association update rate |
 | `decay_rate` | 0.002 | 0.001 | 0.0005 | Unreinforced pattern decay per tick |
 
@@ -907,7 +907,7 @@ death/respawn.
 - When enabled: agent must survive 5000 ticks continuously.
 - **Once per life**: `has_reproduced` flag prevents repeated spawning.
 - **Population cap**: `MAX_AGENTS = 100`.
-- **Mutation**: Each `BrainConfig` parameter is perturbed using momentum-biased perturbation. Each island maintains a per-parameter momentum vector that learns which mutation directions improve fitness. The perturbation combines random noise (±strength%) with a directional nudge from momentum. Parameters with strong momentum are pushed toward winning values; parameters with weak momentum get mostly random exploration. `visual_encoding_size` and `representation_dim` are preserved (visual_encoding_size must match the sensory pipeline; representation_dim is locked to prevent weight inheritance breakage across generations).
+- **Mutation**: Each `BrainConfig` parameter is perturbed using momentum-biased perturbation. Each island maintains a per-parameter momentum vector that learns which mutation directions improve fitness. The perturbation combines random noise (±strength%) with a directional nudge from momentum. Parameters with strong momentum are pushed toward winning values; parameters with weak momentum get mostly random exploration. `visual_encoding_size` and `representation_dimension` are preserved (visual_encoding_size must match the sensory pipeline; representation_dimension is locked to prevent weight inheritance breakage across generations).
 - **Generation tracking**: Generation increments on each death/respawn, tracking how many lives the agent has lived.
 
 ### Telemetry Focus

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -14,7 +14,8 @@ const MAX_MEMORY_CAPACITY: usize = 2048;
 /// Large preset uses 32; 128 gives ~4x evolutionary headroom.
 const MAX_PROCESSING_SLOTS: usize = 128;
 use xagent_brain::buffers::{
-    AgentBrainState, DIM, FIXED_TAIL_SIZE, O_ACT_FWD_WTS, O_ACT_TURN_WTS, O_PRED_CTX_WT,
+    AgentBrainState, ENCODED_DIMENSION, FIXED_TAIL_SIZE, O_ACTION_FORWARD_WEIGHTS,
+    O_ACTION_TURN_WEIGHTS, O_PREDICTOR_CONTEXT_WEIGHT, PREDICTOR_DIMENSION,
 };
 use xagent_shared::{BodyState, BrainConfig, InternalState, SensoryFrame};
 
@@ -321,7 +322,7 @@ pub fn mutate_config_with_strength(
             )
             .min(MAX_PROCESSING_SLOTS),
         visual_encoding_size: parent.visual_encoding_size,
-        representation_dim: parent.representation_dim,
+        representation_dimension: parent.representation_dimension,
         learning_rate: momentum.biased_perturb_f(
             &mut rng,
             parent.learning_rate,
@@ -377,31 +378,33 @@ pub fn mutate_brain_state(state: &AgentBrainState, strength: f32) -> AgentBrainS
     let mut mutated = state.clone();
 
     // Derive layout from actual state length (supports dynamic vision_width × vision_height).
-    // brain_stride = fc * DIM + DIM + DIM*DIM + FIXED_TAIL_SIZE
+    // brain_stride = fc * ENCODED_DIMENSION + ENCODED_DIMENSION + ENCODED_DIMENSION*ENCODED_DIMENSION + FIXED_TAIL_SIZE
     let variable_part = state
         .brain_state
         .len()
-        .checked_sub(DIM + DIM * DIM + FIXED_TAIL_SIZE)
+        .checked_sub(ENCODED_DIMENSION + PREDICTOR_DIMENSION * ENCODED_DIMENSION + FIXED_TAIL_SIZE)
         .expect("brain_state too short for layout");
     assert!(
-        variable_part % DIM == 0,
-        "brain_state length not aligned to DIM"
+        variable_part % ENCODED_DIMENSION == 0,
+        "brain_state length not aligned to ENCODED_DIMENSION"
     );
-    let fc = variable_part / DIM;
+    let fc = variable_part / ENCODED_DIMENSION;
 
-    let o_pred_wts = fc * DIM + DIM;
-    let o_pred_ctx = o_pred_wts + DIM * DIM;
-    // Fixed deltas from O_PRED_CTX_WT are layout-independent
-    let act_fwd = o_pred_ctx + (O_ACT_FWD_WTS - O_PRED_CTX_WT);
-    let act_turn = o_pred_ctx + (O_ACT_TURN_WTS - O_PRED_CTX_WT);
+    let predictor_weights_offset = fc * ENCODED_DIMENSION + ENCODED_DIMENSION;
+    let predictor_context_offset =
+        predictor_weights_offset + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
+    // Fixed deltas from O_PREDICTOR_CONTEXT_WEIGHT are layout-independent
+    let act_fwd =
+        predictor_context_offset + (O_ACTION_FORWARD_WEIGHTS - O_PREDICTOR_CONTEXT_WEIGHT);
+    let act_turn = predictor_context_offset + (O_ACTION_TURN_WEIGHTS - O_PREDICTOR_CONTEXT_WEIGHT);
 
     assert!(
-        act_turn + DIM <= state.brain_state.len(),
+        act_turn + ENCODED_DIMENSION <= state.brain_state.len(),
         "computed offsets exceed brain_state bounds"
     );
 
     // Mutate encoder weights (small perturbation)
-    for i in 0..(fc * DIM) {
+    for i in 0..(fc * ENCODED_DIMENSION) {
         if rng.random::<f32>() < 0.1 {
             mutated.brain_state[i] += (rng.random::<f32>() * 2.0 - 1.0) * strength * 0.1;
             mutated.brain_state[i] = mutated.brain_state[i].clamp(-2.0, 2.0);
@@ -409,7 +412,7 @@ pub fn mutate_brain_state(state: &AgentBrainState, strength: f32) -> AgentBrainS
     }
 
     // Mutate action weights
-    for i in 0..DIM {
+    for i in 0..ENCODED_DIMENSION {
         if rng.random::<f32>() < 0.2 {
             mutated.brain_state[act_fwd + i] += (rng.random::<f32>() * 2.0 - 1.0) * strength * 0.2;
             mutated.brain_state[act_turn + i] += (rng.random::<f32>() * 2.0 - 1.0) * strength * 0.2;
@@ -417,12 +420,12 @@ pub fn mutate_brain_state(state: &AgentBrainState, strength: f32) -> AgentBrainS
     }
 
     // Mutate predictor weights
-    for i in 0..(DIM * DIM) {
+    for i in 0..(PREDICTOR_DIMENSION * ENCODED_DIMENSION) {
         if rng.random::<f32>() < 0.05 {
-            mutated.brain_state[o_pred_wts + i] +=
+            mutated.brain_state[predictor_weights_offset + i] +=
                 (rng.random::<f32>() * 2.0 - 1.0) * strength * 0.1;
-            mutated.brain_state[o_pred_wts + i] =
-                mutated.brain_state[o_pred_wts + i].clamp(-3.0, 3.0);
+            mutated.brain_state[predictor_weights_offset + i] =
+                mutated.brain_state[predictor_weights_offset + i].clamp(-3.0, 3.0);
         }
     }
 
@@ -444,7 +447,7 @@ pub fn crossover_config(a: &BrainConfig, b: &BrainConfig) -> BrainConfig {
             b.processing_slots
         },
         visual_encoding_size: a.visual_encoding_size,
-        representation_dim: a.representation_dim,
+        representation_dimension: a.representation_dimension,
         learning_rate: if rng.random::<f32>() < 0.5 {
             a.learning_rate
         } else {
@@ -601,7 +604,7 @@ pub fn generate_all_agents_mesh(agents: &[Agent]) -> Mesh {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use xagent_brain::buffers::O_ACT_TURN_WTS;
+    use xagent_brain::buffers::O_ACTION_TURN_WEIGHTS;
 
     #[test]
     fn reset_for_new_life_clears_fatigue_history() {
@@ -624,14 +627,15 @@ mod tests {
     fn mutate_brain_state_perturbs_weights() {
         let mut state = AgentBrainState::new_blank();
         // Set some non-zero action weights
-        for i in 0..DIM {
-            state.brain_state[O_ACT_FWD_WTS + i] = 0.5;
-            state.brain_state[O_ACT_TURN_WTS + i] = 0.5;
+        for i in 0..ENCODED_DIMENSION {
+            state.brain_state[O_ACTION_FORWARD_WEIGHTS + i] = 0.5;
+            state.brain_state[O_ACTION_TURN_WEIGHTS + i] = 0.5;
         }
         let mutated = mutate_brain_state(&state, 0.1);
         // Action weights should differ (20% mutation rate per weight)
-        let fwd_same = (0..DIM).all(|i| {
-            mutated.brain_state[O_ACT_FWD_WTS + i] == state.brain_state[O_ACT_FWD_WTS + i]
+        let fwd_same = (0..ENCODED_DIMENSION).all(|i| {
+            mutated.brain_state[O_ACTION_FORWARD_WEIGHTS + i]
+                == state.brain_state[O_ACTION_FORWARD_WEIGHTS + i]
         });
         assert!(
             !fwd_same,
@@ -668,9 +672,11 @@ mod tests {
         // Use non-default vision dimensions to exercise dynamic offset logic
         let layout = BrainLayout::new(6, 4);
         let mut state = AgentBrainState::new_for(layout.brain_stride);
-        let dyn_act_fwd =
-            layout.feature_count * DIM + DIM + DIM * DIM + (O_ACT_FWD_WTS - O_PRED_CTX_WT);
-        for i in 0..DIM {
+        let dyn_act_fwd = layout.feature_count * ENCODED_DIMENSION
+            + ENCODED_DIMENSION
+            + PREDICTOR_DIMENSION * ENCODED_DIMENSION
+            + (O_ACTION_FORWARD_WEIGHTS - O_PREDICTOR_CONTEXT_WEIGHT);
+        for i in 0..ENCODED_DIMENSION {
             state.brain_state[dyn_act_fwd + i] = 0.5;
         }
         // Should not panic — validates checked arithmetic with non-default layout

--- a/crates/xagent-sandbox/src/governor.rs
+++ b/crates/xagent-sandbox/src/governor.rs
@@ -669,7 +669,7 @@ impl Governor {
                         let short = match *name {
                             "memory_capacity" => "mem",
                             "processing_slots" => "slots",
-                            "representation_dim" => "repr",
+                            "representation_dimension" => "repr",
                             "learning_rate" => "lr",
                             "decay_rate" => "decay",
                             "distress_exponent" => "distress",
@@ -1021,7 +1021,7 @@ impl Governor {
                 "  Config: mem={} slots={} dim={} lr={:.4} decay={:.4}",
                 c.memory_capacity,
                 c.processing_slots,
-                c.representation_dim,
+                c.representation_dimension,
                 c.learning_rate,
                 c.decay_rate,
             );
@@ -1481,9 +1481,9 @@ fn record_mutations(
             child.processing_slots as f64,
         ),
         (
-            "representation_dim",
-            parent.representation_dim as f64,
-            child.representation_dim as f64,
+            "representation_dimension",
+            parent.representation_dimension as f64,
+            child.representation_dimension as f64,
         ),
         (
             "learning_rate",
@@ -2014,8 +2014,8 @@ mod tests {
         assert_eq!(configs[0].memory_capacity, parent_config.memory_capacity);
         assert_eq!(configs[0].processing_slots, parent_config.processing_slots);
         assert_eq!(
-            configs[0].representation_dim,
-            parent_config.representation_dim
+            configs[0].representation_dimension,
+            parent_config.representation_dimension
         );
         assert!((configs[0].learning_rate - parent_config.learning_rate).abs() < f32::EPSILON);
         assert!((configs[0].decay_rate - parent_config.decay_rate).abs() < f32::EPSILON);
@@ -2261,7 +2261,7 @@ mod tests {
             memory_capacity: 1000,
             processing_slots: 100,
             visual_encoding_size: 64,
-            representation_dim: 500,
+            representation_dimension: 500,
             learning_rate: 0.9,
             decay_rate: 0.9,
             distress_exponent: 2.0,
@@ -2271,7 +2271,7 @@ mod tests {
             memory_capacity: 1,
             processing_slots: 1,
             visual_encoding_size: 64,
-            representation_dim: 1,
+            representation_dimension: 1,
             learning_rate: 0.001,
             decay_rate: 0.001,
             distress_exponent: 2.0,
@@ -2286,13 +2286,13 @@ mod tests {
             let child = crossover_config(&a, &b);
             if child.memory_capacity == a.memory_capacity
                 || child.processing_slots == a.processing_slots
-                || child.representation_dim == a.representation_dim
+                || child.representation_dimension == a.representation_dimension
             {
                 has_a_param = true;
             }
             if child.memory_capacity == b.memory_capacity
                 || child.processing_slots == b.processing_slots
-                || child.representation_dim == b.representation_dim
+                || child.representation_dimension == b.representation_dimension
             {
                 has_b_param = true;
             }

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -173,7 +173,7 @@ fn print_config(config: &FullConfig) {
         config.brain.memory_capacity,
         config.brain.processing_slots,
         config.brain.visual_encoding_size,
-        config.brain.representation_dim,
+        config.brain.representation_dimension,
         config.brain.learning_rate,
         config.brain.decay_rate,
     );
@@ -1110,7 +1110,7 @@ impl App {
             "  Child config: cap={} slots={} dim={} lr={:.4} decay={:.4}",
             child.brain_config.memory_capacity,
             child.brain_config.processing_slots,
-            child.brain_config.representation_dim,
+            child.brain_config.representation_dimension,
             child.brain_config.learning_rate,
             child.brain_config.decay_rate,
         );

--- a/crates/xagent-sandbox/src/momentum.rs
+++ b/crates/xagent-sandbox/src/momentum.rs
@@ -121,7 +121,10 @@ impl MutationMomentum {
         let params: Vec<(&str, f32)> = vec![
             ("memory_capacity", parent.memory_capacity as f32),
             ("processing_slots", parent.processing_slots as f32),
-            ("representation_dim", parent.representation_dim as f32),
+            (
+                "representation_dimension",
+                parent.representation_dimension as f32,
+            ),
             ("learning_rate", parent.learning_rate),
             ("decay_rate", parent.decay_rate),
             ("distress_exponent", parent.distress_exponent),
@@ -138,7 +141,7 @@ impl MutationMomentum {
                     let w_val = match *name {
                         "memory_capacity" => w.memory_capacity as f32,
                         "processing_slots" => w.processing_slots as f32,
-                        "representation_dim" => w.representation_dim as f32,
+                        "representation_dimension" => w.representation_dimension as f32,
                         "learning_rate" => w.learning_rate,
                         "decay_rate" => w.decay_rate,
                         "distress_exponent" => w.distress_exponent,

--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1364,10 +1364,10 @@ impl<'a> TabContext<'a> {
                     b.visual_encoding_size = ve.max(1) as usize;
                     ui.end_row();
 
-                    ui.label("representation_dim");
-                    let mut rd = b.representation_dim as i32;
+                    ui.label("representation_dimension");
+                    let mut rd = b.representation_dimension as i32;
                     ui.add(egui::DragValue::new(&mut rd).range(4..=128).speed(1));
-                    b.representation_dim = rd.max(1) as usize;
+                    b.representation_dimension = rd.max(1) as usize;
                     ui.end_row();
 
                     ui.label("learning_rate");
@@ -1527,8 +1527,8 @@ impl<'a> TabContext<'a> {
                         ui.label("visual_encoding_size");
                         ui.monospace(format!("{}", cfg.visual_encoding_size));
                         ui.end_row();
-                        ui.label("representation_dim");
-                        ui.monospace(format!("{}", cfg.representation_dim));
+                        ui.label("representation_dimension");
+                        ui.monospace(format!("{}", cfg.representation_dimension));
                         ui.end_row();
                         ui.label("learning_rate");
                         ui.monospace(format!("{:.5}", cfg.learning_rate));
@@ -1702,8 +1702,8 @@ impl<'a> TabContext<'a> {
                                         ui.label("visual_encoding_size");
                                         ui.monospace(format!("{}", cfg.visual_encoding_size));
                                         ui.end_row();
-                                        ui.label("representation_dim");
-                                        ui.monospace(format!("{}", cfg.representation_dim));
+                                        ui.label("representation_dimension");
+                                        ui.monospace(format!("{}", cfg.representation_dimension));
                                         ui.end_row();
                                         ui.label("learning_rate");
                                         ui.monospace(format!("{:.5}", cfg.learning_rate));
@@ -1738,8 +1738,8 @@ impl<'a> TabContext<'a> {
                             ui.label("visual_encoding_size");
                             ui.monospace(format!("{}", cfg.visual_encoding_size));
                             ui.end_row();
-                            ui.label("representation_dim");
-                            ui.monospace(format!("{}", cfg.representation_dim));
+                            ui.label("representation_dimension");
+                            ui.monospace(format!("{}", cfg.representation_dimension));
                             ui.end_row();
                             ui.label("learning_rate");
                             ui.monospace(format!("{:.5}", cfg.learning_rate));
@@ -1920,8 +1920,8 @@ impl<'a> TabContext<'a> {
                         ui.label("visual_encoding_size");
                         ui.monospace(format!("{}", cfg.visual_encoding_size));
                         ui.end_row();
-                        ui.label("representation_dim");
-                        ui.monospace(format!("{}", cfg.representation_dim));
+                        ui.label("representation_dimension");
+                        ui.monospace(format!("{}", cfg.representation_dimension));
                         ui.end_row();
                         ui.label("learning_rate");
                         ui.monospace(format!("{:.5}", cfg.learning_rate));

--- a/crates/xagent-shared/README.md
+++ b/crates/xagent-shared/README.md
@@ -253,7 +253,7 @@ pub struct BrainConfig {
     pub memory_capacity: usize,
     pub processing_slots: usize,
     pub visual_encoding_size: usize,
-    pub representation_dim: usize,
+    pub representation_dimension: usize,
     pub learning_rate: f32,
     pub decay_rate: f32,
     pub distress_exponent: f32,
@@ -271,7 +271,7 @@ Brain capacity parameters. These are not implementation details — they are the
 | `memory_capacity` | 128 | Maximum number of patterns the memory can hold. Smaller values force the brain to forget more aggressively, leading to stronger habit formation and more stereotyped behavior. Larger values allow richer memory but slower convergence. The increased default (128) allows learning multiple survival skills while still maintaining capacity pressure — only the most reinforced patterns survive decay, which *is* emergent attention. |
 | `processing_slots` | 16 | Maximum number of patterns that can be recalled/compared per tick. This is the agent's "attention span" — with fewer slots, it makes faster but cruder decisions. More slots means better pattern matching but higher computational cost per tick. |
 | `visual_encoding_size` | 64 | Resolution of the visual encoder output (downsampled from raw vision). Smaller values force more aggressive compression, which means the brain sees less detail but processes faster. Larger values preserve more visual information. |
-| `representation_dim` | 32 | Length of the internal representation vector. This is the dimensionality of the space in which the brain thinks. Smaller values force more abstraction — the brain must compress its experience into fewer numbers, leading to coarser but more generalizable representations. |
+| `representation_dimension` | 128 | Length of the internal representation vector. This is the dimensionality of the space in which the brain thinks. Smaller values force more abstraction — the brain must compress its experience into fewer numbers, leading to coarser but more generalizable representations. |
 | `learning_rate` | 0.05 | Base learning rate for association updates. Higher rates mean faster adaptation but more instability (catastrophic forgetting). Lower rates mean more stable memory but slower learning. |
 | `decay_rate` | 0.001 | Decay rate for unreinforced patterns per tick. Patterns that aren't recalled or reinforced gradually lose strength. Higher decay means more aggressive forgetting — the brain only retains frequently-used patterns. |
 | `distress_exponent` | 2.0 | Exponent for the homeostatic distress curve. Higher values mean the agent stays calm longer but panics harder at critical levels. Heritable: mutated during breeding, clamped to [1.5, 5.0]. |

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -16,6 +16,7 @@ pub struct BrainConfig {
     /// Resolution of the visual encoder (downsampled from raw vision).
     pub visual_encoding_size: usize,
     /// Length of the internal representation vector.
+    #[serde(alias = "representation_dim")]
     pub representation_dimension: usize,
     /// Base learning rate for association updates.
     pub learning_rate: f32,
@@ -52,11 +53,11 @@ pub struct BrainConfig {
     /// Default 10.
     #[serde(default = "default_vision_stride")]
     pub vision_stride: u32,
-    /// Multiplier for all energy costs (metabolic + movement). Default 0.01.
+    /// Multiplier for all energy costs (metabolic + movement). Default 0.5.
     /// Lower = agents survive longer. Higher = harsher energy pressure.
     #[serde(default = "default_metabolic_rate")]
     pub metabolic_rate: f32,
-    /// Multiplier for integrity damage and regen. Default 0.01.
+    /// Multiplier for integrity damage and regen. Default 0.5.
     /// Lower = agents take less damage. Higher = hazard zones are deadlier.
     #[serde(default = "default_integrity_scale")]
     pub integrity_scale: f32,

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -16,7 +16,7 @@ pub struct BrainConfig {
     /// Resolution of the visual encoder (downsampled from raw vision).
     pub visual_encoding_size: usize,
     /// Length of the internal representation vector.
-    pub representation_dim: usize,
+    pub representation_dimension: usize,
     /// Base learning rate for association updates.
     pub learning_rate: f32,
     /// Decay rate for unreinforced patterns per tick.
@@ -127,11 +127,11 @@ fn default_vision_stride() -> u32 {
 }
 
 fn default_metabolic_rate() -> f32 {
-    0.01
+    0.5
 }
 
 fn default_integrity_scale() -> f32 {
-    0.01
+    0.5
 }
 
 fn default_movement_speed() -> f32 {
@@ -240,7 +240,7 @@ impl Default for BrainConfig {
             memory_capacity: 128,
             processing_slots: 16,
             visual_encoding_size: 64,
-            representation_dim: 32,
+            representation_dimension: 128,
             learning_rate: 0.05,
             decay_rate: 0.001,
             distress_exponent: 2.0,
@@ -265,7 +265,7 @@ impl BrainConfig {
             memory_capacity: 24,
             processing_slots: 8,
             visual_encoding_size: 32,
-            representation_dim: 16,
+            representation_dimension: 128,
             learning_rate: 0.08,
             decay_rate: 0.002,
             distress_exponent: 2.0,
@@ -288,7 +288,7 @@ impl BrainConfig {
             memory_capacity: 512,
             processing_slots: 32,
             visual_encoding_size: 128,
-            representation_dim: 64,
+            representation_dimension: 128,
             learning_rate: 0.03,
             decay_rate: 0.0005,
             distress_exponent: 2.0,
@@ -372,8 +372,8 @@ mod tests {
         assert_eq!(config.vision_stride, 10);
         assert_eq!(config.vision_width, 8);
         assert_eq!(config.vision_height, 6);
-        assert!((config.metabolic_rate - 0.01).abs() < 1e-6);
-        assert!((config.integrity_scale - 0.01).abs() < 1e-6);
+        assert!((config.metabolic_rate - 0.5).abs() < 1e-6);
+        assert!((config.integrity_scale - 0.5).abs() < 1e-6);
         assert!((config.movement_speed - 20.0).abs() < 1e-6);
     }
 


### PR DESCRIPTION
## Summary

Root cause investigation of issue #13 across 14 independent circling causes, plus foundational improvements for deliberate behavior.

### What changed
- **Klinotaxis** — reactive turn modulation from fast-vs-medium gradient deviation. Sudden worsening → brief turn burst (reorient). Sustained shift → suppress turns (straight-line escape).
- **Forward bias** — agents default to moving forward (`INITIAL_FORWARD_BIAS=0.3`)
- **Memory re-enabled** — recalls past experiences with valence-weighted motor blend. Negative valence negates stored approach → escape direction.
- **Immediate homeostatic sensing** — gradient reads from `physics_state` directly (zero lag vs 100-tick sensory buffer lag)
- **Wall bounce** — reflect off world boundaries instead of sticking
- **Weight decay** — prevents random drift from accumulating a turn bias
- **Independent noise seeds** — hash-based, no cross-tick correlation
- **ENCODED_DIMENSION 32→128** — 4× richer representation for cross-location generalization
- **Comprehensive naming cleanup** — all abbreviated identifiers renamed per CONTRIBUTING.md

### What didn't change (remaining work)
Agents explore naturally and no longer circle, but don't yet develop deliberate food-seeking or danger-avoidance. The REINFORCE credit signal has too low SNR for spatial learning — the noise direction at credit time doesn't correlate with food/hazard direction. The learning architecture needs a deeper rethink (tracked in #13).

## Test plan
- [x] `cargo test --workspace` — 142 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] CONTRIBUTING.md compliance verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)