### PR TITLE
fix: remove representation_dimension from UI

### DIFF
--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1364,12 +1364,6 @@ impl<'a> TabContext<'a> {
                     b.visual_encoding_size = ve.max(1) as usize;
                     ui.end_row();
 
-                    ui.label("representation_dimension");
-                    let mut rd = b.representation_dimension as i32;
-                    ui.add(egui::DragValue::new(&mut rd).range(4..=128).speed(1));
-                    b.representation_dimension = rd.max(1) as usize;
-                    ui.end_row();
-
                     ui.label("learning_rate");
                     ui.add(
                         egui::DragValue::new(&mut b.learning_rate)
@@ -1526,9 +1520,6 @@ impl<'a> TabContext<'a> {
                         ui.end_row();
                         ui.label("visual_encoding_size");
                         ui.monospace(format!("{}", cfg.visual_encoding_size));
-                        ui.end_row();
-                        ui.label("representation_dimension");
-                        ui.monospace(format!("{}", cfg.representation_dimension));
                         ui.end_row();
                         ui.label("learning_rate");
                         ui.monospace(format!("{:.5}", cfg.learning_rate));
@@ -1702,9 +1693,6 @@ impl<'a> TabContext<'a> {
                                         ui.label("visual_encoding_size");
                                         ui.monospace(format!("{}", cfg.visual_encoding_size));
                                         ui.end_row();
-                                        ui.label("representation_dimension");
-                                        ui.monospace(format!("{}", cfg.representation_dimension));
-                                        ui.end_row();
                                         ui.label("learning_rate");
                                         ui.monospace(format!("{:.5}", cfg.learning_rate));
                                         ui.end_row();
@@ -1737,9 +1725,6 @@ impl<'a> TabContext<'a> {
                             ui.end_row();
                             ui.label("visual_encoding_size");
                             ui.monospace(format!("{}", cfg.visual_encoding_size));
-                            ui.end_row();
-                            ui.label("representation_dimension");
-                            ui.monospace(format!("{}", cfg.representation_dimension));
                             ui.end_row();
                             ui.label("learning_rate");
                             ui.monospace(format!("{:.5}", cfg.learning_rate));
@@ -1919,9 +1904,6 @@ impl<'a> TabContext<'a> {
                         ui.end_row();
                         ui.label("visual_encoding_size");
                         ui.monospace(format!("{}", cfg.visual_encoding_size));
-                        ui.end_row();
-                        ui.label("representation_dimension");
-                        ui.monospace(format!("{}", cfg.representation_dimension));
                         ui.end_row();
                         ui.label("learning_rate");
                         ui.monospace(format!("{:.5}", cfg.learning_rate));


### PR DESCRIPTION
## Summary

- The `representation_dimension` editor control in the Brain Config pane wrote to `BrainConfig` but the GPU kernel uses the compile-time `ENCODED_DIMENSION` constant (`crates/xagent-brain/src/buffers.rs:15` and the matching WGSL `common.wgsl:21`), so edits had no effect and risked producing configs that silently disagreed with the shader.
- Per issue #103, take the simplest path: drop the editor row in `render_config_editor` and the four read-only summary rows in `render_config_summary`, the evolution detail view, the fallback view, and the node detail view. The underlying `BrainConfig` field stays intact (still serialized, still used by the governor/momentum logging); only the UI exposure is removed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p xagent-sandbox` (70 lib + 3 bin + 44 integration, all green)
- [ ] Manually verify the Brain Config editor and summary panes render without the removed row

Closes #103