### PR TITLE
chore: drop unreachable timer waits from work-on-issue skill

### DIFF
--- a/.claude/skills/work-on-issue/SKILL.md
+++ b/.claude/skills/work-on-issue/SKILL.md
@@ -92,24 +92,30 @@ Do not push on hook failure. Fix the root cause and create a new commit.
 2. If no open PR exists, create one with `mcp__github__create_pull_request` targeting `develop`:
    - Title: conventional-commit style, < 70 chars.
    - Body: Summary (1–3 bullets), Test Plan (checklist), and `Closes #<num>` (or `Refs #<num>` if scope is partial).
-3. Subscribe to PR activity: `mcp__github__subscribe_pr_activity` for the PR number. Tell the user you're now watching CI + review events. Webhook delivery is best-effort — events can be dropped — so treat the subscription as the primary signal and use bounded-wait fallbacks (Step 6 for CI, Step 7c for Copilot) to keep progress from stalling when the event never arrives.
+3. Subscribe to PR activity: `mcp__github__subscribe_pr_activity` for the PR number. Tell the user you're now watching CI + review events. The subscription brings Claude back into the conversation when an event arrives — it does **not** let Claude sleep inside a single turn with a fallback timer. Step 6 and Step 7b describe how to reconcile this: poll on each turn, end the turn to wait, and rely on webhook arrivals (or `/loop`) to resume.
 
-## Step 6 — CI babysitting (webhook-first, bounded polling fallback)
+## Step 6 — CI babysitting (turn-based polling)
 
-After every push, capture the head SHA (`git rev-parse HEAD`) and wait for CI to conclude using this policy:
+Claude runs in a turn-based loop. It cannot pause a turn for N seconds waiting for a webhook and then time out — between turns Claude isn't running, so any "timer" described in the skill would never fire on its own. Treat CI status like this:
 
-1. **Webhook window — 60 seconds.** Wait up to 1 minute for a `<github-webhook-activity>` event whose `head_sha`/`commit_sha` matches the pushed SHA. If a `check_run.completed` / `check_suite.completed` / `status` event arrives indicating conclusion, jump straight to step 3.
-2. **Poll fallback.** If the webhook window expires with no conclusion event (or if an event arrived but is ambiguous), start polling `mcp__github__get_commit` on the head SHA (or `mcp__github__pull_request_read` — whichever exposes check-run / status data). Poll cadence: every 30s for the first 3 min, then every 60s, capped at 2 min. Between polls, keep listening for webhook events — if one arrives, act on it immediately and reset the poll timer. Surface the state to the user after ~20 min of `in_progress`/`queued` so they can intervene.
-3. **Classify the aggregate state** (from the webhook payload or the latest poll):
-   - **All required checks `success`** → CI is green, proceed to Step 7.
+1. **Same turn as the push.** Capture the head SHA (`git rev-parse HEAD`) and poll `mcp__github__pull_request_read` (method `get_check_runs`) or `mcp__github__get_commit` on the head SHA. Report the current state to the user in one line.
+2. **End the turn** if CI is still pending. Claude will be resumed by:
+   - a `check_run.completed` / `check_suite.completed` / `status` webhook event (via the subscription), or
+   - a user ping, or
+   - a `/loop` tick if the user has set one up.
+3. **On every resume,** re-poll the check-runs and reconcile:
+   - **All required checks `success`** → proceed to Step 7.
    - **Any `failure` / `cancelled` / `timed_out` / `action_required`** → fix loop below.
-   - **Any `in_progress` / `queued` / `pending`** → keep waiting (webhook + poll).
-4. **On failure:**
-   1. Read the failing check's log URL from the `get_commit` payload or the webhook event; fetch the log (or use `mcp__github__list_commits` → `get_commit` to drill into the check run if needed).
-   2. Reproduce locally when possible (`cargo fmt` / `clippy` / `test`).
-   3. Fix the root cause — never `--no-verify`, never disable a failing test, never mask a clippy lint without a justified `#[allow]` + comment.
-   4. Commit (`fix:` or `chore:` prefix), push, and return to step 1 with the new head SHA. Repeat until green.
-5. **Authority rule.** If a webhook says "success" and a poll says otherwise (or vice versa), trust the poll — the API reflects current state, webhooks may be stale.
+   - **Any `in_progress` / `queued` / `pending`** → report status and end the turn again.
+4. **If the user wants guaranteed forward progress** while CI runs (e.g. webhooks are dropping), offer `/loop 2m keep working on PR #<num>` so the harness brings Claude back on a timer. The skill itself has no way to self-schedule.
+5. **Authority rule.** The API poll is authoritative; webhook payloads are hints. If they disagree, trust the poll.
+
+On failure:
+
+1. Read the failing check's log URL from the `get_commit` / `get_check_runs` payload; fetch the log if needed (or use `mcp__github__list_commits` → `get_commit` to drill into the run).
+2. Reproduce locally when possible (`cargo fmt` / `clippy` / `test`).
+3. Fix the root cause — never `--no-verify`, never disable a failing test, never mask a clippy lint without a justified `#[allow]` + comment.
+4. Commit (`fix:` or `chore:` prefix), push, and return to step 1 with the new head SHA. Repeat until green.
 
 ## Step 7 — Copilot review loop
 
