### PR TITLE
fix: gate subgroup bitonic sort on min_subgroup_size >= 32

### DIFF
--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -71,7 +71,7 @@ const BITONIC_SORT_SUBGROUP_SRC: &str = include_str!("shaders/kernel/bitonic_sor
 /// members of the same subgroup. On narrower subgroups (e.g. 16-wide Intel
 /// iGPUs and some AMD configs) `sgid ^ 16` addresses a lane outside the
 /// subgroup and the shuffle returns an implementation-defined value, corrupting
-/// top-K recall (issue #133).
+/// top-K recall.
 const MIN_SUBGROUP_WIDTH_FOR_BITONIC: u32 = 32;
 
 /// Whether the subgroup-accelerated bitonic sort may be spliced into the brain
@@ -80,8 +80,8 @@ const MIN_SUBGROUP_WIDTH_FOR_BITONIC: u32 = 32;
 /// Requires both the `SUBGROUP` feature and a guaranteed subgroup width of at
 /// least [`MIN_SUBGROUP_WIDTH_FOR_BITONIC`]. `min_subgroup_size` is the floor the
 /// adapter promises, so gating on it ensures *every* subgroup the device
-/// produces is wide enough for the lane-pairing math — see issue #133. Adapters
-/// that do not report subgroup limits leave `min_subgroup_size` at `0`, which
+/// produces is wide enough for the lane-pairing math. Adapters that do not
+/// report subgroup limits leave `min_subgroup_size` at `0`, which
 /// correctly fails the check and keeps the workgroup-memory fallback sort.
 fn subgroup_bitonic_supported(has_feature: bool, min_subgroup_size: u32) -> bool {
     has_feature && min_subgroup_size >= MIN_SUBGROUP_WIDTH_FOR_BITONIC
@@ -429,8 +429,8 @@ impl GpuKernel {
 
         let adapter_limits = adapter.limits();
 
-        // Subgroup-accelerated bitonic sort gating (issue #133). The splice is
-        // only correct when every subgroup the device can produce is at least
+        // Subgroup-accelerated bitonic sort gating. The splice is only correct
+        // when every subgroup the device can produce is at least
         // `MIN_SUBGROUP_WIDTH_FOR_BITONIC` wide, so gate on the adapter's
         // guaranteed floor rather than the bare `SUBGROUP` feature.
         let has_subgroup_feature = adapter.features().contains(wgpu::Features::SUBGROUP);
@@ -444,7 +444,7 @@ impl GpuKernel {
         } else if has_subgroup_feature {
             log::info!(
                 "[GpuKernel] Subgroup feature present but min width {subgroup_min_width} < {} — \
-                 using shared-memory-only bitonic sort (issue #133)",
+                 using shared-memory-only bitonic sort",
                 MIN_SUBGROUP_WIDTH_FOR_BITONIC
             );
         } else {
@@ -2480,8 +2480,8 @@ mod tests {
     }
 
     // ────────────────────────────────────────────────────────────────────────
-    // Subgroup-width gating (issue #133) — the subgroup bitonic sort must only
-    // be spliced in when the adapter guarantees a wide-enough subgroup.
+    // Subgroup-width gating — the subgroup bitonic sort must only be spliced in
+    // when the adapter guarantees a wide-enough subgroup.
     // ────────────────────────────────────────────────────────────────────────
 
     #[test]
@@ -2489,7 +2489,7 @@ mod tests {
         // Feature present and the guaranteed width covers the shuffle stages.
         assert!(subgroup_bitonic_supported(true, 32));
         assert!(subgroup_bitonic_supported(true, 64));
-        // Feature present but subgroups can be too narrow → fall back (issue #133).
+        // Feature present but subgroups can be too narrow → fall back.
         assert!(!subgroup_bitonic_supported(true, 16));
         assert!(!subgroup_bitonic_supported(true, 8));
         // Adapters that do not report subgroup limits leave the floor at 0.

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -63,6 +63,30 @@ use crate::buffers::*;
 /// dedicated WGSL file so the fragment stays validator-friendly.
 const BITONIC_SORT_SUBGROUP_SRC: &str = include_str!("shaders/kernel/bitonic_sort_subgroup.wgsl");
 
+/// Minimum subgroup width (in invocations) required by the subgroup-accelerated
+/// bitonic sort in `bitonic_sort_subgroup.wgsl`.
+///
+/// Stages 0–4 of that sort pair lanes with `subgroupShuffle(_, sgid ^ half)`
+/// where `half` reaches `1 << 4 == 16`, so lanes `0..=31` must all be valid
+/// members of the same subgroup. On narrower subgroups (e.g. 16-wide Intel
+/// iGPUs and some AMD configs) `sgid ^ 16` addresses a lane outside the
+/// subgroup and the shuffle returns an implementation-defined value, corrupting
+/// top-K recall (issue #133).
+const MIN_SUBGROUP_WIDTH_FOR_BITONIC: u32 = 32;
+
+/// Whether the subgroup-accelerated bitonic sort may be spliced into the brain
+/// shader for the running adapter.
+///
+/// Requires both the `SUBGROUP` feature and a guaranteed subgroup width of at
+/// least [`MIN_SUBGROUP_WIDTH_FOR_BITONIC`]. `min_subgroup_size` is the floor the
+/// adapter promises, so gating on it ensures *every* subgroup the device
+/// produces is wide enough for the lane-pairing math — see issue #133. Adapters
+/// that do not report subgroup limits leave `min_subgroup_size` at `0`, which
+/// correctly fails the check and keeps the workgroup-memory fallback sort.
+fn subgroup_bitonic_supported(has_feature: bool, min_subgroup_size: u32) -> bool {
+    has_feature && min_subgroup_size >= MIN_SUBGROUP_WIDTH_FOR_BITONIC
+}
+
 /// Build the pipeline override map that feeds `VISION_W` / `VISION_H`
 /// into the WGSL override cascade. The returned map is the single source
 /// of truth for the vision-grid dimensions at pipeline creation time.
@@ -403,14 +427,30 @@ impl GpuKernel {
 
         log::info!("[GpuKernel] Adapter: {:?}", adapter.get_info());
 
-        let has_subgroup = adapter.features().contains(wgpu::Features::SUBGROUP);
+        let adapter_limits = adapter.limits();
+
+        // Subgroup-accelerated bitonic sort gating (issue #133). The splice is
+        // only correct when every subgroup the device can produce is at least
+        // `MIN_SUBGROUP_WIDTH_FOR_BITONIC` wide, so gate on the adapter's
+        // guaranteed floor rather than the bare `SUBGROUP` feature.
+        let has_subgroup_feature = adapter.features().contains(wgpu::Features::SUBGROUP);
+        let subgroup_min_width = adapter_limits.min_subgroup_size;
+        let has_subgroup = subgroup_bitonic_supported(has_subgroup_feature, subgroup_min_width);
         if has_subgroup {
-            log::info!("[GpuKernel] Subgroup support detected — enabling subgroup intrinsics for brain shader");
+            log::info!(
+                "[GpuKernel] Subgroup support detected (min width {subgroup_min_width}) — \
+                 enabling subgroup intrinsics for brain shader"
+            );
+        } else if has_subgroup_feature {
+            log::info!(
+                "[GpuKernel] Subgroup feature present but min width {subgroup_min_width} < {} — \
+                 using shared-memory-only bitonic sort (issue #133)",
+                MIN_SUBGROUP_WIDTH_FOR_BITONIC
+            );
         } else {
             log::info!("[GpuKernel] No subgroup support — using shared-memory-only bitonic sort");
         }
 
-        let adapter_limits = adapter.limits();
         let mut required_limits = wgpu::Limits::default();
         required_limits.max_storage_buffer_binding_size =
             adapter_limits.max_storage_buffer_binding_size;
@@ -2437,6 +2477,37 @@ mod tests {
     fn non_subgroup_path_strips_all_kernel_markers() {
         let out = apply_subgroup_markers(&composed_kernel_shader(), false);
         assert_no_markers_remain(&out);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Subgroup-width gating (issue #133) — the subgroup bitonic sort must only
+    // be spliced in when the adapter guarantees a wide-enough subgroup.
+    // ────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn subgroup_bitonic_gating_requires_feature_and_width() {
+        // Feature present and the guaranteed width covers the shuffle stages.
+        assert!(subgroup_bitonic_supported(true, 32));
+        assert!(subgroup_bitonic_supported(true, 64));
+        // Feature present but subgroups can be too narrow → fall back (issue #133).
+        assert!(!subgroup_bitonic_supported(true, 16));
+        assert!(!subgroup_bitonic_supported(true, 8));
+        // Adapters that do not report subgroup limits leave the floor at 0.
+        assert!(!subgroup_bitonic_supported(true, 0));
+        // Feature absent → fall back regardless of the reported width.
+        assert!(!subgroup_bitonic_supported(false, 64));
+        assert!(!subgroup_bitonic_supported(false, 0));
+    }
+
+    #[test]
+    fn subgroup_bitonic_threshold_covers_widest_shuffle_stage() {
+        // Stages 0–4 shuffle with `half` up to `1 << 4 == 16`. The partner lane
+        // `sgid ^ half` reaches index `(half << 1) - 1` (e.g. lane 31 for sgid
+        // 15), so the subgroup must be at least `half << 1 == 32` wide. Guards
+        // against the constant being lowered below what the sort's lane-pairing
+        // math actually needs.
+        const WIDEST_SHUFFLE_HALF: u32 = 1 << 4;
+        assert!(MIN_SUBGROUP_WIDTH_FOR_BITONIC >= WIDEST_SHUFFLE_HALF << 1);
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/crates/xagent-brain/src/shaders/kernel/bitonic_sort_subgroup.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/bitonic_sort_subgroup.wgsl
@@ -11,7 +11,7 @@
 // and on local variables `tid` (thread id, 0..255) and `sgid` (subgroup
 // invocation id) being in scope at the splice site.
 //
-// ── Subgroup-width contract (issue #133) ──
+// ── Subgroup-width contract ──
 // This fragment REQUIRES a subgroup width of at least 32 invocations. Stages
 // 0–4 pair lanes via `subgroupShuffle(my_val, sgid ^ half)` with `half` up to
 // `1 << 4 == 16`, so lanes 0..=31 must all be valid members of the same

--- a/crates/xagent-brain/src/shaders/kernel/bitonic_sort_subgroup.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/bitonic_sort_subgroup.wgsl
@@ -1,14 +1,29 @@
 // ── Subgroup-accelerated bitonic sort (replaces the workgroup-memory sort) ──
 // This fragment is spliced between the `BEGIN_BITONIC_SORT` /
 // `END_BITONIC_SORT` markers in `brain_passes.wgsl` by the Rust host before
-// creating the shader module/pipeline, when `wgpu::Features::SUBGROUP` is
-// available. This is host-side shader composition, not WGSL `override`
-// specialization via `PipelineCompilationOptions::constants`.
+// creating the shader module/pipeline, when the `wgpu::Features::SUBGROUP`
+// feature is present AND the adapter guarantees a subgroup width of at least 32
+// (see the width contract below). This is host-side shader composition, not
+// WGSL `override` specialization via `PipelineCompilationOptions::constants`.
 //
 // The fragment is self-contained — it relies on the same shared memory
 // (`s_similarities`, `shared_sort_indices`) declared in brain_passes.wgsl,
 // and on local variables `tid` (thread id, 0..255) and `sgid` (subgroup
 // invocation id) being in scope at the splice site.
+//
+// ── Subgroup-width contract (issue #133) ──
+// This fragment REQUIRES a subgroup width of at least 32 invocations. Stages
+// 0–4 pair lanes via `subgroupShuffle(my_val, sgid ^ half)` with `half` up to
+// `1 << 4 == 16`, so lanes 0..=31 must all be valid members of the same
+// subgroup. The mapping of `tid` onto subgroup lanes must also be contiguous in
+// aligned blocks of the subgroup width — true for the 1-D workgroup used here,
+// where `sgid == tid % subgroup_size` — so that `tid ^ half` and `sgid ^ half`
+// address the same bitonic partner. On 16-wide subgroups (some Intel iGPUs,
+// some AMD configs) `sgid ^ 16` would address a lane outside the subgroup and
+// return an implementation-defined value, corrupting top-K recall. The Rust
+// host therefore only splices this fragment in when the adapter reports
+// `min_subgroup_size >= 32` — see `subgroup_bitonic_supported()` in
+// gpu_kernel.rs.
 //
 // See `gpu_kernel.rs::apply_subgroup_markers()` for the full marker contract.
 

--- a/crates/xagent-brain/src/shaders/kernel/bitonic_sort_subgroup.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/bitonic_sort_subgroup.wgsl
@@ -15,10 +15,15 @@
 // This fragment REQUIRES a subgroup width of at least 32 invocations. Stages
 // 0–4 pair lanes via `subgroupShuffle(my_val, sgid ^ half)` with `half` up to
 // `1 << 4 == 16`, so lanes 0..=31 must all be valid members of the same
-// subgroup. The mapping of `tid` onto subgroup lanes must also be contiguous in
-// aligned blocks of the subgroup width — true for the 1-D workgroup used here,
-// where `sgid == tid % subgroup_size` — so that `tid ^ half` and `sgid ^ half`
-// address the same bitonic partner. On 16-wide subgroups (some Intel iGPUs,
+// subgroup. It also ASSUMES the invocation-to-lane mapping is the natural
+// contiguous one — `sgid == tid % subgroup_size`, with subgroups partitioning
+// `tid` into aligned blocks of the subgroup width — so that `tid ^ half` and
+// `sgid ^ half` select the same bitonic partner. WGSL/WebGPU does NOT guarantee
+// this: the relation between `local_invocation_id` and `subgroup_invocation_id`
+// is implementation-defined, so it is a requirement of this optimization, not a
+// spec property. It holds on the naga backends in use for a 1-D workgroup; a
+// backend that lays subgroups out differently must not take this path. On
+// 16-wide subgroups (some Intel iGPUs,
 // some AMD configs) `sgid ^ 16` would address a lane outside the subgroup and
 // return an implementation-defined value, corrupting top-K recall. The Rust
 // host therefore only splices this fragment in when the adapter reports


### PR DESCRIPTION
## Summary

- The subgroup-accelerated bitonic sort pairs lanes via `subgroupShuffle(_, sgid ^ half)` with `half` up to 16, so it requires a subgroup width of at least 32. It was activated on the bare `wgpu::Features::SUBGROUP` flag with no width check, so on 16-wide subgroups (some Intel iGPUs, some AMD configs) `sgid ^ 16` addressed a lane outside the subgroup and `subgroupShuffle` returned an implementation-defined value, corrupting top-K recall (issue #133).
- Gate the splice on `adapter.limits().min_subgroup_size >= 32` (the adapter's guaranteed floor, so *every* subgroup is wide enough). Narrower subgroups now use the workgroup-memory fallback sort; NVIDIA (32-wide) and AMD (32/64-wide) keep the acceleration — no regression. Adapters that don't report subgroup limits leave the floor at `0`, which safely fails the check.
- Document the subgroup-width contract in `bitonic_sort_subgroup.wgsl` and extract the gating into a pure, unit-tested helper (`subgroup_bitonic_supported`) with a named `MIN_SUBGROUP_WIDTH_FOR_BITONIC` constant.

This implements option 2 (restrict activation) from the issue. Option 1 (in-shader runtime branch) was rejected: the fallback sort needs `workgroupBarrier()`, and branching on `subgroup_size` (subgroup-uniform, not workgroup-uniform) would place barriers in non-uniform control flow — a uniformity violation naga rejects. Since `min_subgroup_size` is known host-side at device creation, the host gate is strictly simpler and equivalent.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p xagent-brain` (50 pass, incl. 2 new gating tests)
- [x] `cargo test -p xagent-sandbox` (44 pass)
- [x] New `subgroup_bitonic_gating_requires_feature_and_width` asserts the path is taken only when the feature is present **and** width ≥ 32 (16/8/0 fall back; feature-absent falls back).
- [x] New `subgroup_bitonic_threshold_covers_widest_shuffle_stage` ties the threshold to the sort's widest shuffle stage (`half = 1 << 4`), so lowering the constant below 32 fails the build.

Closes #133

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSgYikmDukMWarUP4AXYmk)_