### PR TITLE
refactor: extract ReadbackTracker for async GPU readback plumbing

### DIFF
--- a/crates/xagent-brain/src/async_readback.rs
+++ b/crates/xagent-brain/src/async_readback.rs
@@ -1,0 +1,212 @@
+//! Reusable async-readback plumbing for `wgpu` buffer mapping.
+//!
+//! Each async readback in [`crate::gpu_kernel`] needs to:
+//!
+//! 1. Call `map_async(MapMode::Read, …)` on one or more buffer slices,
+//! 2. Keep a shared completion counter so the main thread knows when every
+//!    callback has fired,
+//! 3. Keep a shared error flag so a single failing mapping short-circuits the
+//!    whole group without hanging forever.
+//!
+//! Before this module each call site hand-rolled the `Arc<AtomicU32>` +
+//! `Arc<AtomicBool>` + closure trio. [`ReadbackTracker`] centralises that
+//! ceremony so the call sites express intent (which slices map, how many
+//! callbacks to expect) instead of plumbing.
+//!
+//! Buffer ownership and the post-completion `get_mapped_range` / `unmap`
+//! sequence stay with the caller: staging buffers are often pre-allocated
+//! and reused across readback rounds, and only the caller knows the exact
+//! byte ranges and data layout.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+
+/// Current state of a [`ReadbackTracker`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReadbackStatus {
+    /// Fewer than `expected` callbacks have fired.
+    Pending,
+    /// All expected callbacks fired without error.
+    Ready,
+    /// All expected callbacks fired and at least one reported an error.
+    Failed,
+}
+
+/// Shared tracker for a group of `wgpu::BufferSlice::map_async` callbacks.
+///
+/// Call [`ReadbackTracker::install`] once per buffer slice that participates
+/// in the group. Each installed callback increments a shared counter on any
+/// outcome and sets a shared error flag on failure, so [`status`] can report
+/// `Ready`, `Failed`, or `Pending` in constant time.
+///
+/// # Error semantics
+///
+/// The counter is incremented on **every** callback invocation (success or
+/// failure), so `completed >= expected` eventually holds whether or not a
+/// mapping failed. Callers must therefore check [`ReadbackStatus::Failed`]
+/// before consuming mapped ranges — a failed buffer is not safe to read.
+///
+/// # Reuse
+///
+/// Trackers can be reused across readback rounds on the same set of
+/// pre-allocated staging buffers by calling [`reset`] before issuing the
+/// next batch of `map_async` calls.
+///
+/// [`status`]: ReadbackTracker::status
+/// [`reset`]: ReadbackTracker::reset
+pub(crate) struct ReadbackTracker {
+    completed: Arc<AtomicU32>,
+    had_error: Arc<AtomicBool>,
+    expected: u32,
+}
+
+impl ReadbackTracker {
+    /// Create a tracker that expects `expected` `map_async` callbacks.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds when `expected` is zero — a zero-callback
+    /// tracker would return [`ReadbackStatus::Ready`] immediately and is
+    /// almost certainly a bug.
+    pub(crate) fn new(expected: u32) -> Self {
+        debug_assert!(
+            expected > 0,
+            "ReadbackTracker::new called with expected = 0 — the tracker would report Ready before any map_async ran"
+        );
+        Self {
+            completed: Arc::new(AtomicU32::new(0)),
+            had_error: Arc::new(AtomicBool::new(false)),
+            expected,
+        }
+    }
+
+    /// Reset the completion counter and error flag so this tracker can be
+    /// reused for the next round of `map_async` calls on the same pre-allocated
+    /// buffers.
+    pub(crate) fn reset(&self) {
+        self.completed.store(0, Ordering::Release);
+        self.had_error.store(false, Ordering::Release);
+    }
+
+    /// Install a `MapMode::Read` callback on `slice`.
+    ///
+    /// The callback:
+    /// - increments the shared completion counter on any outcome,
+    /// - sets the shared error flag when `result.is_err()`.
+    pub(crate) fn install(&self, slice: wgpu::BufferSlice<'_>) {
+        let completed = Arc::clone(&self.completed);
+        let had_error = Arc::clone(&self.had_error);
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            if result.is_err() {
+                had_error.store(true, Ordering::Release);
+            }
+            completed.fetch_add(1, Ordering::Release);
+        });
+    }
+
+    /// Current status of the tracker.
+    ///
+    /// - [`Pending`](ReadbackStatus::Pending) while fewer than `expected`
+    ///   callbacks have fired.
+    /// - [`Failed`](ReadbackStatus::Failed) once every callback has fired and
+    ///   at least one reported an error.
+    /// - [`Ready`](ReadbackStatus::Ready) once every callback has fired and
+    ///   none reported an error.
+    pub(crate) fn status(&self) -> ReadbackStatus {
+        if self.completed.load(Ordering::Acquire) < self.expected {
+            return ReadbackStatus::Pending;
+        }
+        if self.had_error.load(Ordering::Acquire) {
+            return ReadbackStatus::Failed;
+        }
+        ReadbackStatus::Ready
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Simulate the shared-counter closure the tracker installs on each
+    /// slice. Tests call this instead of a real `map_async` callback so the
+    /// tracker's bookkeeping can be exercised without a wgpu device.
+    fn fake_callback(tracker: &ReadbackTracker, result: Result<(), wgpu::BufferAsyncError>) {
+        let completed = Arc::clone(&tracker.completed);
+        let had_error = Arc::clone(&tracker.had_error);
+        // Mirrors ReadbackTracker::install exactly.
+        if result.is_err() {
+            had_error.store(true, Ordering::Release);
+        }
+        completed.fetch_add(1, Ordering::Release);
+    }
+
+    #[test]
+    fn pending_until_all_callbacks_fire() {
+        let tracker = ReadbackTracker::new(3);
+        assert_eq!(tracker.status(), ReadbackStatus::Pending);
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Pending);
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Pending);
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Ready);
+    }
+
+    #[test]
+    fn ready_only_when_all_succeed() {
+        let tracker = ReadbackTracker::new(2);
+        fake_callback(&tracker, Ok(()));
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Ready);
+    }
+
+    #[test]
+    fn failed_when_any_callback_errors_after_all_fired() {
+        let tracker = ReadbackTracker::new(3);
+        fake_callback(&tracker, Ok(()));
+        fake_callback(&tracker, Err(wgpu::BufferAsyncError));
+        // Still pending: only 2/3 callbacks fired.
+        assert_eq!(tracker.status(), ReadbackStatus::Pending);
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Failed);
+    }
+
+    #[test]
+    fn reset_clears_completion_and_error() {
+        let tracker = ReadbackTracker::new(2);
+        fake_callback(&tracker, Err(wgpu::BufferAsyncError));
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Failed);
+
+        tracker.reset();
+        assert_eq!(tracker.status(), ReadbackStatus::Pending);
+
+        fake_callback(&tracker, Ok(()));
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Ready);
+    }
+
+    #[test]
+    fn error_flag_short_circuits_once_all_callbacks_fire() {
+        // Even when the very last callback is the failure, the tracker reports
+        // Failed rather than Ready — the error flag is sticky.
+        let tracker = ReadbackTracker::new(2);
+        fake_callback(&tracker, Ok(()));
+        fake_callback(&tracker, Err(wgpu::BufferAsyncError));
+        assert_eq!(tracker.status(), ReadbackStatus::Failed);
+    }
+
+    #[test]
+    fn expected_count_one_reports_ready_after_single_callback() {
+        let tracker = ReadbackTracker::new(1);
+        assert_eq!(tracker.status(), ReadbackStatus::Pending);
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Ready);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected = 0")]
+    fn zero_expected_panics_in_debug() {
+        let _ = ReadbackTracker::new(0);
+    }
+}

