### PR TITLE
doc: document and bound the one-batch sensory lag invariant

### DIFF
--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -440,6 +440,31 @@ impl GpuKernel {
         let layout = BrainLayout::new(brain_config.vision_width, brain_config.vision_height);
         let brain_tick_stride = brain_config.brain_tick_stride;
 
+        // Sensory-lag bound (issue #115). The brain reads vision/proprioception
+        // from `sensory_buffer`, refreshed by the vision pass at the end of each
+        // batch, so it acts on data `sensory_lag_ticks()` physics ticks stale (see
+        // `BrainConfig::MAX_SENSORY_LAG_TICKS`). Beyond the bound, credit
+        // assignment desynchronizes from action outcomes — the failure mode behind
+        // the circling investigation (#13). Warn in every build for visibility on
+        // externally-loaded configs, and `debug_assert!` to hard-trip a developer
+        // who grows the strides past what the design was validated for.
+        let sensory_lag = brain_config.sensory_lag_ticks();
+        if sensory_lag > BrainConfig::MAX_SENSORY_LAG_TICKS {
+            log::warn!(
+                "sensory lag {sensory_lag} ticks (vision_stride {} * brain_tick_stride {}) \
+                 exceeds MAX_SENSORY_LAG_TICKS {}; credit assignment may desynchronize from \
+                 action outcomes (issue #115)",
+                brain_config.vision_stride,
+                brain_tick_stride,
+                BrainConfig::MAX_SENSORY_LAG_TICKS,
+            );
+        }
+        debug_assert!(
+            sensory_lag <= BrainConfig::MAX_SENSORY_LAG_TICKS,
+            "sensory lag {sensory_lag} ticks exceeds MAX_SENSORY_LAG_TICKS {} (issue #115)",
+            BrainConfig::MAX_SENSORY_LAG_TICKS,
+        );
+
         let storage_rw = wgpu::BufferUsages::STORAGE
             | wgpu::BufferUsages::COPY_DST
             | wgpu::BufferUsages::COPY_SRC;

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -503,6 +503,16 @@ fn kernel_tick(
         // vision pass.  Physics state updated in this cycle is NOT yet in
         // sensory_buffer — that update happens in the vision pass at the end of
         // this batch, making it available for the following batch.
+        //
+        // SENSORY-LAG RISK (issue #115): this read is stale by exactly one batch =
+        // vision_stride * brain_tick_stride physics ticks. The lag is intentional
+        // and constant, but credit assignment pairs a motor command with the
+        // gradient it produced — the larger the lag, the more the visual evidence
+        // at decision time desynchronizes from the action's outcome, the failure
+        // mode behind the circling investigation. The product is bounded on the
+        // Rust side by `BrainConfig::MAX_SENSORY_LAG_TICKS` (asserted in
+        // `GpuKernel::new`); do NOT grow the strides or make them dynamic past that
+        // bound without revalidating credit assignment.
         brain_tick_inner(agent_id, tid /* KERNEL_SUBGROUP_TOPK_INNER_ARGS */);
         workgroupBarrier();
     }

--- a/crates/xagent-sandbox/src/ui.rs
+++ b/crates/xagent-sandbox/src/ui.rs
@@ -1429,16 +1429,20 @@ impl<'a> TabContext<'a> {
                     b.vision_height = vision_height.max(2) as u32;
                     ui.end_row();
 
+                    // Clamp ranges come from BrainConfig so the UI ceiling stays
+                    // tied to the sensory-lag bound (BrainConfig::MAX_SENSORY_LAG_TICKS).
+                    let max_bts = xagent_shared::BrainConfig::MAX_BRAIN_TICK_STRIDE as i32;
+                    let max_vs = xagent_shared::BrainConfig::MAX_VISION_STRIDE as i32;
                     ui.label("brain_tick_stride");
                     let mut bts = b.brain_tick_stride as i32;
-                    ui.add(egui::DragValue::new(&mut bts).range(1..=32).speed(1));
-                    b.brain_tick_stride = bts.clamp(1, 32) as u32;
+                    ui.add(egui::DragValue::new(&mut bts).range(1..=max_bts).speed(1));
+                    b.brain_tick_stride = bts.clamp(1, max_bts) as u32;
                     ui.end_row();
 
                     ui.label("vision_stride");
                     let mut vs = b.vision_stride as i32;
-                    ui.add(egui::DragValue::new(&mut vs).range(1..=50).speed(1));
-                    b.vision_stride = vs.clamp(1, 50) as u32;
+                    ui.add(egui::DragValue::new(&mut vs).range(1..=max_vs).speed(1));
+                    b.vision_stride = vs.clamp(1, max_vs) as u32;
                     ui.end_row();
 
                     ui.label("metabolic_rate");

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -77,12 +77,16 @@ pub struct BrainConfig {
     #[serde(default = "default_vision_height", alias = "vision_h")]
     pub vision_height: u32,
     /// Physics ticks per brain+vision cycle. Higher = faster but less responsive.
-    /// Default 10.
+    /// Default 10, clamped to `[1, MAX_BRAIN_TICK_STRIDE]` in the UI. Combined
+    /// with `vision_stride` this sets the one-batch sensory lag — see
+    /// [`BrainConfig::sensory_lag_ticks`].
     #[serde(default = "default_brain_tick_stride")]
     pub brain_tick_stride: u32,
     /// Brain cycles between global passes (grid rebuild, collisions, vision).
     /// Higher = more brain throughput, less frequent vision updates.
-    /// Default 10.
+    /// Default 10, clamped to `[1, MAX_VISION_STRIDE]` in the UI. Combined with
+    /// `brain_tick_stride` this sets the one-batch sensory lag — see
+    /// [`BrainConfig::sensory_lag_ticks`].
     #[serde(default = "default_vision_stride")]
     pub vision_stride: u32,
     /// Multiplier for all energy costs (metabolic + movement). Default 0.5.
@@ -292,6 +296,61 @@ impl Default for BrainConfig {
 }
 
 impl BrainConfig {
+    /// Maximum `brain_tick_stride` (physics ticks per brain+vision cycle). The
+    /// UI `DragValue` clamps to this; configs loaded from JSON or mutated
+    /// programmatically are expected to respect it as well.
+    pub const MAX_BRAIN_TICK_STRIDE: u32 = 32;
+
+    /// Maximum `vision_stride` (brain cycles between vision passes). The UI
+    /// `DragValue` clamps to this.
+    pub const MAX_VISION_STRIDE: u32 = 50;
+
+    /// Upper bound on the one-batch sensory lag, in physics ticks.
+    ///
+    /// # The sensory-lag invariant
+    ///
+    /// The brain reads vision and proprioception from `sensory_buffer`, which the
+    /// global vision pass refreshes *after* each fused-kernel batch completes (see
+    /// `kernel_tick.wgsl` and `GpuKernel::dispatch_batch`). One batch covers
+    /// `vision_stride * brain_tick_stride` physics ticks, so the brain always acts
+    /// on visual state that is exactly one batch — [`sensory_lag_ticks`] ticks —
+    /// stale. The lag is intentional and constant across stride settings.
+    ///
+    /// # Why it is bounded
+    ///
+    /// Credit assignment pairs a motor command with the gradient that command
+    /// produced (CONTRIBUTING.md → State Invariants: temporal alignment). The
+    /// larger the lag, the more the visual evidence at decision time
+    /// desynchronizes from the action's actual outcome. The credit-assignment
+    /// bugs unraveled during the circling investigation (issue #13) were rooted in
+    /// exactly this kind of temporal mismatch, so bounding the product acts as a
+    /// tripwire: if a future change grows the strides — or makes them dynamic —
+    /// past what the design was validated for, the bound trips instead of silently
+    /// resurrecting those bugs.
+    ///
+    /// The bound is the largest lag the UI clamps permit
+    /// (`MAX_BRAIN_TICK_STRIDE * MAX_VISION_STRIDE`), so every in-range config is
+    /// accepted and anything larger signals a path that bypassed those clamps.
+    ///
+    /// See `docs/reviews/2026-04-15-gemini-31-pro.md` ("The One-Batch Sensory
+    /// Lag") and issue #115.
+    ///
+    /// [`sensory_lag_ticks`]: BrainConfig::sensory_lag_ticks
+    pub const MAX_SENSORY_LAG_TICKS: u32 = Self::MAX_BRAIN_TICK_STRIDE * Self::MAX_VISION_STRIDE;
+
+    /// The one-batch sensory lag for this config, in physics ticks
+    /// (`vision_stride * brain_tick_stride`).
+    ///
+    /// Saturates to [`u32::MAX`] if the product overflows (e.g. a corrupt config),
+    /// so a caller comparing against
+    /// [`MAX_SENSORY_LAG_TICKS`](Self::MAX_SENSORY_LAG_TICKS) still rejects it
+    /// rather than wrapping to a small value. See the
+    /// [`MAX_SENSORY_LAG_TICKS`](Self::MAX_SENSORY_LAG_TICKS) docs for the full
+    /// invariant and the rationale for the bound.
+    pub fn sensory_lag_ticks(&self) -> u32 {
+        self.vision_stride.saturating_mul(self.brain_tick_stride)
+    }
+
     /// Minimal capacity — interesting for observing constraints.
     pub fn tiny() -> Self {
         Self {
@@ -414,5 +473,54 @@ mod tests {
     fn governor_config_tuned_defaults() {
         let config = GovernorConfig::default();
         assert_eq!(config.tick_budget, 1_000_000);
+    }
+
+    #[test]
+    fn sensory_lag_is_product_of_strides() {
+        let config = BrainConfig {
+            brain_tick_stride: 7,
+            vision_stride: 9,
+            ..BrainConfig::default()
+        };
+        assert_eq!(config.sensory_lag_ticks(), 63);
+    }
+
+    #[test]
+    fn default_sensory_lag_is_within_bound() {
+        let config = BrainConfig::default();
+        // Default 10 * 10 = 100 ticks, well under the bound.
+        assert_eq!(config.sensory_lag_ticks(), 100);
+        assert!(config.sensory_lag_ticks() <= BrainConfig::MAX_SENSORY_LAG_TICKS);
+    }
+
+    #[test]
+    fn sensory_lag_bound_tracks_stride_clamps() {
+        // These mirror the UI DragValue clamps in ui.rs — keep them in sync.
+        assert_eq!(BrainConfig::MAX_BRAIN_TICK_STRIDE, 32);
+        assert_eq!(BrainConfig::MAX_VISION_STRIDE, 50);
+        assert_eq!(BrainConfig::MAX_SENSORY_LAG_TICKS, 1600);
+        // A config at both clamp ceilings hits exactly the bound (inclusive).
+        let config = BrainConfig {
+            brain_tick_stride: BrainConfig::MAX_BRAIN_TICK_STRIDE,
+            vision_stride: BrainConfig::MAX_VISION_STRIDE,
+            ..BrainConfig::default()
+        };
+        assert_eq!(
+            config.sensory_lag_ticks(),
+            BrainConfig::MAX_SENSORY_LAG_TICKS
+        );
+    }
+
+    #[test]
+    fn sensory_lag_saturates_on_overflow() {
+        // A corrupt/hand-edited config must not wrap to a small lag and sneak past
+        // the bound; the product saturates so the comparison still rejects it.
+        let config = BrainConfig {
+            brain_tick_stride: u32::MAX,
+            vision_stride: 2,
+            ..BrainConfig::default()
+        };
+        assert_eq!(config.sensory_lag_ticks(), u32::MAX);
+        assert!(config.sensory_lag_ticks() > BrainConfig::MAX_SENSORY_LAG_TICKS);
     }
 }


### PR DESCRIPTION
## Summary

- The brain reads vision/proprioception from `sensory_buffer`, refreshed by the vision pass *after* each fused-kernel batch, so it acts on data exactly `vision_stride * brain_tick_stride` physics ticks stale. This one-batch lag was intentional but undocumented as an invariant and unbounded — if strides grow or become dynamic, credit assignment desyncs from action outcomes (the failure mode behind the circling investigation, #13).
- Adds `BrainConfig::{MAX_BRAIN_TICK_STRIDE, MAX_VISION_STRIDE, MAX_SENSORY_LAG_TICKS}` + `sensory_lag_ticks()`, documenting the invariant and its rationale. The bound (`1600`) is the product of the UI stride clamps, so every in-range config is accepted and anything larger signals a path that bypassed those clamps.
- Asserts the bound in `GpuKernel::new` (`debug_assert!` tripwire for developers + `log::warn!` for externally-loaded configs in release), and notes the **SENSORY-LAG RISK** in `kernel_tick.wgsl` right at the sensory read.
- Ties the UI `brain_tick_stride`/`vision_stride` clamps to the new constants (removes magic `32`/`50`).

## Test Plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p xagent-shared -p xagent-sandbox` — all pass (incl. GPU integration tests at strides up to 32×32, under the bound)
- [x] New unit tests: lag = product of strides, default within bound, bound/clamp coupling (`32`/`50`/`1600`), overflow saturation

Closes #115

---
_Generated by [Claude Code](https://claude.ai/code/session_01UD753GSkrboTggAXt9NWr9)_