### PR TITLE
fix: plumb GPU death tick to CPU for accurate longest_life (#124)

### DIFF
--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -136,7 +136,9 @@ pub const P_MOTOR_FWD_OUT: usize = 27;
 pub const P_MOTOR_TURN_OUT: usize = 28;
 pub const P_GRADIENT_OUT: usize = 29;
 pub const P_URGENCY_OUT: usize = 30;
-/// Tick at which this agent most recently died (f32 for bitcast from u32).
+/// Tick at which this agent most recently died, stored as f32 via numeric
+/// conversion (`f32(tick)` in WGSL, `as u64` on readback).  Exact for integer
+/// ticks up to 2^24 — matches the precision guarantees of `P_TICKS_ALIVE`.
 /// Written by the physics phase when energy/integrity reaches zero, preserved
 /// across the death/respawn reset so CPU readback can attribute the death to
 /// an exact tick instead of the end-of-batch upper bound.

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -136,7 +136,12 @@ pub const P_MOTOR_FWD_OUT: usize = 27;
 pub const P_MOTOR_TURN_OUT: usize = 28;
 pub const P_GRADIENT_OUT: usize = 29;
 pub const P_URGENCY_OUT: usize = 30;
-pub const PHYS_STRIDE: usize = 31;
+/// Tick at which this agent most recently died (f32 for bitcast from u32).
+/// Written by the physics phase when energy/integrity reaches zero, preserved
+/// across the death/respawn reset so CPU readback can attribute the death to
+/// an exact tick instead of the end-of-batch upper bound.
+pub const P_LAST_DEATH_TICK: usize = 31;
+pub const PHYS_STRIDE: usize = 32;
 /// Brain runs once every N physics ticks. Must match the cycle logic in dispatch_batch.
 pub const BRAIN_TICK_STRIDE: u32 = 4;
 
@@ -787,6 +792,7 @@ mod tests {
             P_EXPLORATION_RATE_OUT as u32
         );
         assert_eq!(wgsl["P_FATIGUE_FACTOR_OUT"], P_FATIGUE_FACTOR_OUT as u32);
+        assert_eq!(wgsl["P_LAST_DEATH_TICK"], P_LAST_DEATH_TICK as u32);
     }
 
     #[test]
@@ -966,6 +972,7 @@ mod tests {
             P_MOTOR_TURN_OUT,
             P_GRADIENT_OUT,
             P_URGENCY_OUT,
+            P_LAST_DEATH_TICK,
         ]
         .iter()
         .max()

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -103,7 +103,7 @@ const CFG_INTEGRITY_SCALE: u32 = 8u;
 
 // ── Agent physics buffer layout (P_*) ───────────────────────────────────────
 
-const PHYS_STRIDE: u32 = 31u;
+const PHYS_STRIDE: u32 = 32u;
 const P_POS_X: u32 = 0u;
 const P_POS_Y: u32 = 1u;
 const P_POS_Z: u32 = 2u;
@@ -135,6 +135,7 @@ const P_MOTOR_FWD_OUT: u32 = 27u;
 const P_MOTOR_TURN_OUT: u32 = 28u;
 const P_GRADIENT_OUT: u32 = 29u;
 const P_URGENCY_OUT: u32 = 30u;