--- a/crates/xagent-brain/src/async_readback.rs
+++ b/crates/xagent-brain/src/async_readback.rs
@@ -18,8 +18,13 @@
 //! and reused across readback rounds, and only the caller knows the exact
 //! byte ranges and data layout.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+
+/// High bit of the packed state word — set when any callback reported an error.
+const ERROR_BIT: u32 = 1 << 31;
+/// Low 31 bits of the packed state word — completion count.
+const COUNT_MASK: u32 = ERROR_BIT - 1;
 
 /// Current state of a [`ReadbackTracker`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -35,16 +40,27 @@ pub(crate) enum ReadbackStatus {
 /// Shared tracker for a group of `wgpu::BufferSlice::map_async` callbacks.
 ///
 /// Call [`ReadbackTracker::install`] once per buffer slice that participates
-/// in the group. Each installed callback increments a shared counter on any
-/// outcome and sets a shared error flag on failure, so [`status`] can report
-/// `Ready`, `Failed`, or `Pending` in constant time.
+/// in the group. Each installed callback encodes both "completed" and "had
+/// error" into a single packed `AtomicU32` so [`status`] can decide between
+/// `Ready`, `Failed`, and `Pending` with a single atomic load.
 ///
-/// # Error semantics
+/// # Packed state layout
 ///