@@ -126,17 +132,18 @@ Copilot reviews the PR diff against `develop`. A dirty merge state produces nois
    - Re-run the full local gate after resolution: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p xagent-sandbox`.
    - Commit with a `chore: merge develop into <branch>` (or `fix:` if the resolution involved behavior changes) — never amend an existing commit.
    - `git push`. If the remote rejected because someone else pushed meanwhile, `git pull --rebase` and retry.
-5. Wait for CI on the merge commit per Step 6 (1-minute webhook window, then poll) until it goes green. Loop back to Step 6's fix path if it fails.
+5. Wait for CI on the merge commit per Step 6 (poll on each turn; resume on webhook or `/loop` tick) until it goes green. Loop back to Step 6's fix path if it fails.
 
 Only then call `mcp__github__request_copilot_review`.
 
-### 7b. Wait for the review (webhook-first, 5-minute fallback)
+### 7b. Wait for the review (turn-based polling)
 
 After calling `mcp__github__request_copilot_review`:
 
-1. **Webhook window — 5 minutes.** Watch for `<github-webhook-activity>` events tagged as a Copilot review (`pull_request_review` with `user.login` matching the Copilot reviewer, or `pull_request_review_comment` from the same bot). When the `submitted`/`completed` event arrives, proceed to 7c with the event payload.
-2. **Poll fallback.** If 5 minutes pass with no review event, call `mcp__github__pull_request_read` to list reviews/comments and check whether Copilot has posted a review since the last request. Keep polling every 60s (capped at 2 min) while still listening for webhooks; after ~15 min with no review, surface to the user — Copilot may be disabled, rate-limited, or the request may have silently failed. Offer to re-request.
-3. **Authority rule.** The API is authoritative for "has Copilot reviewed yet" — a missing webhook does not mean no review exists.
+1. Tell the user the review is requested and end the turn. As with CI, Claude can't sleep inside a turn — it will be resumed by a `pull_request_review` / `pull_request_review_comment` webhook event, a user ping, or a `/loop` tick.
+2. **On every resume,** poll `mcp__github__pull_request_read` (methods `get_reviews` and `get_review_comments`) and check whether Copilot has posted a review newer than the last request. If yes, proceed to 7c with the API data.
+3. If several resumes pass without a Copilot review, surface to the user — Copilot may be disabled, rate-limited, or the request may have silently failed. Offer to re-request, and suggest `/loop 2m …` if the user wants timed polling.
+4. **Authority rule.** The API is authoritative for "has Copilot reviewed yet" — a missing webhook does not mean no review exists.
 
 ### 7c. Processing review comments
 


### PR DESCRIPTION
## Summary
- Removes unreachable timer-based wait language from the `work-on-issue` skill (60s CI webhook window, 5-minute Copilot window, nested poll cadences). Claude's agent loop is turn-based — it cannot pause a single turn for N seconds waiting for a webhook and then time out.
- Replaces both waits with a turn-based polling model: poll status on the same turn as the push/request, end the turn when still pending, and rely on webhook arrivals (or `/loop` ticks, or user pings) to resume. On each resume, re-poll.
- Points the user at `/loop 2m …` when they want guaranteed timed progress, since the skill itself has no way to self-schedule.
- API poll remains authoritative over webhook payloads.

## Test plan
- [ ] Invoke `/work-on-issue` on a real issue and confirm the CI step polls on each turn, ends the turn while pending, and resumes on webhook or manual ping.
- [ ] Confirm the Copilot-review step behaves the same way — request review, end turn, poll on resume.
- [ ] Spot-check the `/loop 2m …` suggestion shows up when webhooks are silent and the user asks for progress.