+const P_LAST_DEATH_TICK: u32 = 31u;
 
 // ── Food buffer layout ─────────────────────────────────────────────────────
 

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -165,6 +165,9 @@ fn agent_physics(agent_id: u32, tick: u32) {
     if energy <= 0.0 || integrity <= 0.0 {
         physics_state[b + P_ALIVE] = 0.0;
         physics_state[b + P_DIED_FLAG] = 1.0;
+        // Record the exact tick of death for CPU-side longest_life accounting.
+        // Stored as f32 (exact for integer ticks up to 2^24 — matches P_TICKS_ALIVE).
+        physics_state[b + P_LAST_DEATH_TICK] = f32(tick);
     } else {
         physics_state[b + P_TICKS_ALIVE] = physics_state[b + P_TICKS_ALIVE] + 1.0;
     }
@@ -286,6 +289,9 @@ fn agent_death_respawn(agent_id: u32, tick: u32) {
     let max_integrity      = physics_state[base + P_MAX_INTEGRITY];
     let memory_cap         = physics_state[base + P_MEMORY_CAP];
     let processing_slots   = physics_state[base + P_PROCESSING_SLOTS];
+    // Preserve the physics-recorded death tick through the reset so CPU
+    // readback can attribute this death to its exact tick.
+    let saved_last_death_tick = physics_state[base + P_LAST_DEATH_TICK];
 
     // 3. Reset physics state
     for (var i = 0u; i < PHYS_STRIDE; i++) {
@@ -307,6 +313,7 @@ fn agent_death_respawn(agent_id: u32, tick: u32) {
     physics_state[base + P_FOOD_COUNT]      = saved_food_count;
     physics_state[base + P_TICKS_ALIVE]     = saved_ticks_alive;
     physics_state[base + P_DEATH_COUNT]     = saved_death_count;
+    physics_state[base + P_LAST_DEATH_TICK] = saved_last_death_tick;
 
     // 4. Reset brain state
     let brain_base = agent_id * BRAIN_STRIDE;

--- a/crates/xagent-brain/src/shaders/kernel/phase_death.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_death.wgsl
@@ -43,6 +43,9 @@ fn phase_death_respawn(tid: u32, tick: u32) {
     let max_integrity      = physics_state[base + P_MAX_INTEGRITY];
     let memory_cap         = physics_state[base + P_MEMORY_CAP];
     let processing_slots   = physics_state[base + P_PROCESSING_SLOTS];
+    // Preserve the physics-recorded death tick through the reset so CPU
+    // readback can attribute this death to its exact tick.
+    let saved_last_death_tick = physics_state[base + P_LAST_DEATH_TICK];
 
     // ── 3. Reset physics state ─────────────────────────────────────────────
     // Zero the full stride first, then write specific values.
@@ -70,6 +73,7 @@ fn phase_death_respawn(tid: u32, tick: u32) {
     physics_state[base + P_FOOD_COUNT]      = saved_food_count;
     physics_state[base + P_TICKS_ALIVE]     = saved_ticks_alive;
     physics_state[base + P_DEATH_COUNT]     = saved_death_count;
+    physics_state[base + P_LAST_DEATH_TICK] = saved_last_death_tick;
 
     // ── 4. Reset brain state ───────────────────────────────────────────────
     let brain_base = tid * BRAIN_STRIDE;

--- a/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl
@@ -151,6 +151,9 @@ fn phase_physics(tid: u32, tick: u32) {
     if energy <= 0.0 || integrity <= 0.0 {
         physics_state[b + P_ALIVE] = 0.0;
         physics_state[b + P_DIED_FLAG] = 1.0;
+        // Record the exact tick of death for CPU-side longest_life accounting.
+        // Stored as f32 (exact for integer ticks up to 2^24 — matches P_TICKS_ALIVE).
+        physics_state[b + P_LAST_DEATH_TICK] = f32(tick);
     } else {
         // Increment ticks alive (stored as f32, safe for integers up to 2^24)
         physics_state[b + P_TICKS_ALIVE] = physics_state[b + P_TICKS_ALIVE] + 1.0;

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -782,9 +782,9 @@ mod tests {
         // entire batch has been dispatched (self.tick has advanced past the
         // actual death tick by up to `ticks_to_run - 1`).
         //
-        // With GPU-reported death ticks, longest_life must match the true
-        // life duration — NOT a conservative upper bound derived from
-        // `self.tick - 1`.
+        // With a GPU-reported death tick from a single observed death, the
+        // life duration must match the true lifetime — NOT a conservative
+        // upper bound derived from `self.tick - 1`.
         let mut agent = Agent::new(0, Vec3::ZERO, 0, BrainConfig::default(), 0);
         // Agent was born at tick 0.  It dies at tick 100 but the CPU's
         // next-tick counter has already advanced to 500 (500-tick batch).
@@ -795,25 +795,6 @@ mod tests {
             "longest_life must reflect the GPU-reported death tick, not the batch boundary"
         );
         assert_eq!(agent.life_start_tick, 101);
-    }
-
-    #[test]
-    fn record_death_multiple_deaths_in_batch_updates_longest_life_for_most_recent() {
-        // When multiple deaths cluster in one batch, each readback invocation
-        // calls record_death_and_restart_life once with the *most recent*
-        // GPU-reported death tick.  We accept that earlier intra-batch lives
-        // aren't individually timed — the most recent life is covered.
-        let mut agent = Agent::new(0, Vec3::ZERO, 0, BrainConfig::default(), 0);
-        // Say two deaths happened in one batch: first at tick 40, second at 90.
-        // CPU only sees death_count jump by 2 and reads P_LAST_DEATH_TICK = 90.
-        // The most recent life (respawn at ~41 through death at 90) is 49 ticks.
-        let last_gpu_death_tick = 90;
-        agent.record_death_and_restart_life(last_gpu_death_tick);
-        assert_eq!(
-            agent.longest_life, 90,
-            "longest_life should reflect most recent GPU death tick (agent still tracked from birth 0)"
-        );
-        assert_eq!(agent.life_start_tick, 91);
     }
 
     #[test]

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -274,6 +274,47 @@ impl Agent {
         self.reset_trail();
     }
 
+    /// Reconcile CPU-side life bookkeeping with a GPU readback of `P_DEATH_COUNT`
+    /// and `P_LAST_DEATH_TICK`.
+    ///
+    /// `gpu_death_tick` is the tick the GPU recorded for the **most recent** death
+    /// in the batch; `last_simulated_tick` caps it as a safety net against
+    /// corrupted or stale readbacks (`self.tick - 1` in the readback loop).
+    ///
+    /// Single-death batches (`new_deaths - self.death_count == 1`) call
+    /// `record_death_and_restart_life`, so `longest_life` reflects the exact
+    /// GPU-reported life duration — the win over PR #123's batch-boundary
+    /// upper bound.
+    ///
+    /// Multi-death batches skip the `longest_life` update: we only know the
+    /// most recent death tick, not the intermediate respawn ticks, so computing
+    /// `life_duration` from the current `life_start_tick` would span several
+    /// lives and overestimate. Instead we resync `life_start_tick` to
+    /// `death_tick + 1` so the new life's `age()` starts from zero and reset
+    /// the trail. Full per-life timing would require a per-agent ring buffer
+    /// of death ticks or a GPU-side `last_respawn_tick` slot.
+    ///
+    /// `self.death_count` is always updated to `new_deaths` on exit; callers
+    /// must not also write it.
+    pub fn apply_death_count_readback(
+        &mut self,
+        new_deaths: u32,
+        gpu_death_tick: u64,
+        last_simulated_tick: u64,
+    ) {
+        if new_deaths > self.death_count {
+            let death_delta = new_deaths - self.death_count;
+            let death_tick = gpu_death_tick.min(last_simulated_tick);
+            if death_delta == 1 {
+                self.record_death_and_restart_life(death_tick);
+            } else {
+                self.life_start_tick = death_tick.saturating_add(1);
+                self.reset_trail();
+            }
+        }
+        self.death_count = new_deaths;
+    }
+
     /// Number of unique heatmap cells visited (non-zero entries).
     pub fn unique_cells_explored(&self) -> u32 {
         self.heatmap.iter().filter(|&&c| c > 0).count() as u32
@@ -794,6 +835,70 @@ mod tests {
             agent.longest_life, 100,
             "longest_life must reflect the GPU-reported death tick, not the batch boundary"
         );
+        assert_eq!(agent.life_start_tick, 101);
+    }
+
+    #[test]
+    fn apply_death_count_readback_single_death_uses_gpu_tick() {
+        // Single death observed since the last readback: longest_life should
+        // match the GPU-reported tick exactly, and death_count should sync.
+        let mut agent = Agent::new(0, Vec3::ZERO, 0, BrainConfig::default(), 0);
+        // Agent was born at tick 0.  It died at tick 100; CPU is now at tick
+        // 500 (dispatched 500 ticks in one batch).
+        agent.apply_death_count_readback(1, 100, 499);
+        assert_eq!(
+            agent.longest_life, 100,
+            "single-death path must use the GPU death tick for longest_life"
+        );
+        assert_eq!(agent.life_start_tick, 101);
+        assert_eq!(agent.death_count, 1);
+    }
+
+    #[test]
+    fn apply_death_count_readback_multi_death_does_not_inflate_longest_life() {
+        // Two deaths observed in one batch: we only know the most recent death
+        // tick, so computing life_duration from life_start_tick would span
+        // several lives and overestimate.  Must skip the longest_life update
+        // but still resync life_start_tick and death_count.
+        let mut agent = Agent::new(0, Vec3::ZERO, 0, BrainConfig::default(), 0);
+        // Say deaths occurred at ticks 40 and 90 (we only see GPU tick 90).
+        // From life_start_tick=0, record_death_and_restart_life(90) would
+        // report a life of 90 ticks — but the agent actually lived at most
+        // 49 ticks (41..90).  The multi-death branch must NOT inflate.
+        agent.apply_death_count_readback(2, 90, 499);
+        assert_eq!(
+            agent.longest_life, 0,
+            "multi-death path must NOT update longest_life (can't reconstruct per-life timing)"
+        );
+        assert_eq!(
+            agent.life_start_tick, 91,
+            "life_start_tick should resync to the tick after the most recent GPU death"
+        );
+        assert_eq!(agent.death_count, 2);
+    }
+
+    #[test]
+    fn apply_death_count_readback_no_death_delta_is_noop() {
+        // Readback observes the same death count we already have: nothing to do.
+        let mut agent = Agent::new(0, Vec3::ZERO, 0, BrainConfig::default(), 10);
+        agent.death_count = 3;
+        agent.longest_life = 42;
+        let start_before = agent.life_start_tick;
+        agent.apply_death_count_readback(3, 500, 999);
+        assert_eq!(agent.longest_life, 42);
+        assert_eq!(agent.life_start_tick, start_before);
+        assert_eq!(agent.death_count, 3);
+    }
+
+    #[test]
+    fn apply_death_count_readback_clamps_stale_gpu_tick_to_last_simulated() {
+        // Safety net: if the GPU reports a death tick past the last simulated
+        // tick (shouldn't happen, but defensively guard), clamp to the CPU's
+        // view of the simulation frontier.
+        let mut agent = Agent::new(0, Vec3::ZERO, 0, BrainConfig::default(), 0);
+        // Implausible gpu_death_tick = 10_000, last_simulated_tick = 100.
+        agent.apply_death_count_readback(1, 10_000, 100);
+        assert_eq!(agent.longest_life, 100);
         assert_eq!(agent.life_start_tick, 101);
     }
 

--- a/crates/xagent-sandbox/src/agent/mod.rs
+++ b/crates/xagent-sandbox/src/agent/mod.rs
@@ -776,6 +776,47 @@ mod tests {
     }
 
     #[test]
+    fn record_death_with_gpu_reported_tick_is_accurate_under_batching() {
+        // Simulate the scenario PR #123 fixed conservatively: an agent dies
+        // mid-batch and the CPU only observes the new death_count after the
+        // entire batch has been dispatched (self.tick has advanced past the
+        // actual death tick by up to `ticks_to_run - 1`).
+        //
+        // With GPU-reported death ticks, longest_life must match the true
+        // life duration — NOT a conservative upper bound derived from
+        // `self.tick - 1`.
+        let mut agent = Agent::new(0, Vec3::ZERO, 0, BrainConfig::default(), 0);
+        // Agent was born at tick 0.  It dies at tick 100 but the CPU's
+        // next-tick counter has already advanced to 500 (500-tick batch).
+        let gpu_death_tick = 100;
+        agent.record_death_and_restart_life(gpu_death_tick);
+        assert_eq!(
+            agent.longest_life, 100,
+            "longest_life must reflect the GPU-reported death tick, not the batch boundary"
+        );
+        assert_eq!(agent.life_start_tick, 101);
+    }
+
+    #[test]
+    fn record_death_multiple_deaths_in_batch_updates_longest_life_for_most_recent() {
+        // When multiple deaths cluster in one batch, each readback invocation
+        // calls record_death_and_restart_life once with the *most recent*
+        // GPU-reported death tick.  We accept that earlier intra-batch lives
+        // aren't individually timed — the most recent life is covered.
+        let mut agent = Agent::new(0, Vec3::ZERO, 0, BrainConfig::default(), 0);
+        // Say two deaths happened in one batch: first at tick 40, second at 90.
+        // CPU only sees death_count jump by 2 and reads P_LAST_DEATH_TICK = 90.
+        // The most recent life (respawn at ~41 through death at 90) is 49 ticks.
+        let last_gpu_death_tick = 90;
+        agent.record_death_and_restart_life(last_gpu_death_tick);
+        assert_eq!(
+            agent.longest_life, 90,
+            "longest_life should reflect most recent GPU death tick (agent still tracked from birth 0)"
+        );
+        assert_eq!(agent.life_start_tick, 91);
+    }
+
+    #[test]
     fn hsv_to_rgb_outputs_in_unit_range() {
         let hues = [0.0, 30.0, 60.0, 120.0, 180.0, 240.0, 300.0, 359.999];
         for &h in &hues {

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -18,9 +18,9 @@ use xagent_shared::{BrainConfig, FullConfig, GovernorConfig, WorldConfig};
 use xagent_brain::buffers::{
     FOOD_STATE_STRIDE, F_POS_X, F_POS_Z, F_RESPAWN_TIMER, PHYS_STRIDE, P_ALIVE, P_DEATH_COUNT,
     P_ENERGY, P_EXPLORATION_RATE_OUT, P_FACING_X, P_FACING_Y, P_FACING_Z, P_FATIGUE_FACTOR_OUT,
-    P_FOOD_COUNT, P_GRADIENT_OUT, P_INTEGRITY, P_MAX_ENERGY, P_MAX_INTEGRITY, P_MOTOR_FWD_OUT,
-    P_MOTOR_TURN_OUT, P_POS_X, P_POS_Y, P_POS_Z, P_PREDICTION_ERROR, P_TICKS_ALIVE, P_URGENCY_OUT,
-    P_VEL_X, P_VEL_Y, P_VEL_Z, P_YAW,
+    P_FOOD_COUNT, P_GRADIENT_OUT, P_INTEGRITY, P_LAST_DEATH_TICK, P_MAX_ENERGY, P_MAX_INTEGRITY,
+    P_MOTOR_FWD_OUT, P_MOTOR_TURN_OUT, P_POS_X, P_POS_Y, P_POS_Z, P_PREDICTION_ERROR,
+    P_TICKS_ALIVE, P_URGENCY_OUT, P_VEL_X, P_VEL_Y, P_VEL_Z, P_YAW,
 };
 use xagent_brain::{AgentBrainState, GpuKernel};
 use xagent_sandbox::agent::{mutate_brain_state, mutate_config, Agent, MAX_AGENTS};
@@ -1732,23 +1732,22 @@ impl ApplicationHandler for App {
                                 a.total_ticks_alive = state[base + P_TICKS_ALIVE] as u64;
                                 let new_deaths = state[base + P_DEATH_COUNT] as u32;
                                 if new_deaths > a.death_count {
-                                    let death_delta = new_deaths - a.death_count;
-                                    if death_delta == 1 {
-                                        // Upper-bound the death tick with the last simulated
-                                        // tick — the actual death may have happened earlier
-                                        // within the dispatched batch, but we lack per-death
-                                        // timing from GPU to pinpoint it exactly.
-                                        let last_simulated_tick = self.tick.saturating_sub(1);
-                                        a.record_death_and_restart_life(last_simulated_tick);
-                                    } else {
-                                        // Multiple deaths can happen between readbacks at high
-                                        // speed multipliers. Without per-death timing from GPU,
-                                        // skip longest-life updates to avoid overestimation and
-                                        // start the new life at self.tick so age(self.tick) == 0.
-                                        // death_count still syncs to new_deaths below.
-                                        a.life_start_tick = self.tick;
-                                        a.reset_trail();
-                                    }
+                                    // GPU records the tick at which death was detected
+                                    // (energy/integrity hit zero in agent_physics) and
+                                    // preserves it across the death/respawn reset.  This
+                                    // lets longest_life reflect the actual life duration
+                                    // even when several ticks are dispatched per batch.
+                                    let gpu_death_tick = state[base + P_LAST_DEATH_TICK] as u64;
+                                    // Clamp to the most recent simulated tick as a safety
+                                    // net in case the GPU value is corrupted or lags the
+                                    // death_count increment by a staging readback.
+                                    let last_simulated_tick = self.tick.saturating_sub(1);
+                                    let death_tick = gpu_death_tick.min(last_simulated_tick);
+                                    // Multi-death batches update longest_life using only
+                                    // the most recent GPU death tick; earlier lives in the
+                                    // same batch aren't individually timed (would need a
+                                    // per-agent ring buffer of death ticks).
+                                    a.record_death_and_restart_life(death_tick);
                                 }
                                 a.death_count = new_deaths;
                                 a.body.body.facing = Vec3::new(

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1708,7 +1708,10 @@ impl ApplicationHandler for App {
                             let state = kernel.cached_state();
                             for i in 0..self.agents.len() {
                                 let base = i * PHYS_STRIDE;
-                                if base + P_URGENCY_OUT >= state.len() {
+                                // Guard every physics field we read below. Use the
+                                // stride's highest offset (PHYS_STRIDE - 1) so adding
+                                // new fields doesn't silently leave the guard stale.
+                                if base + PHYS_STRIDE > state.len() {
                                     break;
                                 }
                                 let a = &mut self.agents[i];
@@ -1732,22 +1735,34 @@ impl ApplicationHandler for App {
                                 a.total_ticks_alive = state[base + P_TICKS_ALIVE] as u64;
                                 let new_deaths = state[base + P_DEATH_COUNT] as u32;
                                 if new_deaths > a.death_count {
-                                    // GPU records the tick at which death was detected
-                                    // (energy/integrity hit zero in agent_physics) and
-                                    // preserves it across the death/respawn reset.  This
-                                    // lets longest_life reflect the actual life duration
-                                    // even when several ticks are dispatched per batch.
+                                    let death_delta = new_deaths - a.death_count;
+                                    // GPU records the tick at which the most recent
+                                    // death in the batch was detected (energy/integrity
+                                    // hit zero in agent_physics) and preserves it across
+                                    // the death/respawn reset.
                                     let gpu_death_tick = state[base + P_LAST_DEATH_TICK] as u64;
-                                    // Clamp to the most recent simulated tick as a safety
-                                    // net in case the GPU value is corrupted or lags the
-                                    // death_count increment by a staging readback.
+                                    // Clamp to the most recent simulated tick as a
+                                    // safety net in case the GPU value is corrupted or
+                                    // lags the death_count increment by a staging readback.
                                     let last_simulated_tick = self.tick.saturating_sub(1);
                                     let death_tick = gpu_death_tick.min(last_simulated_tick);
-                                    // Multi-death batches update longest_life using only
-                                    // the most recent GPU death tick; earlier lives in the
-                                    // same batch aren't individually timed (would need a
-                                    // per-agent ring buffer of death ticks).
-                                    a.record_death_and_restart_life(death_tick);
+                                    if death_delta == 1 {
+                                        a.record_death_and_restart_life(death_tick);
+                                    } else {
+                                        // Multiple deaths occurred since the last
+                                        // readback; we only know the most recent death
+                                        // tick.  Calling record_death_and_restart_life
+                                        // here would compute life_duration against a
+                                        // stale life_start_tick (spanning several lives)
+                                        // and overestimate longest_life — the exact
+                                        // failure PR #123 guarded against.  Resync the
+                                        // life boundary using the GPU death tick without
+                                        // updating longest_life.  Full per-life timing
+                                        // would require a per-agent ring buffer of death
+                                        // ticks or a GPU-side last_respawn_tick slot.
+                                        a.life_start_tick = death_tick.saturating_add(1);
+                                        a.reset_trail();
+                                    }
                                 }
                                 a.death_count = new_deaths;
                                 a.body.body.facing = Vec3::new(

--- a/crates/xagent-sandbox/src/main.rs
+++ b/crates/xagent-sandbox/src/main.rs
@@ -1734,37 +1734,12 @@ impl ApplicationHandler for App {
                                 a.food_consumed = state[base + P_FOOD_COUNT] as u32;
                                 a.total_ticks_alive = state[base + P_TICKS_ALIVE] as u64;
                                 let new_deaths = state[base + P_DEATH_COUNT] as u32;
-                                if new_deaths > a.death_count {
-                                    let death_delta = new_deaths - a.death_count;
-                                    // GPU records the tick at which the most recent
-                                    // death in the batch was detected (energy/integrity
-                                    // hit zero in agent_physics) and preserves it across
-                                    // the death/respawn reset.
-                                    let gpu_death_tick = state[base + P_LAST_DEATH_TICK] as u64;
-                                    // Clamp to the most recent simulated tick as a
-                                    // safety net in case the GPU value is corrupted or
-                                    // lags the death_count increment by a staging readback.
-                                    let last_simulated_tick = self.tick.saturating_sub(1);
-                                    let death_tick = gpu_death_tick.min(last_simulated_tick);
-                                    if death_delta == 1 {
-                                        a.record_death_and_restart_life(death_tick);
-                                    } else {
-                                        // Multiple deaths occurred since the last
-                                        // readback; we only know the most recent death
-                                        // tick.  Calling record_death_and_restart_life
-                                        // here would compute life_duration against a
-                                        // stale life_start_tick (spanning several lives)
-                                        // and overestimate longest_life — the exact
-                                        // failure PR #123 guarded against.  Resync the
-                                        // life boundary using the GPU death tick without
-                                        // updating longest_life.  Full per-life timing
-                                        // would require a per-agent ring buffer of death
-                                        // ticks or a GPU-side last_respawn_tick slot.
-                                        a.life_start_tick = death_tick.saturating_add(1);
-                                        a.reset_trail();
-                                    }
-                                }
-                                a.death_count = new_deaths;
+                                let gpu_death_tick = state[base + P_LAST_DEATH_TICK] as u64;
+                                a.apply_death_count_readback(
+                                    new_deaths,
+                                    gpu_death_tick,
+                                    self.tick.saturating_sub(1),
+                                );
                                 a.body.body.facing = Vec3::new(
                                     state[base + P_FACING_X],
                                     state[base + P_FACING_Y],


### PR DESCRIPTION
## Summary

Closes #124.

PR #123 kept `longest_life` from inflating under batched dispatches by conservatively clamping the death tick to `self.tick - 1` and skipping the `longest_life` update entirely on multi-death batches. That avoided overestimates but systematically under-reported lifetimes when deaths clustered inside high-speed frames (up to 500 ticks/batch).

This PR wires the exact per-agent death tick from GPU to CPU so **single-death** batches update `longest_life` accurately. Multi-death batches (`death_delta > 1`) still skip the `longest_life` update — a single GPU-reported tick isn't enough to reconstruct the most recent life's duration (we'd also need the last respawn tick, which isn't plumbed). Full per-life timing is called out as future work.

## Changes

- `crates/xagent-brain/src/buffers.rs`: add `P_LAST_DEATH_TICK` (slot 31) and bump `PHYS_STRIDE` to 32. Update `phys_stride_covers_all_fields` + `shader_phys_constants_match_rust` tests.
- `crates/xagent-brain/src/shaders/kernel/common.wgsl`: mirror the Rust constant and new stride.
- `crates/xagent-brain/src/shaders/kernel/phase_physics.wgsl` + `kernel_tick.wgsl` (`agent_physics`): write `P_LAST_DEATH_TICK = f32(tick)` at the exact sub-tick where energy/integrity hit zero.
- `crates/xagent-brain/src/shaders/kernel/phase_death.wgsl` + `kernel_tick.wgsl` (`agent_death_respawn`): save the death tick before the full-stride zero-reset and restore it after, so CPU readback sees it.
- `crates/xagent-sandbox/src/agent/mod.rs`: new `Agent::apply_death_count_readback(new_deaths, gpu_death_tick, last_simulated_tick)` method that handles both paths:
  - `death_delta == 1` → call `record_death_and_restart_life` with the GPU tick (the win vs. PR #123).
  - `death_delta > 1` → resync `life_start_tick = death_tick + 1` and reset trail; **skip** the `longest_life` update (preserves PR #123's no-overestimate guarantee).
- `crates/xagent-sandbox/src/main.rs`: read `P_LAST_DEATH_TICK` alongside `P_DEATH_COUNT` and delegate to `apply_death_count_readback`. Widen the per-agent physics-state bounds guard from `base + P_URGENCY_OUT` to `base + PHYS_STRIDE`.

## Tests

Five new unit tests on `Agent` cover the readback helper and the underlying method:

- `record_death_with_gpu_reported_tick_is_accurate_under_batching` — single death with `self.tick` far past `death_tick`.
- `apply_death_count_readback_single_death_uses_gpu_tick` — `death_delta == 1` end-to-end.
- `apply_death_count_readback_multi_death_does_not_inflate_longest_life` — **PR #123 guarantee**, directly asserting `longest_life == 0` after a `death_delta = 2` readback (regression guard).
- `apply_death_count_readback_no_death_delta_is_noop`.
- `apply_death_count_readback_clamps_stale_gpu_tick_to_last_simulated` — safety-net clamp behavior when GPU reports a tick past the last simulated tick.

## Known limitation

Multi-death lives within a single batch aren't individually timed. A full fix would require either a per-agent ring buffer of death ticks or a GPU-side `last_respawn_tick` slot — called out as future work rather than in-scope here.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p xagent-brain` — 24 passed (includes updated shader-sync and `phys_stride_covers_all_fields` tests)
- [x] `cargo test -p xagent-sandbox` — 122 passed (75 lib + 3 bin + 44 integration), including five new agent tests
- [ ] Manual run at 500× speed to eyeball `longest_life` advancing through single deaths (not blocking — covered by the unit tests)

https://claude.ai/code/session_01Tf9EbvRMcbxECZfEhvTzAq