-/// The counter is incremented on **every** callback invocation (success or
-/// failure), so `completed >= expected` eventually holds whether or not a
-/// mapping failed. Callers must therefore check [`ReadbackStatus::Failed`]
-/// before consuming mapped ranges — a failed buffer is not safe to read.
+/// - Bit 31 — error flag; set by [`ERROR_BIT`] when any callback reports an
+///   error.
+/// - Bits 0..=30 — completion count; incremented on every callback.
+///
+/// Using a single atomic (instead of separate `AtomicU32` + `AtomicBool`)
+/// avoids subtle release-sequence reasoning across two distinct atomics:
+/// once the caller's `Acquire` load observes `count >= expected`, any error
+/// bit set by prior callbacks is visible in the same word.
+///
+/// # Callback ordering
+///
+/// On an errored callback the error bit is set **before** the count is
+/// incremented. Callbacks therefore publish the error to any later load that
+/// observes the completion increment — `status()` never reports `Ready` when
+/// an errored callback has already pushed the count past `expected`.
 ///
 /// # Reuse
 ///
@@ -55,8 +71,8 @@ pub(crate) enum ReadbackStatus {
 /// [`status`]: ReadbackTracker::status
 /// [`reset`]: ReadbackTracker::reset
 pub(crate) struct ReadbackTracker {
-    completed: Arc<AtomicU32>,
-    had_error: Arc<AtomicBool>,
+    /// Packed (error_bit | count) state shared with every installed callback.
+    state: Arc<AtomicU32>,
     expected: u32,
 }
 
@@ -65,42 +81,50 @@ impl ReadbackTracker {
     ///
     /// # Panics
     ///
-    /// Panics in debug builds when `expected` is zero — a zero-callback
+    /// Panics in debug builds when `expected` is zero (a zero-callback
     /// tracker would return [`ReadbackStatus::Ready`] immediately and is
-    /// almost certainly a bug.
+    /// almost certainly a bug) or when `expected` would overflow the
+    /// 31-bit count field (callers track at most a handful of buffer
+    /// mappings — this limit is a sanity guard, not a real constraint).
     pub(crate) fn new(expected: u32) -> Self {
         debug_assert!(
             expected > 0,
             "ReadbackTracker::new called with expected = 0 — the tracker would report Ready before any map_async ran"
         );
+        debug_assert!(
+            expected <= COUNT_MASK,
+            "ReadbackTracker::new: expected = {expected} overflows the 31-bit count field"
+        );
         Self {
-            completed: Arc::new(AtomicU32::new(0)),
-            had_error: Arc::new(AtomicBool::new(false)),
+            state: Arc::new(AtomicU32::new(0)),
             expected,
         }
     }
 
-    /// Reset the completion counter and error flag so this tracker can be
-    /// reused for the next round of `map_async` calls on the same pre-allocated
-    /// buffers.
+    /// Reset the packed state so this tracker can be reused for the next
+    /// round of `map_async` calls on the same pre-allocated buffers.
     pub(crate) fn reset(&self) {
-        self.completed.store(0, Ordering::Release);
-        self.had_error.store(false, Ordering::Release);
+        self.state.store(0, Ordering::Release);
     }
 
     /// Install a `MapMode::Read` callback on `slice`.
     ///
     /// The callback:
-    /// - increments the shared completion counter on any outcome,
-    /// - sets the shared error flag when `result.is_err()`.
+    /// - sets the shared error bit (via `fetch_or`) before incrementing the
+    ///   count when `result.is_err()`,
+    /// - increments the shared completion count on every outcome.
+    ///
+    /// Performing `fetch_or` **before** `fetch_add` guarantees that if a
+    /// future `status()` load observes `count >= expected`, it also observes
+    /// the error bit set by any errored callback — both operations modify
+    /// the same atomic, so a single `Acquire` load is sufficient.
     pub(crate) fn install(&self, slice: wgpu::BufferSlice<'_>) {
-        let completed = Arc::clone(&self.completed);
-        let had_error = Arc::clone(&self.had_error);
+        let state = Arc::clone(&self.state);
         slice.map_async(wgpu::MapMode::Read, move |result| {
             if result.is_err() {
-                had_error.store(true, Ordering::Release);
+                state.fetch_or(ERROR_BIT, Ordering::Release);
             }
-            completed.fetch_add(1, Ordering::Release);
+            state.fetch_add(1, Ordering::Release);
         });
     }
 
@@ -112,11 +136,18 @@ impl ReadbackTracker {
     ///   at least one reported an error.
     /// - [`Ready`](ReadbackStatus::Ready) once every callback has fired and
     ///   none reported an error.
+    ///
+    /// A single `Acquire` load is enough because count and error flag live
+    /// in the same atomic word — release sequences across separate atomics
+    /// are not required for correctness.
     pub(crate) fn status(&self) -> ReadbackStatus {
-        if self.completed.load(Ordering::Acquire) < self.expected {
+        let state = self.state.load(Ordering::Acquire);
+        let count = state & COUNT_MASK;
+        let error = (state & ERROR_BIT) != 0;
+        if count < self.expected {
             return ReadbackStatus::Pending;
         }
-        if self.had_error.load(Ordering::Acquire) {
+        if error {
             return ReadbackStatus::Failed;
         }
         ReadbackStatus::Ready
@@ -127,17 +158,17 @@ impl ReadbackTracker {
 mod tests {
     use super::*;
 
-    /// Simulate the shared-counter closure the tracker installs on each
-    /// slice. Tests call this instead of a real `map_async` callback so the
+    /// Simulate the shared-state update the tracker installs on each slice.
+    /// Tests call this instead of a real `map_async` callback so the
     /// tracker's bookkeeping can be exercised without a wgpu device.
     fn fake_callback(tracker: &ReadbackTracker, result: Result<(), wgpu::BufferAsyncError>) {
-        let completed = Arc::clone(&tracker.completed);
-        let had_error = Arc::clone(&tracker.had_error);
-        // Mirrors ReadbackTracker::install exactly.
+        let state = Arc::clone(&tracker.state);
+        // Mirrors ReadbackTracker::install exactly: error bit set first so
+        // the count increment publishes it.
         if result.is_err() {
-            had_error.store(true, Ordering::Release);
+            state.fetch_or(ERROR_BIT, Ordering::Release);
         }
-        completed.fetch_add(1, Ordering::Release);
+        state.fetch_add(1, Ordering::Release);
     }
 
     #[test]
@@ -202,6 +233,31 @@ mod tests {
         assert_eq!(tracker.status(), ReadbackStatus::Pending);
         fake_callback(&tracker, Ok(()));
         assert_eq!(tracker.status(), ReadbackStatus::Ready);
+    }
+
+    #[test]
+    fn multiple_errors_collapse_into_single_error_bit() {
+        // fetch_or is idempotent — two errored callbacks leave the error bit
+        // set exactly once, and the count still reflects both callbacks.
+        let tracker = ReadbackTracker::new(2);
+        fake_callback(&tracker, Err(wgpu::BufferAsyncError));
+        fake_callback(&tracker, Err(wgpu::BufferAsyncError));
+        assert_eq!(tracker.status(), ReadbackStatus::Failed);
+    }
+
+    #[test]
+    fn errored_callback_sets_error_bit_before_count_reaches_expected() {
+        // The closure sets the error bit *before* incrementing the count,
+        // so there is no window in which an observer sees count == expected
+        // but misses an error from a callback that has already completed.
+        let tracker = ReadbackTracker::new(2);
+        fake_callback(&tracker, Err(wgpu::BufferAsyncError));
+        // After only one callback, error bit is set but count < expected.
+        let raw = tracker.state.load(Ordering::Acquire);
+        assert_eq!(raw & COUNT_MASK, 1);
+        assert_ne!(raw & ERROR_BIT, 0);
+        fake_callback(&tracker, Ok(()));
+        assert_eq!(tracker.status(), ReadbackStatus::Failed);
     }
 
     #[test]

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -52,12 +52,11 @@
 //! rename or move markers without updating both the helper and the tests.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
-use std::sync::Arc;
 
 use wgpu;
 use xagent_shared::{BrainConfig, WorldConfig};
 
+use crate::async_readback::{ReadbackStatus, ReadbackTracker};
 use crate::buffers::*;
 
 /// Replacement for the subgroup-accelerated bitonic sort. Loaded from a
@@ -152,10 +151,8 @@ const STAGING_SLOTS: usize = 6;
 
 /// Pending async readback of 4 staging buffers for telemetry.
 struct TelemetryReadback {
-    /// Number of map_async callbacks that have fired (need all 4).
-    completed: Arc<AtomicU32>,
-    /// Set if any map_async callback returned an error.
-    had_error: Arc<AtomicBool>,
+    /// Shared completion/error state for all 4 `map_async` callbacks.
+    tracker: ReadbackTracker,
     agent_index: u32,
 }
 
@@ -191,10 +188,8 @@ struct AgentStateReadback {
     brain_size: u64,
     pattern_size: u64,
     history_size: u64,
-    /// Counts how many of the 3 map_async callbacks have fired successfully.
-    mapped_count: Arc<AtomicU8>,
-    /// Set if any map_async callback reports an error.
-    had_error: Arc<AtomicBool>,
+    /// Shared completion/error state for all 3 `map_async` callbacks.
+    tracker: ReadbackTracker,
     brain_stride: usize,
 }
 
@@ -244,14 +239,13 @@ pub struct GpuKernel {
     // ── Async state readback (STAGING_SLOTS ring, non-blocking) ──
     // Staging is decoupled from dispatch: in-flight readbacks do not
     // block new dispatches. Each slot contains state + food staging
-    // buffers for one readback.
-    // staging_ready counts completed map_async callbacks (need expected_staging_callbacks).
+    // buffers for one readback, plus a `ReadbackTracker` that aggregates
+    // completion/error across the slot's `map_async` callbacks.
     state_staging: [wgpu::Buffer; STAGING_SLOTS],
     food_staging: [wgpu::Buffer; STAGING_SLOTS],
-    staging_index: usize,                           // which buffer to write NEXT
-    staging_in_flight: [bool; STAGING_SLOTS],       // submitted, not yet collected
-    staging_ready: [Arc<AtomicU32>; STAGING_SLOTS], // map_async callbacks completed
-    staging_had_error: [Arc<AtomicBool>; STAGING_SLOTS], // set if any map_async callback errored
+    staging_index: usize,                     // which buffer to write NEXT
+    staging_in_flight: [bool; STAGING_SLOTS], // submitted, not yet collected
+    staging_trackers: [ReadbackTracker; STAGING_SLOTS],
     state_cache: Vec<f32>,
     food_cache: Vec<f32>,
     food_cache_valid: bool,
@@ -327,38 +321,17 @@ impl GpuKernel {
 
     fn reset_agents_with_rng(&mut self, brain_config: &BrainConfig, rng: &mut impl rand::Rng) {
         // Drain any pending async readback so staging buffers are clean.
-        let expected = self.expected_staging_callbacks();
         for i in 0..STAGING_SLOTS {
             if self.staging_in_flight[i] {
-                while self.staging_ready[i].load(Ordering::Acquire) < expected {
+                // Spin until every callback has fired, blocking if needed —
+                // reset is a rare, synchronous operation.
+                while self.staging_trackers[i].status() == ReadbackStatus::Pending {
                     self.device.poll(wgpu::Maintain::Poll);
                 }
-
-                if self.staging_had_error[i].load(Ordering::Acquire) {
-                    // map_async errored — buffer isn't mapped, just unmap and clear.
-                    self.state_staging[i].unmap();
-                    if self.food_count > 0 {
-                        self.food_staging[i].unmap();
-                    }
-                } else {
-                    let buf_size = (self.agent_count as usize * PHYS_STRIDE * 4) as u64;
-                    let slice = self.state_staging[i].slice(..buf_size);
-                    let _data = slice.get_mapped_range();
-                    drop(_data);
-                    self.state_staging[i].unmap();
-
-                    if self.food_count > 0 {
-                        let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
-                        let food_slice = self.food_staging[i].slice(..food_size);
-                        let _food_data = food_slice.get_mapped_range();
-                        drop(_food_data);
-                        self.food_staging[i].unmap();
-                    }
-                }
-
+                self.unmap_staging_slot(i);
                 self.staging_in_flight[i] = false;
             }
-            self.staging_ready[i].store(0, Ordering::Release);
+            self.staging_trackers[i].reset();
         }
         self.staging_index = 0;
         self.food_cache_valid = false;
@@ -998,8 +971,10 @@ impl GpuKernel {
             food_staging,
             staging_index: 0,
             staging_in_flight: [false; STAGING_SLOTS],
-            staging_ready: std::array::from_fn(|_| Arc::new(AtomicU32::new(0))),
-            staging_had_error: std::array::from_fn(|_| Arc::new(AtomicBool::new(false))),
+            // One `map_async` for agent phys plus one for food state when food_count > 0.
+            staging_trackers: std::array::from_fn(|_| {
+                ReadbackTracker::new(if f > 0 { 2 } else { 1 })
+            }),
             state_cache: vec![0.0; n * PHYS_STRIDE],
             food_cache: vec![0.0; f * FOOD_STATE_STRIDE],
             food_cache_valid: false,
@@ -1228,13 +1203,17 @@ impl GpuKernel {
         self.active_config_index = 1 - self.active_config_index;
     }
 
-    /// Number of map_async callbacks expected per staging slot: 1 (phys) + 1 (food)
-    /// when food exists, or just 1 when food_count is 0.
-    fn expected_staging_callbacks(&self) -> u32 {
+    /// Unmap every buffer participating in the given staging slot.
+    ///
+    /// Always called after the slot's [`ReadbackTracker`] reports
+    /// [`ReadbackStatus::Ready`] or [`ReadbackStatus::Failed`]: on failure
+    /// the mapping never completed so `unmap` is a no-op on the unmapped
+    /// buffer, while on success we need to release the mapping before the
+    /// slot can be reused.
+    fn unmap_staging_slot(&self, slot: usize) {
+        self.state_staging[slot].unmap();
         if self.food_count > 0 {
-            2
-        } else {
-            1
+            self.food_staging[slot].unmap();
         }
     }
 
@@ -1243,24 +1222,20 @@ impl GpuKernel {
     fn try_collect_staging(&mut self) -> bool {
         let n = self.agent_count as usize;
         let buf_size = (n * PHYS_STRIDE * 4) as u64;
-        let expected = self.expected_staging_callbacks();
         let mut collected = false;
         for i in 0..STAGING_SLOTS {
             if !self.staging_in_flight[i] {
                 continue;
             }
-            if self.staging_ready[i].load(Ordering::Acquire) < expected {
-                continue;
-            }
-
-            if self.staging_had_error[i].load(Ordering::Acquire) {
-                // A map_async callback errored — abandon this slot.
-                self.state_staging[i].unmap();
-                if self.food_count > 0 {
-                    self.food_staging[i].unmap();
+            match self.staging_trackers[i].status() {
+                ReadbackStatus::Pending => continue,
+                ReadbackStatus::Failed => {
+                    // A map_async callback errored — abandon this slot.
+                    self.unmap_staging_slot(i);
+                    self.staging_in_flight[i] = false;
+                    continue;
                 }
-                self.staging_in_flight[i] = false;
-                continue;
+                ReadbackStatus::Ready => {}
             }
 
             // Collect agent phys state
@@ -1270,7 +1245,6 @@ impl GpuKernel {
             self.state_cache.clear();
             self.state_cache.extend_from_slice(floats);
             drop(data);
-            self.state_staging[i].unmap();
 
             // Collect food state (only when food exists)
             if self.food_count > 0 {
@@ -1281,10 +1255,10 @@ impl GpuKernel {
                 self.food_cache.clear();
                 self.food_cache.extend_from_slice(food_floats);
                 drop(food_data);
-                self.food_staging[i].unmap();
                 self.food_cache_valid = true;
             }
 
+            self.unmap_staging_slot(i);
             self.staging_in_flight[i] = false;
             collected = true;
         }
@@ -1461,33 +1435,13 @@ impl GpuKernel {
             }
             self.queue.submit(std::iter::once(encoder.finish()));
 
-            self.staging_ready[slot_index].store(0, Ordering::Release);
-            self.staging_had_error[slot_index].store(false, Ordering::Release);
-
-            let phys_flag = self.staging_ready[slot_index].clone();
-            let phys_err = self.staging_had_error[slot_index].clone();
-            self.state_staging[slot_index].slice(..buf_size).map_async(
-                wgpu::MapMode::Read,
-                move |result| {
-                    if result.is_err() {
-                        phys_err.store(true, Ordering::Release);
-                    }
-                    phys_flag.fetch_add(1, Ordering::Release);
-                },
-            );
+            self.staging_trackers[slot_index].reset();
+            self.staging_trackers[slot_index]
+                .install(self.state_staging[slot_index].slice(..buf_size));
             if self.food_count > 0 {
                 let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
-                let food_flag = self.staging_ready[slot_index].clone();
-                let food_err = self.staging_had_error[slot_index].clone();
-                self.food_staging[slot_index].slice(..food_size).map_async(
-                    wgpu::MapMode::Read,
-                    move |result| {
-                        if result.is_err() {
-                            food_err.store(true, Ordering::Release);
-                        }
-                        food_flag.fetch_add(1, Ordering::Release);
-                    },
-                );
+                self.staging_trackers[slot_index]
+                    .install(self.food_staging[slot_index].slice(..food_size));
             }
             self.staging_in_flight[slot_index] = true;
             self.staging_index = (slot_index + 1) % STAGING_SLOTS;
@@ -1718,35 +1672,11 @@ impl GpuKernel {
 
         self.queue.submit(std::iter::once(encoder.finish()));
 
-        // Set up map_async on all three staging buffers. Each callback
-        // increments a shared counter; we only consider the readback ready
-        // when all 3 have completed. If any fails, we set an error flag so
-        // the caller can abandon the readback instead of hanging forever.
-        let mapped_count = Arc::new(AtomicU8::new(0));
-        let had_error = Arc::new(AtomicBool::new(false));
-
-        let make_callback = |count: Arc<AtomicU8>, err: Arc<AtomicBool>| {
-            move |result: Result<(), wgpu::BufferAsyncError>| {
-                if result.is_ok() {
-                    count.fetch_add(1, Ordering::Release);
-                } else {
-                    err.store(true, Ordering::Release);
-                }
-            }
-        };
-
-        brain_staging.slice(..).map_async(
-            wgpu::MapMode::Read,
-            make_callback(mapped_count.clone(), had_error.clone()),
-        );
-        pattern_staging.slice(..).map_async(
-            wgpu::MapMode::Read,
-            make_callback(mapped_count.clone(), had_error.clone()),
-        );
-        history_staging.slice(..).map_async(
-            wgpu::MapMode::Read,
-            make_callback(mapped_count.clone(), had_error.clone()),
-        );
+        // Aggregate completion/error for all 3 staging buffers in a single tracker.
+        let tracker = ReadbackTracker::new(3);
+        tracker.install(brain_staging.slice(..));
+        tracker.install(pattern_staging.slice(..));
+        tracker.install(history_staging.slice(..));
 
         self.agent_state_staging = Some(AgentStateReadback {
             brain_staging,
@@ -1755,8 +1685,7 @@ impl GpuKernel {
             brain_size,
             pattern_size: pat_size,
             history_size: hist_size,
-            mapped_count,
-            had_error,
+            tracker,
             brain_stride: bs,
         });
         true
@@ -1769,24 +1698,24 @@ impl GpuKernel {
         let readback = self.agent_state_staging.as_ref()?;
         self.device.poll(wgpu::Maintain::Poll);
 
-        // If any mapping failed, abandon the readback.
-        if readback.had_error.load(Ordering::Acquire) {
-            log::error!("[GPU] agent-state map_async failed — abandoning readback");
-            let rb = self.agent_state_staging.take().unwrap();
-            // Unmap any buffers that did succeed to avoid leaking.
-            let _ =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| rb.brain_staging.unmap()));
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                rb.pattern_staging.unmap()
-            }));
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                rb.history_staging.unmap()
-            }));
-            return Some(None);
-        }
-
-        if readback.mapped_count.load(Ordering::Acquire) < 3 {
-            return None; // not all 3 buffers mapped yet
+        match readback.tracker.status() {
+            ReadbackStatus::Pending => return None,
+            ReadbackStatus::Failed => {
+                log::error!("[GPU] agent-state map_async failed — abandoning readback");
+                let rb = self.agent_state_staging.take().unwrap();
+                // Unmap any buffers that did succeed to avoid leaking.
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    rb.brain_staging.unmap()
+                }));
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    rb.pattern_staging.unmap()
+                }));
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    rb.history_staging.unmap()
+                }));
+                return Some(None);
+            }
+            ReadbackStatus::Ready => {}
         }
 
         let readback = self.agent_state_staging.take().unwrap();
@@ -1888,38 +1817,18 @@ impl GpuKernel {
     /// buffers are still in flight (caller should retry next frame).
     pub fn try_reset_agents(&mut self, brain_config: &BrainConfig) -> bool {
         // Check if any staging buffer is still in flight.
-        let expected = self.expected_staging_callbacks();
         for i in 0..STAGING_SLOTS {
             if self.staging_in_flight[i] {
                 self.device.poll(wgpu::Maintain::Poll);
-                if self.staging_ready[i].load(Ordering::Acquire) < expected {
-                    return false; // not ready yet — caller retries next frame
-                }
-
-                if self.staging_had_error[i].load(Ordering::Acquire) {
-                    self.state_staging[i].unmap();
-                    if self.food_count > 0 {
-                        self.food_staging[i].unmap();
-                    }
-                } else {
-                    let buf_size = (self.agent_count as usize * PHYS_STRIDE * 4) as u64;
-                    let slice = self.state_staging[i].slice(..buf_size);
-                    let _data = slice.get_mapped_range();
-                    drop(_data);
-                    self.state_staging[i].unmap();
-
-                    if self.food_count > 0 {
-                        let food_size = (self.food_count * FOOD_STATE_STRIDE * 4) as u64;
-                        let food_slice = self.food_staging[i].slice(..food_size);
-                        let _food_data = food_slice.get_mapped_range();
-                        drop(_food_data);
-                        self.food_staging[i].unmap();
+                match self.staging_trackers[i].status() {
+                    ReadbackStatus::Pending => return false, // caller retries next frame
+                    ReadbackStatus::Ready | ReadbackStatus::Failed => {
+                        self.unmap_staging_slot(i);
+                        self.staging_in_flight[i] = false;
                     }
                 }
-
-                self.staging_in_flight[i] = false;
             }
-            self.staging_ready[i].store(0, Ordering::Release);
+            self.staging_trackers[i].reset();
         }
         self.staging_index = 0;
 
@@ -2155,32 +2064,19 @@ impl GpuKernel {
 
         self.queue.submit(std::iter::once(encoder.finish()));
 
-        // Completion counter increments unconditionally (Ok or Err);
-        // error flag records whether any mapping failed.
-        let completed = Arc::new(AtomicU32::new(0));
-        let had_error = Arc::new(AtomicBool::new(false));
-
+        // Aggregate completion/error for all 4 staging buffers in a single tracker.
+        let tracker = ReadbackTracker::new(4);
         for staging in [
             &self.telemetry_staging.sensory,
             &self.telemetry_staging.decision,
             &self.telemetry_staging.brain,
             &self.telemetry_staging.phys,
         ] {
-            let cnt = completed.clone();
-            let err = had_error.clone();
-            staging
-                .slice(..)
-                .map_async(wgpu::MapMode::Read, move |result| {
-                    if result.is_err() {
-                        err.store(true, Ordering::Release);
-                    }
-                    cnt.fetch_add(1, Ordering::AcqRel);
-                });
+            tracker.install(staging.slice(..));
         }
 
         self.pending_telemetry = Some(TelemetryReadback {
-            completed,
-            had_error,
+            tracker,
             agent_index: index,
         });
     }
@@ -2194,17 +2090,15 @@ impl GpuKernel {
         self.device.poll(wgpu::Maintain::Poll);
 
         let pending = self.pending_telemetry.as_ref()?;
-        let completed = pending.completed.load(Ordering::Acquire);
-        if completed < 4 {
-            return None;
-        }
-
-        // All 4 callbacks fired. Check for errors.
-        if pending.had_error.load(Ordering::Acquire) {
-            // At least one mapping failed — unmap staging buffers and allow retry.
-            self.unmap_telemetry_staging();
-            self.pending_telemetry = None;
-            return None;
+        match pending.tracker.status() {
+            ReadbackStatus::Pending => return None,
+            ReadbackStatus::Failed => {
+                // At least one mapping failed — unmap staging buffers and allow retry.
+                self.unmap_telemetry_staging();
+                self.pending_telemetry = None;
+                return None;
+            }
+            ReadbackStatus::Ready => {}
         }
 
         // All 4 mappings succeeded — consume pending state and read data.

--- a/crates/xagent-brain/src/lib.rs
+++ b/crates/xagent-brain/src/lib.rs
@@ -5,6 +5,7 @@
 //! from the interaction of capacity constraints, prediction error, and
 //! homeostatic pressure.
 
+pub(crate) mod async_readback;
 pub mod buffers;
 pub mod gpu_kernel;
 


### PR DESCRIPTION
## Summary

- Extract the shared `Arc<AtomicU32>` + `Arc<AtomicBool>` + `map_async` closure plumbing from `gpu_kernel.rs` into a new `ReadbackTracker` helper in a new private `crate::async_readback` module.
- Refactor all three async readback paths (ring-buffer staging, per-agent brain-state via `request_agent_state` / `try_collect_agent_state`, per-agent telemetry via `request_agent_telemetry` / `try_collect_telemetry`) to use it.
- Net **−105 lines** in `gpu_kernel.rs` (278 → 192 in the async paths) — call sites now express intent (which slices map, how many callbacks to expect) instead of plumbing.

The tracker exposes `new(expected)`, `reset()`, `install(slice)`, and `status() -> ReadbackStatus { Pending | Ready | Failed }`. Buffer ownership (and `get_mapped_range` / `unmap` on every outcome) stays with the caller because staging buffers are pre-allocated and reused across readback rounds, and only the caller knows the exact byte ranges and data layout.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p xagent-brain` — 46 tests pass, including 7 new unit tests covering `ReadbackTracker` state transitions (pending/ready/failed, reset, sticky error flag, debug-assert on `expected = 0`)
- [x] `cargo test -p xagent-sandbox` — 95 tests pass
- [x] `cargo test --workspace` — full suite green

Closes #114