### PR TITLE
chore: skip Copilot re-review when a cycle pushes no commits

### DIFF
--- a/.claude/skills/work-on-issue/SKILL.md
+++ b/.claude/skills/work-on-issue/SKILL.md
@@ -151,7 +151,9 @@ For each review comment (from the webhook payload or the poll result):
 
 After **every** push that addresses review feedback, repeat step 7a (sync + conflict check), call `mcp__github__request_copilot_review` again, and re-enter step 7b so Copilot re-reads the updated diff against a clean merge.
 
-Loop until Copilot's next review emits zero new comments.
+**No-change exit:** if an entire review cycle completes without any "apply the fix" outcomes — every comment was declined with reason or deferred to a follow-up issue, and no new commits were pushed — do **not** re-request a review. The diff Copilot reviewed hasn't changed, so a re-review would produce the same comments. Once all threads are resolved, go straight to Step 8 (merge).
+
+Loop until either Copilot's next review emits zero new comments, or a cycle ends with zero code changes.
 
 ## Step 8 — Merge
 


### PR DESCRIPTION
## Summary
- Adds a no-change exit to the Copilot review loop in the `work-on-issue` skill: if a review cycle ends with every comment declined or deferred to a follow-up issue (i.e. no commits pushed), the skill stops re-requesting reviews and goes straight to merge, since the diff Copilot reviewed hasn't changed.

## Test plan
- [ ] Run `/work-on-issue` on an issue where Copilot's review yields only decline/defer outcomes and confirm the skill proceeds to merge without a redundant re-review.
- [ ] Run `/work-on-issue` where at least one comment produces a fix-and-push and confirm the re-review path still fires.
