### PR TITLE
feat: TD(λ) actor-critic credit + learning measurement harness (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That 
 
 ## Build & Test
 - `cargo check -p xagent-sandbox` — quick compile check for the sandbox crate
-- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 50 integration tests (128 total)
+- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 51 integration tests (129 total)
 
 ## Architecture
 - `crates/xagent-sandbox/src/governor.rs` — evolution state machine, SQLite persistence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That 
 
 ## Build & Test
 - `cargo check -p xagent-sandbox` — quick compile check for the sandbox crate
-- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 51 integration tests (129 total)
+- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 51 integration tests (129 total). GPU tests self-skip without an adapter; CI/dev installs Mesa lavapipe.
 
 ## Architecture
 - `crates/xagent-sandbox/src/governor.rs` — evolution state machine, SQLite persistence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That 
 
 ## Build & Test
 - `cargo check -p xagent-sandbox` — quick compile check for the sandbox crate
-- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 51 integration tests (129 total). GPU tests self-skip without an adapter; CI/dev installs Mesa lavapipe.
+- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 52 integration tests (130 total). GPU tests self-skip without an adapter; CI/dev installs Mesa lavapipe.
 
 ## Architecture
 - `crates/xagent-sandbox/src/governor.rs` — evolution state machine, SQLite persistence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That 
 
 ## Build & Test
 - `cargo check -p xagent-sandbox` — quick compile check for the sandbox crate
-- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 47 integration tests (125 total)
+- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 50 integration tests (128 total)
 
 ## Architecture
 - `crates/xagent-sandbox/src/governor.rs` — evolution state machine, SQLite persistence
@@ -15,6 +15,7 @@ All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That 
 - `crates/xagent-brain/src/gpu_kernel.rs` — fused kernel: single dispatch(agent_count,1,1) per vision-stride cycle, the sole GPU abstraction for all simulation
 - `crates/xagent-brain/src/buffers.rs` — GPU buffer layout constants, sensory packing, AgentBrainState, AgentTelemetry
 - `crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl` — fused per-agent kernel (physics + food detect + death/respawn + brain, looped over vision_stride cycles)
+- `crates/xagent-brain/src/shaders/kernel/brain_passes.wgsl` — the 7 cooperative brain passes; credit assignment is a TD(λ) actor-critic (value head + eligibility traces in `brain_state`), no history ring
 - `crates/xagent-brain/src/shaders/kernel/global_tick.wgsl` — grid rebuild + collision pass (dispatched as (1,1,1))
 
 ## egui Gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ All rules in [CONTRIBUTING.md](CONTRIBUTING.md) must be strictly followed. That 
 
 ## Build & Test
 - `cargo check -p xagent-sandbox` — quick compile check for the sandbox crate
-- `cargo test -p xagent-sandbox` — runs 58 lib unit + 3 bin unit + 34 integration tests (95 total)
+- `cargo test -p xagent-sandbox` — runs 75 lib unit + 3 bin unit + 47 integration tests (125 total)
 
 ## Architecture
 - `crates/xagent-sandbox/src/governor.rs` — evolution state machine, SQLite persistence

--- a/crates/xagent-brain/README.md
+++ b/crates/xagent-brain/README.md
@@ -91,7 +91,7 @@ There is no separate reward signal. There is no loss function designed by a huma
 
 The brain has no concept of "good" or "bad" built in. Instead, `habituate_homeo.wgsl` tracks whether internal variables (energy, physical integrity) are trending toward or away from stability. This gradient -- positive means improving, negative means worsening -- modulates:
 
-- **Credit assignment**: the `predict_and_act.wgsl` pass uses the homeostatic gradient to assign credit/blame to recent actions in the 64-tick history ring
+- **Credit assignment**: the homeostatic gradient is the reward in a TD(λ) actor-critic — a value head learns the discounted return, and its TD error credits recent actions through per-dimension eligibility traces
 - **Urgency**: when energy or integrity drops critically low, urgency suppresses exploration in favor of exploitation
 
 This is analogous to how biological organisms don't have explicit goals -- they have homeostatic set points, and deviations from those set points drive behavior.
@@ -196,9 +196,8 @@ xagent-brain/src/shaders/kernel/   -- All shader fragments live here.
                               └───────────────────────────┘
 
   Persistent GPU buffers (live across ticks; sizes shown for default 8×6 vision, `ENCODED_DIMENSION = 128`):
-  ─── brain_state_buf ────  `BrainLayout::brain_stride` (51,381 f32/agent)  (encoder weights, predictor, habituation, homeo, action, fatigue)
+  ─── brain_state_buf ────  `BrainLayout::brain_stride` (51,898 f32/agent)  (encoder weights, predictor, habituation, homeo, action, fatigue, TD value head + traces)
   ─── pattern_buf ────────  `PATTERN_STRIDE` (17,539 f32/agent)            (128 patterns: states, norms, reinforcement, motor, meta, active)
-  ─── history_buf ────────  `HISTORY_STRIDE` (8,514 f32/agent)             (64-entry action history ring: motor+state snapshots)
   ─── physics_state_buf ──     per-agent     (position, velocity, vitals, motor telemetry echoes)
   ─── food_state_buf ─────     per-food      (position, consumed flag, respawn timer)
   ─── sensory_buf ────────     per-agent     (raw vision + non-visual features written by vision pass)
@@ -245,7 +244,7 @@ A `dispatch_batch(start_tick, ticks_to_run)` call splits the work into one or mo
 | GPU → CPU | When `try_collect_state` is called | Position, vitals, motor cache, exploration/fatigue, death counts |
 | GPU → CPU | When `try_collect_telemetry` is called | One agent's vision + decision snapshot (selected agent only) |
 | GPU → CPU | When `try_collect_agent_state` is called | One agent's full `AgentBrainState` (for inheritance, debugging) |
-| GPU only | Per-tick simulation | Brain state, pattern memory, action history, physics state, food state, **sensory features** (written by the vision pass into `sensory_buf`) |
+| GPU only | Per-tick simulation | Brain state, pattern memory, physics state, food state, **sensory features** (written by the vision pass into `sensory_buf`) |
 
 The asymmetry is intentional. Sensory frames are not packed and uploaded per tick: the vision pass raycasts on the GPU from terrain/biome/food/agent buffers and writes the feature layout directly into `sensory_buf`. The brain stage in the next kernel-batch reads its inputs from that same `sensory_buf` — a one-batch sensory lag that amortizes the cost of vision + grid rebuild over `vision_stride` brain cycles.
 
@@ -257,13 +256,13 @@ The asymmetry is intentional. Sensory frames are not packed and uploaded per tic
 
 ### Buffer Allocation
 
-All buffers are created at `GpuKernel::new` with sizes proportional to `agent_count` and the vision dimensions encoded in `BrainLayout`. Persistent storage buffers (`brain_state`, `pattern_buffer`, `history_buffer`, `physics_state`, `food_state`, sensory) use `STORAGE | COPY_SRC | COPY_DST`, and transient working buffers use `STORAGE` only; the double-buffered world-config and the heritable brain-config are uniform buffers (`UNIFORM | COPY_DST`). Staging buffers for readback use `MAP_READ | COPY_DST` and are sized for the worst-case message (full state for `state_readback`, one agent's slice for the others).
+All buffers are created at `GpuKernel::new` with sizes proportional to `agent_count` and the vision dimensions encoded in `BrainLayout`. Persistent storage buffers (`brain_state`, `pattern_buffer`, `physics_state`, `food_state`, sensory) use `STORAGE | COPY_SRC | COPY_DST`, and transient working buffers use `STORAGE` only; the double-buffered world-config and the heritable brain-config are uniform buffers (`UNIFORM | COPY_DST`). Staging buffers for readback use `MAP_READ | COPY_DST` and are sized for the worst-case message (full state for `state_readback`, one agent's slice for the others).
 
 ---
 
 ## 5. Buffer Layout
 
-Buffer offsets, strides, and dimension constants live in two coordinated source-of-truth slots: the Rust side in `crates/xagent-brain/src/buffers.rs` (`BrainLayout`, `PHYS_STRIDE`, `PATTERN_STRIDE`, `HISTORY_STRIDE`, the `O_*` offset constants, `ENCODED_DIMENSION`, `MEMORY_CAP`, …), and the WGSL side in `crates/xagent-brain/src/shaders/kernel/common.wgsl` as `override` constants (`override VISION_W: u32 = 8u; override SENSORY_STRIDE: u32 = …; override O_ENC_BIASES: u32 = FEATURE_COUNT * ENCODED_DIMENSION; …`). At pipeline creation time `gpu_kernel.rs` concatenates `common.wgsl` with the relevant phase fragments via `include_str!` and sets the matching `override` values on the `ComputePipelineDescriptor`, so the WGSL constants resolve to whatever the live `BrainLayout` produced from the configured vision dimensions.
+Buffer offsets, strides, and dimension constants live in two coordinated source-of-truth slots: the Rust side in `crates/xagent-brain/src/buffers.rs` (`BrainLayout`, `PHYS_STRIDE`, `PATTERN_STRIDE`, the `O_*` offset constants, `ENCODED_DIMENSION`, `MEMORY_CAP`, …), and the WGSL side in `crates/xagent-brain/src/shaders/kernel/common.wgsl` as `override` constants (`override VISION_W: u32 = 8u; override SENSORY_STRIDE: u32 = …; override O_ENC_BIASES: u32 = FEATURE_COUNT * ENCODED_DIMENSION; …`). At pipeline creation time `gpu_kernel.rs` concatenates `common.wgsl` with the relevant phase fragments via `include_str!` and sets the matching `override` values on the `ComputePipelineDescriptor`, so the WGSL constants resolve to whatever the live `BrainLayout` produced from the configured vision dimensions.
 
 ### Core Dimensions
 
@@ -273,10 +272,10 @@ Buffer offsets, strides, and dimension constants live in two coordinated source-
 | `BrainLayout::feature_count` | 265 = `VISION_RAYS * 5 + 25` | Feature vector size (192 RGBA + 48 depth + 25 derived non-visual; scales with `VISION_W`/`VISION_H`) |
 | `MEMORY_CAP` | 128 | Maximum patterns per agent |
 | `RECALL_K` | 16 | Top-K recalled patterns per tick |
-| `ACTION_HISTORY_LEN` | 64 | Credit-assignment lookback window |
 | `ERROR_HISTORY_LEN` | 128 | Prediction-error ring-buffer size |
+| `TD_DISCOUNT` / `TD_LAMBDA` | 0.97 / 0.9 | TD(λ) credit horizon and trace decay |
 
-The feature/encoded sizes and `BrainLayout::brain_stride` scale with the configured vision dimensions (via `feature_count`). `PATTERN_STRIDE` and `HISTORY_STRIDE` do **not** — they are fixed `pub const`s derived from `MEMORY_CAP`, `ACTION_HISTORY_LEN`, and `ENCODED_DIMENSION`. `BrainLayout::new(vision_width, vision_height)` is the single source of truth for the vision-dependent values — see `crates/xagent-brain/src/buffers.rs`. For the default 8×6 layout (`ENCODED_DIMENSION = 128`, `feature_count = 265`): `brain_stride = 51,381` f32, with the fixed `PATTERN_STRIDE = 17,539` f32 and `HISTORY_STRIDE = 8,514` f32. The matching `O_*` offsets and per-region sizes are surfaced to WGSL via the `override` constants in `common.wgsl`, with the values supplied at pipeline creation by `gpu_kernel.rs`.
+The feature/encoded sizes and `BrainLayout::brain_stride` scale with the configured vision dimensions (via `feature_count`). `PATTERN_STRIDE` does **not** — it is a fixed `pub const` derived from `MEMORY_CAP` and `ENCODED_DIMENSION`. `BrainLayout::new(vision_width, vision_height)` is the single source of truth for the vision-dependent values — see `crates/xagent-brain/src/buffers.rs`. For the default 8×6 layout (`ENCODED_DIMENSION = 128`, `feature_count = 265`): `brain_stride = 51,898` f32, with the fixed `PATTERN_STRIDE = 17,539` f32. The matching `O_*` offsets and per-region sizes are surfaced to WGSL via the `override` constants in `common.wgsl`, with the values supplied at pipeline creation by `gpu_kernel.rs`.
 
 ### Sensory Buffer Layout (GPU-produced)
 
@@ -288,22 +287,18 @@ The feature/encoded sizes and `BrainLayout::brain_stride` scale with the configu
 
 Total for the default 8×6 vision: `SENSORY_STRIDE = 267` f32 per agent. In the live `GpuKernel` runtime this layout is written directly into `sensory_buffer` by the vision pass — RGBA + depth come from `phase_vision_raycast`, and the non-visual tail (velocity, facing, angular velocity, normalized energy/integrity, energy/integrity deltas, and up to `MAX_TOUCH_CONTACTS` × 4-channel touch contacts) is written by `phase_vision_senses`. Touch contacts are filled in 3×3-cell discovery order, food cells before agent cells, and stop at `MAX_TOUCH_CONTACTS`; unused slots stay zeroed. The CPU-side `buffers::pack_sensory_frame()` mirrors this layout but is only used by `buffers` tests — it is not in the per-tick data path.
 
-### Brain State Buffer (per agent: `BrainLayout::brain_stride`, 51,381 f32 for the default 8×6 layout)
+### Brain State Buffer (per agent: `BrainLayout::brain_stride`, 51,898 f32 for the default 8×6 layout)
 
 Regions (in offset order; concrete offsets are dimension-dependent and emitted by `BrainLayout` — see `crates/xagent-brain/src/buffers.rs`):
 
 - `O_ENCODER_WEIGHTS` — `feature_count * ENCODED_DIMENSION` (= 33,920 for 8×6) encoder weight matrix.
 - `O_ENCODER_BIASES` — `ENCODED_DIMENSION` (128) per-dimension bias.
 - `O_PREDICTOR_WEIGHTS` — `PREDICTOR_DIMENSION * ENCODED_DIMENSION` predictor matrix (operates in encoded space).
-- `O_PREDICTOR_CONTEXT_WEIGHT` and the rest of the fixed-size tail (`FIXED_TAIL_SIZE`): predictor error ring, habituation EMA + attenuation, previous-encoded snapshot, homeostasis state, action/turn policy weights + biases, exploration rate, motor-fatigue ring + cursor + factor + length, previous prediction, tick counter, heritable config, and per-agent `movement_speed`.
+- `O_PREDICTOR_CONTEXT_WEIGHT` and the rest of the fixed-size tail (`FIXED_TAIL_SIZE`): predictor error ring, habituation EMA + attenuation, previous-encoded snapshot, homeostasis state, action/turn policy weights + biases, exploration rate, motor-fatigue ring + cursor + factor + length, previous prediction, tick counter, heritable config, per-agent `movement_speed`, and the TD critic state — value weights (`O_VALUE_WEIGHTS`, `ENCODED_DIMENSION`) + bias + previous value, the three eligibility-trace vectors (`O_TRACE_CRITIC` / `O_TRACE_FWD` / `O_TRACE_TURN`, `ENCODED_DIMENSION` each), and the three scalar trace biases (`O_TRACE_BIASES`).
 
 ### Pattern Memory Buffer (per agent: `PATTERN_STRIDE` = 17,539 f32, a fixed constant)
 
 Stores `MEMORY_CAP` (= 128) patterns. Regions: `O_PAT_STATES` (`MEMORY_CAP * ENCODED_DIMENSION` encoded-space states), `O_PAT_NORMS` (cached L2 norms), `O_PAT_REINF` (per-pattern reinforcement that decays over time), `O_PAT_MOTOR` (`[forward, turn, outcome_valence] * MEMORY_CAP`), `O_PAT_META` (`[created_at, last_accessed, activation_count] * MEMORY_CAP`), `O_PAT_ACTIVE` (active flag — recall is gated here, not on `O_PAT_REINF`), and `O_ACTIVE_COUNT` bookkeeping. The `O_PAT_*` offsets are fixed constants (derived from `MEMORY_CAP` and `ENCODED_DIMENSION`, independent of vision dimensions); see `crates/xagent-brain/src/buffers.rs`.
-
-### Action History Buffer (per agent: `HISTORY_STRIDE` = 8,514 f32, a fixed constant)
-
-A 64-entry ring of motor commands plus per-entry encoded-state snapshots. Regions: `O_MOTOR_RING` (`[forward, turn, tick, gradient, _pad] * ACTION_HISTORY_LEN`), `O_STATE_RING` (`[encoded_state(ENCODED_DIMENSION)] * ACTION_HISTORY_LEN` snapshots — `ENCODED_DIMENSION * ACTION_HISTORY_LEN` f32 in total), and `O_HIST_CURSOR` bookkeeping. The `O_HIST_*` offsets are fixed constants (derived from `ACTION_HISTORY_LEN` and `ENCODED_DIMENSION`, independent of vision dimensions); see `crates/xagent-brain/src/buffers.rs`.
 
 ### Integer Storage Convention
 
@@ -468,16 +463,30 @@ Predicts the next encoded state from the current habituated state and recalled c
 
 The `context_weight` parameter (stored at `O_PRED_CTX_WT`, initialized to 0.15) controls how much recalled patterns influence the prediction. It is itself adapted in pass 7.
 
-#### 6.6.3 Credit Assignment
+#### 6.6.3 Credit Assignment — TD(λ) actor-critic
 
-The homeostatic gradient is used to assign credit/blame to recent actions in the 64-entry history ring buffer. For each recorded action:
+A linear value head over the encoded state estimates the discounted
+homeostatic return; its TD error is the single credit signal for the
+critic, both policy channels, and the encoder. Per brain tick:
 
-1. **Temporal decay**: `temporal = exp(-age * CREDIT_DECAY)` where `CREDIT_DECAY = 0.3`. The loop skips entries with `temporal < 0.01`, so actions older than ~15 ticks contribute negligibly.
-2. **Improvement signal**: `improvement = current_gradient - recorded_gradient`. If `|improvement| < DEADZONE (0.005)`, the improvement is replaced by a tonic fallback `gradient * urgency * TONIC_CREDIT_SCALE (0.5)` instead of being skipped.
-3. **Pain amplification**: Negative improvements are multiplied by `PAIN_AMP = 3.0`, reflecting the biological reality that aversive stimuli produce stronger learning signals.
-4. **State-conditioned weight update**: `weights[d] += WEIGHT_LR * credit * recorded_motor * recorded_state[d]`. The recorded state snapshot from when the action was taken ensures credit is attributed to the correct sensory context.
+1. **Value estimate**: `v = dot(value_weights, encoded) + value_bias` (threads compute partial products in parallel; thread 0 reduces).
+2. **TD error**: `δ = clamp(reward + TD_DISCOUNT·v − prev_value, ±MAX_TD_ERROR)` where `reward` is the urgency-amplified homeostatic delta since the previous brain tick and `TD_DISCOUNT = 0.97` gives a ~33-brain-tick horizon (the travel time from the edge of vision range at default speed).
+3. **Weight updates through eligibility traces**: `w += lr · TD_VECTOR_SCALE · δ · z` for the critic (`CRITIC_LEARNING_RATE = 0.01`) and both actor channels (`ACTION_WEIGHT_LEARNING_RATE = 0.10`). `TD_VECTOR_SCALE = 1/ENCODED_DIMENSION` keeps the aggregate step inside the linear-TD stability limit regardless of dimensionality. Scalar biases update from scalar traces without the vector scale.
+4. **Trace update** (end of the pass, after the motor block produces this tick's exploration noise): `z ← TD_DISCOUNT·TD_LAMBDA·z + term`, where the critic trace accumulates `encoded[d]` and the actor traces accumulate `noise·encoded[d]` — the likelihood-ratio direction of the action actually taken. `TD_LAMBDA = 0.9`.
 
-**Weight normalization**: After credit assignment, forward and turn weight vectors are clipped to L2 norm <= `MAX_WEIGHT_NORM = 2.0` (synaptic homeostasis).
+There is no deadzone, no tonic fallback, no pain amplifier, and no history
+ring: credit reaches past actions through the traces, and the critic's
+bootstrapping propagates reward backwards across repeated experiences
+beyond the raw trace span. Traces and `prev_value` are episodic — zeroed on
+death — while the value weights are learned knowledge and survive respawn
+and inheritance.
+
+**Weight normalization**: forward, turn, and value weight vectors are
+clipped to L2 norm <= `MAX_WEIGHT_NORM = 2.0` (synaptic homeostasis). There
+is no per-tick weight decay: TD updates are surprise-driven and stop when
+δ calibrates to zero, so decay would only erase accumulated policy
+knowledge (including the initial forward bias that provides exploration
+mobility).
 
 #### 6.6.4 Policy Evaluation
 
@@ -538,11 +547,10 @@ When motor output is varied, fatigue factor is near 1.0 (no dampening). When out
 #### 6.6.8 Output Recording
 
 After computing final motor output:
-1. Records `[noise_fwd * exploration_rate, noise_trn * exploration_rate, tick, gradient, 0.0]` to the action history ring at `O_MOTOR_RING`. Storing the exploration noise (not the full motor) is what makes credit assignment a proper REINFORCE gradient -- see PR #97.
-2. Records the encoded (pre-habituation) state snapshot at `O_STATE_RING` for future credit assignment -- matches the features the policy and credit updates train against.
-3. Saves the prediction to `O_PREV_PREDICTION` for next tick's error computation.
-4. Increments `O_TICK_COUNT`.
-5. Writes `[prediction(32), credit_signal(32), fwd, trn, strafe, _pad]` to the decision buffer for pass 7 and CPU readback.
+1. Publishes `[noise_fwd * exploration_rate, noise_trn * exploration_rate]` to shared memory for the parallel eligibility-trace update at the end of the pass. The traces carry the exploration noise (not the full motor) so only noise directions that correlate with TD errors get reinforced.
+2. Saves the prediction to `O_PREV_PREDICTION` for next tick's error computation.
+3. Increments `O_TICK_COUNT`.
+4. Writes `[prediction(ENCODED_DIMENSION), credit_signal(ENCODED_DIMENSION), fwd, trn, strafe, td_error]` to the decision buffer for pass 7 and CPU readback.
 
 ---
 
@@ -568,15 +576,18 @@ The context weight is also adapted: `ctx_wt += learning_rate * 0.01 * (error_mag
 
 #### 6.7.2 Encoder Hebbian Credit Adaptation
 
-The encoder weights are adapted based on the credit signal from pass 6:
+The encoder weights are adapted based on the credit signal from pass 6
+(`credit_signal[i] = td_error * (forward_trace[i] + turn_trace[i])` — which
+encoded dimensions carried the policy's eligibility when the outcome
+arrived):
 
 ```
 for each (i, j) where |credit_signal[i]| > 1e-6:
-    weights[j * DIM + i] += learning_rate * credit_signal[i] * 0.001 * features[j]
+    weights[j * DIM + i] += learning_rate * credit_signal[i] * ENCODER_CREDIT_SCALE * features[j]
     weights[j * DIM + i] = clamp(weights, -2.0, 2.0)
 ```
 
-This is a Hebbian-style update: features that co-occur with strong credit signals have their encoder weights strengthened. The 0.001 scale factor makes encoder adaptation much slower than predictor learning, reflecting the intuition that the perceptual representation should change gradually while the prediction model adapts quickly.
+This is a Hebbian-style update: features that co-occur with strong credit signals have their encoder weights strengthened. The `ENCODER_CREDIT_SCALE = 0.1` factor makes encoder adaptation slower than action learning, reflecting the intuition that the perceptual representation should change gradually while the policy adapts quickly.
 
 #### 6.7.3 Memory Reinforcement
 
@@ -638,7 +649,7 @@ None of these behaviors are explicitly programmed. They arise from the interacti
 ```rust
 pub struct GpuKernel {
     // wgpu device + queue
-    // Persistent buffers: brain_state, pattern_buffer, history_buffer,
+    // Persistent buffers: brain_state, pattern_buffer,
     //                     physics_state, food_state, world_config,
     //                     sensory + working buffers
     // Compute pipelines: physics, vision, brain, kernel, global, prepare
@@ -684,11 +695,10 @@ The method list below is the contract used by `xagent-sandbox`. See `gpu_kernel.
 pub struct AgentBrainState {
     pub brain_state: Vec<f32>,    // BRAIN_STRIDE, vision-dependent
     pub patterns: Vec<f32>,       // PATTERN_STRIDE
-    pub history: Vec<f32>,        // HISTORY_STRIDE
 }
 ```
 
-Used for cross-generation inheritance (the governor reads parent state, mutates it, writes to offspring), mutation, and DB persistence. The three vectors are the exact GPU buffer contents for one agent slice. Only the `brain_state` slice length is vision-dependent (`BrainLayout::brain_stride`, via `feature_count`); the `patterns` and `history` slices use the fixed `PATTERN_STRIDE` and `HISTORY_STRIDE` constants. The legacy `8,468 / 5,251 / 2,370` figures from the pre-fused era are no longer accurate (current 8×6 values: `51,381 / 17,539 / 8,514`).
+Used for cross-generation inheritance (the governor reads parent state, mutates it, writes to offspring) and mutation. The two vectors are the exact GPU buffer contents for one agent slice. Only the `brain_state` slice length is vision-dependent (`BrainLayout::brain_stride`, via `feature_count`); the `patterns` slice uses the fixed `PATTERN_STRIDE` constant. The learned policy and the TD value head live in `brain_state` and so are inherited; the episodic eligibility traces also live there but are zeroed on the first post-respawn tick of a new life.
 
 ### Death / Respawn on the GPU
 
@@ -697,7 +707,7 @@ Death detection and respawn live entirely in WGSL (`phase_death.wgsl`, invoked f
 1. **Spawn search**: tries up to 50 GPU-RNG samples for a non-Danger biome position; if all 50 attempts land in Danger biomes, the `!found` branch reuses the attempt-0 sample (RNG seed `tick * 256 + agent_id`, the same draw as attempt 0) and spawns there without re-checking the biome — so a fully Danger-blocked agent can land back in a Danger cell (see `phase_death.wgsl` / `kernel_tick.wgsl::agent_death_respawn`).
 2. **Physics reset**: full energy, full integrity, zero velocity, facing +Z; death count incremented; fitness counters (`food_count`, `ticks_alive`, `last_death_tick`) preserved.
 3. **Memory trauma**: all `O_PAT_REINF` entries are multiplied by `0.5`. The death pass leaves `O_PAT_ACTIVE` untouched, so recall (which gates on `O_PAT_ACTIVE` in `brain_passes.wgsl`, not on reinforcement) is not cut off by this step. Halved reinforcement only makes subsequent decay reach the `<= 0.0` deactivation point sooner for the weakest patterns; the strongest memories survive.
-4. **Brain reset**: homeostasis EMAs zeroed, exploration rate set to `0.5`, habituation EMAs zeroed and attenuation reset to `1.0`, fatigue factor reset to `1.0`, position-ring staleness state cleared, action history zeroed.
+4. **Brain reset**: homeostasis EMAs zeroed, exploration rate set to `0.5`, habituation EMAs zeroed and attenuation reset to `1.0`, fatigue factor reset to `1.0`, position-ring staleness state cleared, TD eligibility traces and previous-state value zeroed (the value weights survive — they are learned knowledge, not episodic state).
 
 The CPU only learns about a death by reading `physics_state[base + P_DEATH_COUNT]` on the next state readback.
 
@@ -835,19 +845,15 @@ Biological nervous systems track changes at multiple timescales -- immediate ref
 
 ### Why Continuous Motor Output Instead of Discrete Actions
 
-The old CPU architecture used a discrete 8-action space with a learned preference table. The GPU rewrite replaces this with continuous forward/turn output computed as `dot(weights, habituated) + bias`. This is both simpler (no action table, no softmax, no argmax tie-breaking) and more expressive (the agent can move at any speed and turn at any angle). Credit assignment updates the weight vectors directly via state-conditioned gradient, which is more natural for continuous outputs.
+The old CPU architecture used a discrete 8-action space with a learned preference table. The GPU rewrite replaces this with continuous forward/turn output computed as `dot(weights, encoded) + bias`. This is both simpler (no action table, no softmax, no argmax tie-breaking) and more expressive (the agent can move at any speed and turn at any angle). Credit assignment updates the weight vectors directly through eligibility traces, which is natural for continuous outputs.
 
-### Why Credit Deadzone Filters Metabolic Noise
+### Why TD(λ) Instead of Windowed REINFORCE
 
-Every tick, energy depletion produces a small negative homeostatic gradient (~0.006). Without a deadzone, this constant signal triggers credit assignment on every tick, treating normal metabolism as a negative outcome. The `DEADZONE = 0.01` threshold ensures only meaningful events -- food consumption (+0.03), damage (-0.02), death (-0.5) -- produce weight updates. This is analogous to sensory gating in biological systems, where constant background stimuli are filtered out to preserve signal clarity.
+The earlier learner credited a fixed window of recorded actions with the *change* in homeostatic gradient since each action, gated by a deadzone and a tonic fallback. Food, however, is a sparse reward that arrives ~30 brain ticks after the navigational turn that earned it — far outside any practical exponential-decay window — so the decisive turn was never credited (the core finding of issue #13). TD(λ) closes that gap two ways: a learned value head bootstraps, propagating the terminal food reward backwards across repeated experiences, and eligibility traces give every state-action a decaying claim on future TD errors. The deadzone, tonic fallback, and pain amplifier are gone — δ is a single signed signal that calibrates to zero when the critic is accurate, so steady metabolic drain stops producing spurious updates without any thresholding.
 
-### Why State-Conditioned Credit Assignment
+### Why No Per-Tick Weight Decay
 
-Naive credit assignment applies the same credit to all recent actions regardless of the state in which they were taken. This means dying in a danger zone penalizes actions taken in safe states equally -- the agent learns "forward is bad everywhere" instead of "forward-in-danger is bad." State-conditioned credit uses the recorded state snapshot from when each action was chosen, so the weight update is proportional to `recorded_state[d]`. High feature activation at action time --> full credit. Low activation --> minimal credit.
-
-### Why Pain Amplification (3x)
-
-Negative homeostatic gradients receive a 3x multiplier in credit assignment. This reflects the biological reality that amygdala neurons respond 2-3x more strongly to aversive stimuli. This is NOT hardcoded avoidance -- the brain must learn WHAT to do about the amplified signal. The amplification just ensures that negative outcomes produce louder learning signals than positive ones, which is necessary because damage is typically more catastrophic than the benefit of a single meal.
+TD updates are surprise-driven: they vanish when δ calibrates to zero, so weights settle rather than diverge, and the L2-ball clamps bound magnitude. Per-tick decay would instead bleed away accumulated policy knowledge every tick — including the initial forward bias that gives agents the mobility to explore — so it is omitted. The value head likewise keeps its learned landscape across the lifetime; only the episodic eligibility traces and previous-value scalar reset on death.
 
 ### Why Encoder Adaptation is Hebbian, Not Backpropagated
 

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -1,9 +1,9 @@
 //! GPU buffer layout constants, AgentBrainState, and packing utilities.
 //!
-//! All persistent brain state is stored in three flat f32 arrays on GPU:
-//! - brain_state_buf: encoder weights, predictor, habituation, homeostasis, action, staleness
+//! All persistent brain state is stored in two flat f32 arrays on GPU:
+//! - brain_state_buf: encoder weights, predictor, habituation, homeostasis,
+//!   action, staleness, TD value head + eligibility traces
 //! - pattern_buf: pattern memory (states, norms, reinforcement, motor, meta, active)
-//! - history_buf: action history ring buffer
 //!
 //! Integer values (cursors, counts, ticks) are stored as f32 and cast
 //! via bitcast in WGSL. Safe for exact integers up to 2^24 = 16,777,216.
@@ -29,7 +29,6 @@ pub const PREDICTOR_DIMENSION: usize = ENCODED_DIMENSION;
 const FEATURE_COUNT: usize = 8 * 6 * 4 + 8 * 6 + 25;
 pub const MEMORY_CAP: usize = 128;
 pub const RECALL_K: usize = 16;
-pub const ACTION_HISTORY_LEN: usize = 64;
 pub const INITIAL_FORWARD_BIAS: f32 = 0.3;
 pub const ERROR_HISTORY_LEN: usize = 128;
 pub const MAX_TOUCH_CONTACTS: usize = 4;
@@ -80,7 +79,20 @@ pub const O_HAB_SENSITIVITY: usize = O_TICK_COUNT + 1;
 pub const O_HAB_MAX_CURIOSITY: usize = O_HAB_SENSITIVITY + 1;
 pub const O_FATIGUE_FLOOR: usize = O_HAB_MAX_CURIOSITY + 1;
 pub const O_MOVEMENT_SPEED: usize = O_FATIGUE_FLOOR + 1;
-pub const BRAIN_STRIDE: usize = O_MOVEMENT_SPEED + 1;
+
+// ── TD(λ) critic state ────────────────────────────────────────────────
+// Value head (learned, inherited) plus eligibility traces (episodic,
+// zeroed on death). Trace biases pack three scalars:
+// [critic_bias, forward_bias, turn_bias].
+
+pub const O_VALUE_WEIGHTS: usize = O_MOVEMENT_SPEED + 1;
+pub const O_VALUE_BIAS: usize = O_VALUE_WEIGHTS + ENCODED_DIMENSION;
+pub const O_PREV_VALUE: usize = O_VALUE_BIAS + 1;
+pub const O_TRACE_CRITIC: usize = O_PREV_VALUE + 1;
+pub const O_TRACE_FWD: usize = O_TRACE_CRITIC + ENCODED_DIMENSION;
+pub const O_TRACE_TURN: usize = O_TRACE_FWD + ENCODED_DIMENSION;
+pub const O_TRACE_BIASES: usize = O_TRACE_TURN + ENCODED_DIMENSION;
+pub const BRAIN_STRIDE: usize = O_TRACE_BIASES + 3;
 
 /// Number of elements in `brain_state` from `O_PREDICTOR_CONTEXT_WEIGHT` (inclusive)
 /// to `BRAIN_STRIDE` (exclusive). This tail is layout-independent: it
@@ -101,15 +113,6 @@ pub const O_ACTIVE_COUNT: usize = O_PAT_ACTIVE + MEMORY_CAP;
 pub const O_MIN_REINF_IDX: usize = O_ACTIVE_COUNT + 1;
 pub const O_LAST_STORED_IDX: usize = O_MIN_REINF_IDX + 1;
 pub const PATTERN_STRIDE: usize = O_LAST_STORED_IDX + 1;
-
-// ── Action history buffer offsets (per agent) ─────────────────────────
-
-pub const O_MOTOR_RING: usize = 0;
-// motor_ring: [forward, turn, tick, gradient, _pad] × ACTION_HISTORY_LEN
-pub const O_STATE_RING: usize = O_MOTOR_RING + ACTION_HISTORY_LEN * 5;
-pub const O_HIST_CURSOR: usize = O_STATE_RING + ACTION_HISTORY_LEN * ENCODED_DIMENSION;
-pub const O_HIST_LEN: usize = O_HIST_CURSOR + 1;
-pub const HISTORY_STRIDE: usize = O_HIST_LEN + 1;
 
 // ── Agent physics buffer layout (per agent, GPU-resident) ─────────────
 
@@ -188,7 +191,8 @@ impl BrainLayout {
             .and_then(|v| v.checked_add(NON_VISUAL_COUNT))
             .expect("vision dimensions overflow sensory stride");
         // brain_stride = feature_count * ENCODED_DIMENSION + ENCODED_DIMENSION + ENCODED_DIMENSION*ENCODED_DIMENSION + FIXED_TAIL_SIZE
-        // (FIXED_TAIL_SIZE = fixed fields starting at O_PREDICTOR_CONTEXT_WEIGHT through O_MOVEMENT_SPEED, incl. position ring)
+        // (FIXED_TAIL_SIZE = fixed fields starting at O_PREDICTOR_CONTEXT_WEIGHT
+        // through the TD critic state, incl. position ring and traces)
         let brain_stride = feature_count
             .checked_mul(ENCODED_DIMENSION)
             .and_then(|v| v.checked_add(ENCODED_DIMENSION))
@@ -290,13 +294,12 @@ pub const CONFIG_SIZE: usize = 12; // padded to 12 for uniform vec4 alignment (3
 
 // ── AgentBrainState (CPU-side snapshot for evolution) ──────────────────
 
-/// Serializable snapshot of one agent's full brain state.
-/// Used for cross-generation inheritance, mutation, and DB persistence.
+/// CPU-side snapshot of one agent's full brain state.
+/// Used for cross-generation inheritance and mutation.
 #[derive(Clone, Debug)]
 pub struct AgentBrainState {
     pub brain_state: Vec<f32>, // BRAIN_STRIDE f32s
     pub patterns: Vec<f32>,    // PATTERN_STRIDE f32s
-    pub history: Vec<f32>,     // HISTORY_STRIDE f32s
 }
 
 impl AgentBrainState {
@@ -308,7 +311,6 @@ impl AgentBrainState {
         Self {
             brain_state: vec![0.0; brain_stride],
             patterns: vec![0.0; PATTERN_STRIDE],
-            history: vec![0.0; HISTORY_STRIDE],
         }
     }
 }
@@ -519,11 +521,6 @@ pub fn init_pattern_memory() -> Vec<f32> {
     vec![0.0_f32; PATTERN_STRIDE]
 }
 
-/// Initialize action history buffer for one agent: empty ring.
-pub fn init_action_history() -> Vec<f32> {
-    vec![0.0_f32; HISTORY_STRIDE]
-}
-
 /// Build config buffer values from BrainConfig.
 /// Layout is derived from config's `vision_width`/`vision_height`.
 pub fn build_config(config: &BrainConfig) -> Vec<f32> {
@@ -583,17 +580,16 @@ mod tests {
 
     #[test]
     fn brain_stride_is_consistent() {
-        assert_eq!(BRAIN_STRIDE, O_MOVEMENT_SPEED + 1);
+        // The TD critic state is the last region of the brain layout:
+        // value head, prev value, three trace vectors, three trace biases.
+        assert_eq!(O_VALUE_WEIGHTS, O_MOVEMENT_SPEED + 1);
+        assert_eq!(O_TRACE_BIASES, O_VALUE_WEIGHTS + 4 * ENCODED_DIMENSION + 2);
+        assert_eq!(BRAIN_STRIDE, O_TRACE_BIASES + 3);
     }
 
     #[test]
     fn pattern_stride_is_consistent() {
         assert_eq!(PATTERN_STRIDE, O_LAST_STORED_IDX + 1);
-    }
-
-    #[test]
-    fn history_stride_is_consistent() {
-        assert_eq!(HISTORY_STRIDE, O_HIST_LEN + 1);
     }
 
     #[test]
@@ -1030,16 +1026,19 @@ mod tests {
     }
 
     #[test]
-    fn shader_has_16_bindings() {
+    fn shader_has_15_bindings() {
         let src = include_str!("shaders/kernel/common.wgsl");
         let binding_count = src
             .lines()
             .filter(|l| l.trim().starts_with("@group(0) @binding("))
             .count();
+        // Bindings 0-12, 14, 15. Binding 13 (the old action-history buffer)
+        // was removed when TD(λ) replaced the history ring; the numbering is
+        // intentionally non-contiguous so the remaining bindings keep their
+        // slots and the bind-group layout in gpu_kernel.rs stays aligned.
         assert_eq!(
-            binding_count, 16,
-            "Expected 16 bindings (0-14 existing + 15 dispatch_args), found {}",
-            binding_count
+            binding_count, 15,
+            "Expected 15 bindings (0-12, 14 uniforms/storage + 15 dispatch_args), found {binding_count}"
         );
     }
 }

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -22,10 +22,12 @@ static REPR_DIM_MISMATCH_WARNED: AtomicBool = AtomicBool::new(false);
 
 pub const ENCODED_DIMENSION: usize = 128;
 pub const PREDICTOR_DIMENSION: usize = ENCODED_DIMENSION;
-/// Feature count for the default 8×6 vision layout.
-/// Used to compute default brain state offsets (`O_ENC_BIASES`),
-/// `FEATURES_STRIDE`, and `FIXED_TAIL_SIZE`.
-/// For other vision dimensions, use `BrainLayout::feature_count`.
+/// Feature count for the reference 8×6 vision layout that anchors the
+/// static `O_*` offset constants below. The runtime default layout is
+/// `BrainLayout::default()` (which follows `BrainConfig::default()`); use
+/// `BrainLayout::feature_count` for any live layout. The static constants
+/// remain valid as tail *deltas* (`O_X - O_PREDICTOR_CONTEXT_WEIGHT`) for
+/// every layout, because the tail is vision-independent.
 const FEATURE_COUNT: usize = 8 * 6 * 4 + 8 * 6 + 25;
 pub const MEMORY_CAP: usize = 128;
 pub const RECALL_K: usize = 16;
@@ -40,9 +42,9 @@ pub const TOUCH_FEATURES: usize = 4; // dir_x, dir_z, intensity, tag/4
 /// velocity(3) + facing(3) + angular_vel(1) + energy(1) + integrity(1) + e_delta(1) + i_delta(1) + touch(16)
 pub const NON_VISUAL_COUNT: usize = 3 + 3 + 1 + 1 + 1 + 1 + 1 + MAX_TOUCH_CONTACTS * TOUCH_FEATURES;
 
-// ── Brain state buffer offsets (default 8×6 layout) ──────────────────
-// These constants are valid for the default vision dimensions (8×6).
-// For other dimensions, use `BrainLayout` to compute dynamic offsets.
+// ── Brain state buffer offsets (reference 8×6 layout) ─────────────────
+// Absolute values are valid only for an 8×6 vision grid; for live layouts
+// use `BrainLayout` to compute dynamic offsets.
 // The *tail* offsets (from `O_PREDICTOR_CONTEXT_WEIGHT` onward) are vision-independent:
 // `O_FOO - O_PREDICTOR_CONTEXT_WEIGHT` is the same regardless of vision size.
 
@@ -212,8 +214,10 @@ impl BrainLayout {
 }
 
 impl Default for BrainLayout {
+    /// Follows `BrainConfig::default()` so the two defaults can never drift.
     fn default() -> Self {
-        Self::new(8, 6)
+        let config = BrainConfig::default();
+        Self::new(config.vision_width, config.vision_height)
     }
 }
 
@@ -571,11 +575,21 @@ mod tests {
     #[test]
     fn default_layout_sensory_and_feature_counts() {
         let layout = BrainLayout::default();
-        // Default 8x6: 192 color + 48 depth + 27 non-visual = 267 sensory
-        assert_eq!(layout.sensory_stride, 267);
+        // Default 17×13: 884 color + 221 depth + 27 non-visual = 1132 sensory
+        assert_eq!(layout.sensory_stride, 1132);
         // Feature count excludes 2 non-visual fields (energy_delta, integrity_delta)
-        assert_eq!(layout.feature_count, 265);
+        assert_eq!(layout.feature_count, 1130);
         assert!(layout.sensory_stride >= layout.feature_count);
+    }
+
+    #[test]
+    fn reference_8x6_layout_counts() {
+        let layout = BrainLayout::new(8, 6);
+        // 8×6: 192 color + 48 depth + 27 non-visual = 267 sensory
+        assert_eq!(layout.sensory_stride, 267);
+        assert_eq!(layout.feature_count, 265);
+        // The static offset constants anchor to this reference layout.
+        assert_eq!(layout.brain_stride, BRAIN_STRIDE);
     }
 
     #[test]
@@ -622,13 +636,14 @@ mod tests {
     #[test]
     fn brain_layout_default_values() {
         let layout = BrainLayout::default();
-        assert_eq!(layout.vision_width, 8);
-        assert_eq!(layout.vision_height, 6);
-        assert_eq!(layout.vision_color_count, 192);
-        assert_eq!(layout.vision_depth_count, 48);
-        assert_eq!(layout.sensory_stride, 267);
-        assert_eq!(layout.feature_count, 265);
-        assert_eq!(layout.brain_stride, BRAIN_STRIDE);
+        let config = xagent_shared::BrainConfig::default();
+        assert_eq!(layout.vision_width, config.vision_width);
+        assert_eq!(layout.vision_height, config.vision_height);
+        let pixels = (config.vision_width * config.vision_height) as usize;
+        assert_eq!(layout.vision_color_count, pixels * 4);
+        assert_eq!(layout.vision_depth_count, pixels);
+        assert_eq!(layout.sensory_stride, pixels * 5 + NON_VISUAL_COUNT);
+        assert_eq!(layout.feature_count, pixels * 5 + 25);
     }
 
     #[test]

--- a/crates/xagent-brain/src/buffers.rs
+++ b/crates/xagent-brain/src/buffers.rs
@@ -575,21 +575,22 @@ mod tests {
     #[test]
     fn default_layout_sensory_and_feature_counts() {
         let layout = BrainLayout::default();
-        // Default 17×13: 884 color + 221 depth + 27 non-visual = 1132 sensory
-        assert_eq!(layout.sensory_stride, 1132);
+        // Default 8×6: 192 color + 48 depth + 27 non-visual = 267 sensory
+        assert_eq!(layout.sensory_stride, 267);
         // Feature count excludes 2 non-visual fields (energy_delta, integrity_delta)
-        assert_eq!(layout.feature_count, 1130);
+        assert_eq!(layout.feature_count, 265);
         assert!(layout.sensory_stride >= layout.feature_count);
+        // The static offset constants anchor to the default layout.
+        assert_eq!(layout.brain_stride, BRAIN_STRIDE);
     }
 
     #[test]
-    fn reference_8x6_layout_counts() {
-        let layout = BrainLayout::new(8, 6);
-        // 8×6: 192 color + 48 depth + 27 non-visual = 267 sensory
-        assert_eq!(layout.sensory_stride, 267);
-        assert_eq!(layout.feature_count, 265);
-        // The static offset constants anchor to this reference layout.
-        assert_eq!(layout.brain_stride, BRAIN_STRIDE);
+    fn odd_grid_layout_counts() {
+        // 17×13 (the range-visibility grid): 884 color + 221 depth +
+        // 27 non-visual = 1132 sensory; feature_count drops the 2 deltas.
+        let layout = BrainLayout::new(17, 13);
+        assert_eq!(layout.sensory_stride, 1132);
+        assert_eq!(layout.feature_count, 1130);
     }
 
     #[test]

--- a/crates/xagent-brain/src/gpu_kernel.rs
+++ b/crates/xagent-brain/src/gpu_kernel.rs
@@ -202,17 +202,20 @@ pub struct AgentTelemetry {
     pub gradient: f32,
     pub prediction_error: f32,
     pub exploration_rate: f32,
+    /// Critic estimate of the discounted homeostatic return from the
+    /// agent's latest encoded state.
+    pub value: f32,
+    /// TD error of the latest transition — the unified credit signal.
+    pub td_error: f32,
 }
 
 /// In-flight async readback of a single agent's brain state.
 struct AgentStateReadback {
     brain_staging: wgpu::Buffer,
     pattern_staging: wgpu::Buffer,
-    history_staging: wgpu::Buffer,
     brain_size: u64,
     pattern_size: u64,
-    history_size: u64,
-    /// Shared completion/error state for all 3 `map_async` callbacks.
+    /// Shared completion/error state for both `map_async` callbacks.
     tracker: ReadbackTracker,
     brain_stride: usize,
 }
@@ -243,7 +246,6 @@ pub struct GpuKernel {
     sensory_buffer: wgpu::Buffer,
     brain_state_buffer: wgpu::Buffer,
     pattern_buffer: wgpu::Buffer,
-    history_buffer: wgpu::Buffer,
     brain_config_buffer: wgpu::Buffer,
 
     // ── Indirect dispatch ──
@@ -368,14 +370,12 @@ impl GpuKernel {
 
         let n = self.agent_count as usize;
 
-        // Fresh brain state, pattern memory, and action history.
+        // Fresh brain state and pattern memory.
         let mut brain_data = Vec::with_capacity(n * self.layout.brain_stride);
         let mut pattern_data = Vec::with_capacity(n * PATTERN_STRIDE);
-        let mut history_data = Vec::with_capacity(n * HISTORY_STRIDE);
         for _ in 0..n {
             brain_data.extend_from_slice(&init_brain_state_for(brain_config, &self.layout, rng));
             pattern_data.extend_from_slice(&init_pattern_memory());
-            history_data.extend_from_slice(&init_action_history());
         }
         self.queue.write_buffer(
             &self.brain_state_buffer,
@@ -384,8 +384,6 @@ impl GpuKernel {
         );
         self.queue
             .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
-        self.queue
-            .write_buffer(&self.history_buffer, 0, bytemuck::cast_slice(&history_data));
         self.queue.write_buffer(
             &self.brain_config_buffer,
             0,
@@ -597,12 +595,6 @@ impl GpuKernel {
             usage: storage_rw,
             mapped_at_creation: false,
         });
-        let history_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("kernel_history"),
-            size: (n * HISTORY_STRIDE * 4) as u64,
-            usage: storage_rw,
-            mapped_at_creation: false,
-        });
         let brain_config_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("kernel_brain_config"),
             size: (CONFIG_SIZE * 4) as u64,
@@ -663,15 +655,12 @@ impl GpuKernel {
         let mut rng = rand::rng();
         let mut brain_data = Vec::with_capacity(n * layout.brain_stride);
         let mut pattern_data = Vec::with_capacity(n * PATTERN_STRIDE);
-        let mut history_data = Vec::with_capacity(n * HISTORY_STRIDE);
         for _ in 0..n {
             brain_data.extend_from_slice(&init_brain_state_for(brain_config, &layout, &mut rng));
             pattern_data.extend_from_slice(&init_pattern_memory());
-            history_data.extend_from_slice(&init_action_history());
         }
         queue.write_buffer(&brain_state_buffer, 0, bytemuck::cast_slice(&brain_data));
         queue.write_buffer(&pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
-        queue.write_buffer(&history_buffer, 0, bytemuck::cast_slice(&history_data));
         queue.write_buffer(
             &brain_config_buffer,
             0,
@@ -747,7 +736,7 @@ impl GpuKernel {
             zero_initialize_workgroup_memory: true,
         };
 
-        // ── Explicit bind group layout (all 16 bindings) ──
+        // ── Explicit bind group layout (all 15 bindings) ──
         // Each pipeline entry point only references a subset of bindings, but we
         // need a single shared layout so one bind group works for all 3 pipelines.
         use wgpu::{BindGroupLayoutEntry, BindingType, BufferBindingType, ShaderStages};
@@ -803,7 +792,6 @@ impl GpuKernel {
                 storage_rw_entry(10), // sensory
                 storage_rw_entry(11), // brain_state
                 storage_rw_entry(12), // pattern
-                storage_rw_entry(13), // history
                 uniform_entry(14),    // brain_config
                 storage_rw_entry(15), // dispatch_args
             ],
@@ -983,10 +971,6 @@ impl GpuKernel {
                         resource: pattern_buffer.as_entire_binding(),
                     },
                     wgpu::BindGroupEntry {
-                        binding: 13,
-                        resource: history_buffer.as_entire_binding(),
-                    },
-                    wgpu::BindGroupEntry {
                         binding: 14,
                         resource: brain_config_buffer.as_entire_binding(),
                     },
@@ -1020,7 +1004,6 @@ impl GpuKernel {
             sensory_buffer,
             brain_state_buffer,
             pattern_buffer,
-            history_buffer,
             brain_config_buffer,
             dispatch_args_buffer,
             prepare_pipeline,
@@ -1589,15 +1572,6 @@ impl GpuKernel {
             &mut state.patterns,
         );
 
-        let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
-        let hist_size = (HISTORY_STRIDE * 4) as u64;
-        self.read_buffer_range(
-            &self.history_buffer,
-            hist_offset,
-            hist_size,
-            &mut state.history,
-        );
-
         state
     }
 
@@ -1618,13 +1592,6 @@ impl GpuKernel {
             &self.pattern_buffer,
             pat_offset,
             bytemuck::cast_slice(&state.patterns),
-        );
-
-        let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
-        self.queue.write_buffer(
-            &self.history_buffer,
-            hist_offset,
-            bytemuck::cast_slice(&state.history),
         );
     }
 
@@ -1689,7 +1656,6 @@ impl GpuKernel {
 
         let brain_size = (bs * 4) as u64;
         let pat_size = (PATTERN_STRIDE * 4) as u64;
-        let hist_size = (HISTORY_STRIDE * 4) as u64;
 
         let make_staging = |label, size| {
             self.device.create_buffer(&wgpu::BufferDescriptor {
@@ -1702,7 +1668,6 @@ impl GpuKernel {
 
         let brain_staging = make_staging("agent_state_brain_staging", brain_size);
         let pattern_staging = make_staging("agent_state_pattern_staging", pat_size);
-        let history_staging = make_staging("agent_state_history_staging", hist_size);
 
         let mut encoder = self
             .device
@@ -1726,30 +1691,19 @@ impl GpuKernel {
             0,
             pat_size,
         );
-        let hist_offset = (i * HISTORY_STRIDE * 4) as u64;
-        encoder.copy_buffer_to_buffer(
-            &self.history_buffer,
-            hist_offset,
-            &history_staging,
-            0,
-            hist_size,
-        );
 
         self.queue.submit(std::iter::once(encoder.finish()));
 
-        // Aggregate completion/error for all 3 staging buffers in a single tracker.
-        let tracker = ReadbackTracker::new(3);
+        // Aggregate completion/error for both staging buffers in a single tracker.
+        let tracker = ReadbackTracker::new(2);
         tracker.install(brain_staging.slice(..));
         tracker.install(pattern_staging.slice(..));
-        tracker.install(history_staging.slice(..));
 
         self.agent_state_staging = Some(AgentStateReadback {
             brain_staging,
             pattern_staging,
-            history_staging,
             brain_size,
             pattern_size: pat_size,
-            history_size: hist_size,
             tracker,
             brain_stride: bs,
         });
@@ -1774,9 +1728,6 @@ impl GpuKernel {
                 }));
                 let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     rb.pattern_staging.unmap()
-                }));
-                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    rb.history_staging.unmap()
                 }));
                 return Some(None);
             }
@@ -1804,15 +1755,6 @@ impl GpuKernel {
         drop(mapped);
         readback.pattern_staging.unmap();
 
-        let hist_data = readback.history_staging.slice(..readback.history_size);
-        let mapped = hist_data.get_mapped_range();
-        state.history.clear();
-        state
-            .history
-            .extend_from_slice(bytemuck::cast_slice(&mapped));
-        drop(mapped);
-        readback.history_staging.unmap();
-
         Some(Some(state))
     }
 
@@ -1830,7 +1772,6 @@ impl GpuKernel {
         let bs = self.layout.brain_stride;
         let mut brain_data = Vec::with_capacity(count * bs);
         let mut pattern_data = Vec::with_capacity(count * PATTERN_STRIDE);
-        let mut history_data = Vec::with_capacity(count * HISTORY_STRIDE);
 
         for i in 0..count {
             let s = states(i);
@@ -1850,22 +1791,12 @@ impl GpuKernel {
                 s.patterns.len(),
                 PATTERN_STRIDE
             );
-            debug_assert_eq!(
-                s.history.len(),
-                HISTORY_STRIDE,
-                "agent {}: history length {} != HISTORY_STRIDE {}",
-                i,
-                s.history.len(),
-                HISTORY_STRIDE
-            );
             brain_data.extend_from_slice(&s.brain_state);
             pattern_data.extend_from_slice(&s.patterns);
-            history_data.extend_from_slice(&s.history);
         }
 
         debug_assert_eq!(brain_data.len(), count * bs);
         debug_assert_eq!(pattern_data.len(), count * PATTERN_STRIDE);
-        debug_assert_eq!(history_data.len(), count * HISTORY_STRIDE);
 
         self.queue.write_buffer(
             &self.brain_state_buffer,
@@ -1874,8 +1805,6 @@ impl GpuKernel {
         );
         self.queue
             .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
-        self.queue
-            .write_buffer(&self.history_buffer, 0, bytemuck::cast_slice(&history_data));
     }
 
     /// Non-blocking version of `reset_agents`. Returns false if async staging
@@ -1899,11 +1828,10 @@ impl GpuKernel {
 
         let n = self.agent_count as usize;
 
-        // Fresh brain state, pattern memory, and action history.
+        // Fresh brain state and pattern memory.
         let mut rng = rand::rng();
         let mut brain_data = Vec::with_capacity(n * self.layout.brain_stride);
         let mut pattern_data = Vec::with_capacity(n * PATTERN_STRIDE);
-        let mut history_data = Vec::with_capacity(n * HISTORY_STRIDE);
         for _ in 0..n {
             brain_data.extend_from_slice(&init_brain_state_for(
                 brain_config,
@@ -1911,7 +1839,6 @@ impl GpuKernel {
                 &mut rng,
             ));
             pattern_data.extend_from_slice(&init_pattern_memory());
-            history_data.extend_from_slice(&init_action_history());
         }
         self.queue.write_buffer(
             &self.brain_state_buffer,
@@ -1920,8 +1847,6 @@ impl GpuKernel {
         );
         self.queue
             .write_buffer(&self.pattern_buffer, 0, bytemuck::cast_slice(&pattern_data));
-        self.queue
-            .write_buffer(&self.history_buffer, 0, bytemuck::cast_slice(&history_data));
         self.queue.write_buffer(
             &self.brain_config_buffer,
             0,
@@ -1985,6 +1910,8 @@ impl GpuKernel {
         let motor_base = DECISION_MOTOR;
         let motor_fwd = decision[motor_base];
         let motor_turn = decision[motor_base + 1];
+        // Slot 2 is strafe (consumed by physics); slot 3 carries the TD error.
+        let td_error = decision[motor_base + 3];
 
         // Brain state: read key fields
         let bs = self.layout.brain_stride;
@@ -2004,6 +1931,7 @@ impl GpuKernel {
         let dyn_hab_atten = dyn_pred_ctx_wt + (O_HAB_ATTEN - O_PREDICTOR_CONTEXT_WEIGHT);
         let dyn_fatigue_factor = dyn_pred_ctx_wt + (O_FATIGUE_FACTOR - O_PREDICTOR_CONTEXT_WEIGHT);
         let dyn_fatigue_floor = dyn_pred_ctx_wt + (O_FATIGUE_FLOOR - O_PREDICTOR_CONTEXT_WEIGHT);
+        let dyn_prev_value = dyn_pred_ctx_wt + (O_PREV_VALUE - O_PREDICTOR_CONTEXT_WEIGHT);
         // Habituation: mean of attenuation values (ENCODED_DIMENSION floats)
         let atten_sum: f32 = brain[dyn_hab_atten..dyn_hab_atten + ENCODED_DIMENSION]
             .iter()
@@ -2016,6 +1944,9 @@ impl GpuKernel {
         // Fatigue factor and floor
         let fatigue_factor = brain[dyn_fatigue_factor];
         let fatigue_floor = brain[dyn_fatigue_floor];
+
+        // Critic estimate for the latest encoded state
+        let value = brain[dyn_prev_value];
 
         // Staleness: raw spatial stagnation [0.0, 1.0] recovered by inverting the
         // shader formula: fatigue_factor = 1.0 - staleness * (1.0 - fatigue_floor).
@@ -2046,6 +1977,8 @@ impl GpuKernel {
             gradient,
             prediction_error,
             exploration_rate,
+            value,
+            td_error,
         }
     }
 
@@ -2177,6 +2110,7 @@ impl GpuKernel {
         let dyn_hab_atten = dyn_pred_ctx_wt + (O_HAB_ATTEN - O_PREDICTOR_CONTEXT_WEIGHT);
         let dyn_fatigue_factor = dyn_pred_ctx_wt + (O_FATIGUE_FACTOR - O_PREDICTOR_CONTEXT_WEIGHT);
         let dyn_fatigue_floor = dyn_pred_ctx_wt + (O_FATIGUE_FLOOR - O_PREDICTOR_CONTEXT_WEIGHT);
+        let dyn_prev_value = dyn_pred_ctx_wt + (O_PREV_VALUE - O_PREDICTOR_CONTEXT_WEIGHT);
         // Sensory
         let sensory_data = self.telemetry_staging.sensory.slice(..).get_mapped_range();
         let sensory: &[f32] = bytemuck::cast_slice(&sensory_data);
@@ -2190,6 +2124,8 @@ impl GpuKernel {
         let motor_base = DECISION_MOTOR;
         let motor_fwd = decision[motor_base];
         let motor_turn = decision[motor_base + 1];
+        // Slot 2 is strafe (consumed by physics); slot 3 carries the TD error.
+        let td_error = decision[motor_base + 3];
         drop(decision_data);
         self.telemetry_staging.decision.unmap();
 
@@ -2210,6 +2146,9 @@ impl GpuKernel {
         // range regardless of fatigue_floor.
         let max_penalty = (1.0 - fatigue_floor).max(1e-6);
         let staleness = ((1.0 - fatigue_factor) / max_penalty).clamp(0.0, 1.0);
+
+        // Critic estimate for the latest encoded state
+        let value = brain[dyn_prev_value];
 
         drop(brain_data);
         self.telemetry_staging.brain.unmap();
@@ -2236,6 +2175,8 @@ impl GpuKernel {
             gradient,
             prediction_error,
             exploration_rate,
+            value,
+            td_error,
         };
         self.cached_telemetry = Some(tel.clone());
         Some(tel)

--- a/crates/xagent-brain/src/shaders/kernel/brain_passes.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_passes.wgsl
@@ -372,9 +372,12 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
     // channels, and the encoder-credit vector through the per-dimension
     // eligibility traces — no deadzone, no tonic fallback, no history ring.
     {
-        // Value partial products: threads 0..ENCODED_DIMENSION.
+        // Value partial products: threads 0..ENCODED_DIMENSION. Reuses
+        // s_credit as ENCODED_DIMENSION-sized scratch — it is rewritten
+        // with the encoder-credit values later in this block, after the
+        // reduction below has consumed these partials.
         if (tid < ENCODED_DIMENSION) {
-            s_similarities[tid] =
+            s_credit[tid] =
                 brain_state[brain_base + O_VALUE_WEIGHTS + tid] * s_encoded[tid];
         }
         workgroupBarrier();
@@ -383,7 +386,7 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         if (tid == 0u) {
             var value: f32 = brain_state[brain_base + O_VALUE_BIAS];
             for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
-                value += s_similarities[d];
+                value += s_credit[d];
             }
             // Reward is the immediate urgency-amplified homeostatic delta
             // accrued since the previous brain tick.

--- a/crates/xagent-brain/src/shaders/kernel/brain_passes.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_passes.wgsl
@@ -30,6 +30,10 @@ var<workgroup> s_recall_similarity: array<f32, RECALL_K>;
 var<workgroup> s_prediction: array<f32, PREDICTOR_DIMENSION>;
 var<workgroup> s_credit: array<f32, ENCODED_DIMENSION>;
 var<workgroup> s_pred_error: f32;
+var<workgroup> s_td_error: f32;
+// Exploration noise terms [forward, turn] published by thread 0's motor
+// block for the parallel eligibility-trace update.
+var<workgroup> s_explore: array<f32, 2>;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -285,7 +289,6 @@ fn coop_recall_topk(agent_id: u32, tid: u32 /* SUBGROUP_TOPK_PARAMS */) {
 fn coop_predict_and_act(agent_id: u32, tid: u32) {
     let brain_base = agent_id * BRAIN_STRIDE;
     let pattern_base = agent_id * PATTERN_STRIDE;
-    let history_base = agent_id * HISTORY_STRIDE;
     let decision_base = agent_id * DECISION_STRIDE;
     let tick_count = brain_state[brain_base + O_TICK_COUNT];
     let recall_count = u32(s_recall[RECALL_K]);
@@ -362,68 +365,64 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
     }
     workgroupBarrier();
 
-    // ── Credit assignment: cooperative across threads 0..31 ────────────
-    // Thread 0 computes per-entry credit scalars → s_similarities[0..N].
-    // Threads 0..31 then apply all credits to their dimension in
-    // parallel, eliminating the serial ENCODED_DIMENSION-loop bottleneck that was
-    // blocking 255 threads at the barrier while thread 0 looped over
-    // 64 entries × 32 dimensions.
+    // ── TD(λ) credit: value head + eligibility traces ───────────────────
+    // The critic estimates the discounted homeostatic return from the
+    // current encoded state. The TD error δ for the previous transition is
+    // the single credit signal: it updates the critic, both policy
+    // channels, and the encoder-credit vector through the per-dimension
+    // eligibility traces — no deadzone, no tonic fallback, no history ring.
     {
-        let gradient = s_homeo[0u];
-        let urgency = s_homeo[2u];
-        let hist_len = u32(history_buffer[history_base + O_HIST_LEN]);
-
-        // Phase 1: thread 0 computes credit scalar for each history entry
-        if (tid == 0u) {
-            for (var i: u32 = 0u; i < hist_len; i = i + 1u) {
-                let h_off = i * 5u;
-                let recorded_forward = history_buffer[history_base + O_MOTOR_RING + h_off];
-                let recorded_turn = history_buffer[history_base + O_MOTOR_RING + h_off + 1u];
-                let rec_tick = history_buffer[history_base + O_MOTOR_RING + h_off + 2u];
-                let rec_grad = history_buffer[history_base + O_MOTOR_RING + h_off + 3u];
-                let age = tick_count - rec_tick;
-                let temporal = exp(-age * CREDIT_DECAY);
-                var credit: f32 = 0.0;
-                if (temporal >= 0.01) {
-                    let improvement = gradient - rec_grad;
-                    var credit_input = improvement;
-                    if (abs(improvement) < DEADZONE) {
-                        credit_input = gradient * urgency * TONIC_CREDIT_SCALE;
-                    }
-                    if (abs(credit_input) >= CREDIT_EPSILON) {
-                        var effective: f32;
-                        if (credit_input < 0.0) { effective = credit_input * PAIN_AMP; }
-                        else { effective = credit_input; }
-                        credit = effective * temporal;
-                        brain_state[brain_base + O_ACT_BIASES] += ACTION_WEIGHT_LEARNING_RATE * credit * recorded_forward * 0.1;
-                        brain_state[brain_base + O_ACT_BIASES + 1u] += ACTION_WEIGHT_LEARNING_RATE * credit * recorded_turn * 0.1;
-                    }
-                }
-                s_similarities[i] = credit;
-                // Cache motor values in shared memory so phase 2 threads
-                // read from workgroup memory instead of storage.
-                shared_sort_indices[i * 2u] = bitcast<u32>(recorded_forward);
-                shared_sort_indices[i * 2u + 1u] = bitcast<u32>(recorded_turn);
-            }
+        // Value partial products: threads 0..ENCODED_DIMENSION.
+        if (tid < ENCODED_DIMENSION) {
+            s_similarities[tid] =
+                brain_state[brain_base + O_VALUE_WEIGHTS + tid] * s_encoded[tid];
         }
         workgroupBarrier();
 
-        // Phase 2: threads 0..31 apply all credits to their dimension
-        if (tid < ENCODED_DIMENSION) {
-            s_credit[tid] = 0.0;
-            for (var i: u32 = 0u; i < hist_len; i = i + 1u) {
-                let credit = s_similarities[i];
-                if (abs(credit) > 0.0) {
-                    let recorded_forward = bitcast<f32>(shared_sort_indices[i * 2u]);
-                    let recorded_turn = bitcast<f32>(shared_sort_indices[i * 2u + 1u]);
-                    let feat = history_buffer[history_base + O_STATE_RING + i * ENCODED_DIMENSION + tid];
-                    let forward_weight_update = ACTION_WEIGHT_LEARNING_RATE * credit * recorded_forward * feat;
-                    let turn_weight_update = ACTION_WEIGHT_LEARNING_RATE * credit * recorded_turn * feat;
-                    brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + tid] += forward_weight_update;
-                    brain_state[brain_base + O_ACTION_TURN_WEIGHTS + tid] += turn_weight_update;
-                    s_credit[tid] += credit * recorded_forward * feat + credit * recorded_turn * feat;
-                }
+        // Thread 0: reduce value, form δ, update the scalar biases.
+        if (tid == 0u) {
+            var value: f32 = brain_state[brain_base + O_VALUE_BIAS];
+            for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+                value += s_similarities[d];
             }
+            // Reward is the immediate urgency-amplified homeostatic delta
+            // accrued since the previous brain tick.
+            let reward = s_homeo[1u];
+            let prev_value = brain_state[brain_base + O_PREV_VALUE];
+            let td_error = clamp(
+                reward + TD_DISCOUNT * value - prev_value,
+                -MAX_TD_ERROR, MAX_TD_ERROR,
+            );
+            brain_state[brain_base + O_PREV_VALUE] = value;
+            s_td_error = td_error;
+
+            let critic_bias_trace = brain_state[brain_base + O_TRACE_BIASES];
+            let forward_bias_trace = brain_state[brain_base + O_TRACE_BIASES + 1u];
+            let turn_bias_trace = brain_state[brain_base + O_TRACE_BIASES + 2u];
+            brain_state[brain_base + O_VALUE_BIAS] +=
+                CRITIC_LEARNING_RATE * td_error * critic_bias_trace;
+            brain_state[brain_base + O_ACT_BIASES] +=
+                ACTION_WEIGHT_LEARNING_RATE * td_error * forward_bias_trace;
+            brain_state[brain_base + O_ACT_BIASES + 1u] +=
+                ACTION_WEIGHT_LEARNING_RATE * td_error * turn_bias_trace;
+        }
+        workgroupBarrier();
+
+        // Threads 0..ENCODED_DIMENSION: apply δ through the traces.
+        if (tid < ENCODED_DIMENSION) {
+            let td_error = s_td_error;
+            let critic_trace = brain_state[brain_base + O_TRACE_CRITIC + tid];
+            let forward_trace = brain_state[brain_base + O_TRACE_FWD + tid];
+            let turn_trace = brain_state[brain_base + O_TRACE_TURN + tid];
+            brain_state[brain_base + O_VALUE_WEIGHTS + tid] +=
+                CRITIC_LEARNING_RATE * TD_VECTOR_SCALE * td_error * critic_trace;
+            brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + tid] +=
+                ACTION_WEIGHT_LEARNING_RATE * TD_VECTOR_SCALE * td_error * forward_trace;
+            brain_state[brain_base + O_ACTION_TURN_WEIGHTS + tid] +=
+                ACTION_WEIGHT_LEARNING_RATE * TD_VECTOR_SCALE * td_error * turn_trace;
+            // Encoder credit: which encoded dimensions carried the policy's
+            // eligibility when this outcome arrived.
+            s_credit[tid] = td_error * (forward_trace + turn_trace);
         }
     }
     storageBarrier(); workgroupBarrier();
@@ -434,13 +433,11 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         let urgency = s_homeo[2u];
         let prediction_error = s_pred_error;
 
-        // Weight decay + normalization
-        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
-            brain_state[brain_base + O_ACTION_FORWARD_WEIGHTS + d] *= (1.0 - ACTION_WEIGHT_DECAY);
-            brain_state[brain_base + O_ACTION_TURN_WEIGHTS + d] *= (1.0 - ACTION_WEIGHT_DECAY);
-        }
-        brain_state[brain_base + O_ACT_BIASES] *= (1.0 - ACTION_WEIGHT_DECAY);
-        brain_state[brain_base + O_ACT_BIASES + 1u] *= (1.0 - ACTION_WEIGHT_DECAY);
+        // Weight normalization. No per-tick decay: TD updates are
+        // surprise-driven (they stop when δ calibrates to zero), so decay
+        // would only erase accumulated policy knowledge — including the
+        // initial forward bias that provides exploration mobility. The
+        // L2 balls below are the sole magnitude bound.
         brain_state[brain_base + O_ACT_BIASES] = clamp(brain_state[brain_base + O_ACT_BIASES], -MAX_WEIGHT_NORM, MAX_WEIGHT_NORM);
         brain_state[brain_base + O_ACT_BIASES + 1u] = clamp(brain_state[brain_base + O_ACT_BIASES + 1u], -MAX_WEIGHT_NORM, MAX_WEIGHT_NORM);
         var fwd_norm_sq: f32 = 0.0;
@@ -465,6 +462,24 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
                 brain_state[brain_base + O_ACTION_TURN_WEIGHTS + d] *= scale;
             }
         }
+
+        // Value head: L2-ball clamp only — no per-tick decay. Decay would
+        // continuously erase the learned value landscape, and the critic
+        // must hold "states like this end well/badly" across episodes.
+        var val_norm_sq: f32 = 0.0;
+        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+            let vw = brain_state[brain_base + O_VALUE_WEIGHTS + d];
+            val_norm_sq += vw * vw;
+        }
+        let val_norm = sqrt(val_norm_sq);
+        if (val_norm > MAX_WEIGHT_NORM) {
+            let scale = MAX_WEIGHT_NORM / val_norm;
+            for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
+                brain_state[brain_base + O_VALUE_WEIGHTS + d] *= scale;
+            }
+        }
+        brain_state[brain_base + O_VALUE_BIAS] = clamp(
+            brain_state[brain_base + O_VALUE_BIAS], -MAX_WEIGHT_NORM, MAX_WEIGHT_NORM);
 
         // Policy evaluation
         var forward: f32 = brain_state[brain_base + O_ACT_BIASES];
@@ -606,26 +621,14 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         let klinotaxis_factor = clamp(1.0 - gradient_deviation * KLINOTAXIS_SENSITIVITY, 0.3, 3.0);
         turn *= klinotaxis_factor;
 
-        // History records the exploration noise, not the full motor.
-        // Credit × noise is the proper REINFORCE gradient: noise is zero-mean,
-        // so only noise directions that correlate with outcomes get reinforced.
-        // Using the full motor (policy + noise) creates a feedback loop where
-        // any turn bias gets reinforced by every positive credit event.
-        let exploration_forward = noise_forward * exploration_rate;
-        let exploration_turn = noise_turn * exploration_rate;
-        let hist_cursor = u32(history_buffer[history_base + O_HIST_CURSOR]);
-        let hist_off = hist_cursor * 5u;
-        history_buffer[history_base + O_MOTOR_RING + hist_off] = exploration_forward;
-        history_buffer[history_base + O_MOTOR_RING + hist_off + 1u] = exploration_turn;
-        history_buffer[history_base + O_MOTOR_RING + hist_off + 2u] = tick_count;
-        history_buffer[history_base + O_MOTOR_RING + hist_off + 3u] = gradient;
-        history_buffer[history_base + O_MOTOR_RING + hist_off + 4u] = 0.0;
-        for (var d: u32 = 0u; d < ENCODED_DIMENSION; d = d + 1u) {
-            history_buffer[history_base + O_STATE_RING + hist_cursor * ENCODED_DIMENSION + d] = s_encoded[d];
-        }
-        history_buffer[history_base + O_HIST_CURSOR] = f32((hist_cursor + 1u) % ACTION_HISTORY_LEN);
-        let hist_len_val = history_buffer[history_base + O_HIST_LEN];
-        history_buffer[history_base + O_HIST_LEN] = min(hist_len_val + 1.0, f32(ACTION_HISTORY_LEN));
+        // Publish the exploration noise terms for the eligibility-trace
+        // update below. The traces carry noise, not the full motor: noise is
+        // zero-mean, so only noise directions that correlate with TD errors
+        // get reinforced. Using the full motor (policy + noise) creates a
+        // feedback loop where any turn bias gets reinforced by every
+        // positive credit event.
+        s_explore[0u] = noise_forward * exploration_rate;
+        s_explore[1u] = noise_turn * exploration_rate;
 
         // Save prediction + tick + decision buffer
         for (var d: u32 = 0u; d < PREDICTOR_DIMENSION; d = d + 1u) {
@@ -649,8 +652,10 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         }
         decision_buffer[decision_base + DECISION_MOTOR] = forward;
         decision_buffer[decision_base + DECISION_MOTOR + 1u] = turn;
+        // Slot 2 is consumed by the physics phase as strafe — keep it zero.
         decision_buffer[decision_base + DECISION_MOTOR + 2u] = 0.0;
-        decision_buffer[decision_base + DECISION_MOTOR + 3u] = 0.0;
+        // Slot 3 is TD-error telemetry for CPU readback.
+        decision_buffer[decision_base + DECISION_MOTOR + 3u] = s_td_error;
 
         // Write telemetry to physics buffer for CPU readback
         let phys_base = agent_id * PHYS_STRIDE;
@@ -661,6 +666,34 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
         physics_state[phys_base + P_MOTOR_TURN_OUT] = turn;
         physics_state[phys_base + P_GRADIENT_OUT] = gradient;
         physics_state[phys_base + P_URGENCY_OUT] = urgency;
+    }
+    workgroupBarrier();
+
+    // ── Eligibility trace update (all dims in parallel) ─────────────────
+    // Accumulating traces: z ← γλ·z + feature term. The critic trace
+    // carries the state; the actor traces carry exploration-noise ×
+    // state — the likelihood-ratio direction of the action actually
+    // taken — so future TD errors credit exactly the noise kicks (and the
+    // states they occurred in) that caused them.
+    {
+        let trace_decay = TD_DISCOUNT * TD_LAMBDA;
+        if (tid < ENCODED_DIMENSION) {
+            let enc = s_encoded[tid];
+            brain_state[brain_base + O_TRACE_CRITIC + tid] =
+                brain_state[brain_base + O_TRACE_CRITIC + tid] * trace_decay + enc;
+            brain_state[brain_base + O_TRACE_FWD + tid] =
+                brain_state[brain_base + O_TRACE_FWD + tid] * trace_decay + s_explore[0u] * enc;
+            brain_state[brain_base + O_TRACE_TURN + tid] =
+                brain_state[brain_base + O_TRACE_TURN + tid] * trace_decay + s_explore[1u] * enc;
+        }
+        if (tid == 0u) {
+            brain_state[brain_base + O_TRACE_BIASES] =
+                brain_state[brain_base + O_TRACE_BIASES] * trace_decay + 1.0;
+            brain_state[brain_base + O_TRACE_BIASES + 1u] =
+                brain_state[brain_base + O_TRACE_BIASES + 1u] * trace_decay + s_explore[0u];
+            brain_state[brain_base + O_TRACE_BIASES + 2u] =
+                brain_state[brain_base + O_TRACE_BIASES + 2u] * trace_decay + s_explore[1u];
+        }
     }
 }
 

--- a/crates/xagent-brain/src/shaders/kernel/brain_passes.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/brain_passes.wgsl
@@ -699,8 +699,8 @@ fn coop_predict_and_act(agent_id: u32, tid: u32) {
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Pass 7: Learn and store
-// Predictor: threads 0..31; Encoder: threads 0..31;
-// Memory reinforcement: threads 0..127; Decay: threads 0..127
+// Predictor: threads 0..PREDICTOR_DIMENSION; Encoder credit: one encoded dim
+// per thread; Memory reinforcement / decay: threads 0..MEMORY_CAP.
 // ═══════════════════════════════════════════════════════════════════════════
 
 fn coop_learn_and_store(agent_id: u32, tid: u32) {
@@ -738,7 +738,9 @@ fn coop_learn_and_store(agent_id: u32, tid: u32) {
         brain_state[brain_base + O_PREDICTOR_CONTEXT_WEIGHT] = clamp(brain_state[brain_base + O_PREDICTOR_CONTEXT_WEIGHT], 0.05, 0.5);
     }
 
-    // ── 7b. Encoder credit: threads 0..31 ──────────────────────────────
+    // ── 7b. Encoder credit: one encoded dimension per thread ────────────
+    // Task-driven nudge: features that co-occurred with TD-error eligibility
+    // get their weights into this dimension strengthened.
     if (tid < ENCODED_DIMENSION) {
         let action_credit = decision_buffer[decision_base + DECISION_CREDIT + tid];
         if (abs(action_credit) >= CREDIT_EPSILON) {

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -30,7 +30,6 @@ const PREDICTOR_DIMENSION: u32 = ENCODED_DIMENSION;
 override FEATURE_COUNT: u32 = VISION_COLOR_COUNT + VISION_DEPTH_COUNT + 25u;
 const MEMORY_CAP: u32 = 128u;
 const RECALL_K: u32 = 16u;
-const ACTION_HISTORY_LEN: u32 = 64u;
 const ERROR_HISTORY_LEN: u32 = 128u;
 
 // ── Brain state offsets (derived from FEATURE_COUNT) ────────────────────────
@@ -65,11 +64,23 @@ override O_HAB_MAX_CURIOSITY: u32 = O_HAB_SENSITIVITY + 1u;
 override O_FATIGUE_FLOOR: u32 = O_HAB_MAX_CURIOSITY + 1u;
 override O_MOVEMENT_SPEED: u32 = O_FATIGUE_FLOOR + 1u;
 
+// ── TD(λ) critic state ──────────────────────────────────────────────────────
+// Value head (learned, inherited) plus eligibility traces (episodic,
+// zeroed on death). Trace biases pack three scalars:
+// [critic_bias, forward_bias, turn_bias].
+
+override O_VALUE_WEIGHTS: u32 = O_MOVEMENT_SPEED + 1u;
+override O_VALUE_BIAS: u32 = O_VALUE_WEIGHTS + ENCODED_DIMENSION;
+override O_PREV_VALUE: u32 = O_VALUE_BIAS + 1u;
+override O_TRACE_CRITIC: u32 = O_PREV_VALUE + 1u;
+override O_TRACE_FWD: u32 = O_TRACE_CRITIC + ENCODED_DIMENSION;
+override O_TRACE_TURN: u32 = O_TRACE_FWD + ENCODED_DIMENSION;
+override O_TRACE_BIASES: u32 = O_TRACE_TURN + ENCODED_DIMENSION;
+
 // ── Per-agent buffer strides ────────────────────────────────────────────────
 
-override BRAIN_STRIDE: u32 = O_MOVEMENT_SPEED + 1u;
+override BRAIN_STRIDE: u32 = O_TRACE_BIASES + 3u;
 const PATTERN_STRIDE: u32 = O_LAST_STORED_IDX + 1u;
-const HISTORY_STRIDE: u32 = O_HIST_LEN + 1u;
 override FEATURES_STRIDE: u32 = FEATURE_COUNT;
 const DECISION_PREDICTION: u32 = 0u;
 const DECISION_CREDIT: u32 = ENCODED_DIMENSION;
@@ -93,13 +104,6 @@ const O_PAT_ACTIVE: u32 = O_PAT_META + MEMORY_CAP * 3u;
 const O_ACTIVE_COUNT: u32 = O_PAT_ACTIVE + MEMORY_CAP;
 const O_MIN_REINF_IDX: u32 = O_ACTIVE_COUNT + 1u;
 const O_LAST_STORED_IDX: u32 = O_MIN_REINF_IDX + 1u;
-
-// ── Action history offsets ──────────────────────────────────────────────────
-
-const O_MOTOR_RING: u32 = 0u;
-const O_STATE_RING: u32 = ACTION_HISTORY_LEN * 5u;
-const O_HIST_CURSOR: u32 = O_STATE_RING + ACTION_HISTORY_LEN * ENCODED_DIMENSION;
-const O_HIST_LEN: u32 = O_HIST_CURSOR + 1u;
 
 // ── Config buffer offsets ───────────────────────────────────────────────────
 
@@ -264,20 +268,37 @@ const GRADIENT_WEIGHT_SLOW: f32 = 0.15;
 
 // ── Predict-and-act constants ───────────────────────────────────────────────
 
-const CREDIT_DECAY: f32 = 0.3;
 const ACTION_WEIGHT_LEARNING_RATE: f32 = 0.10;
-const PAIN_AMP: f32 = 3.0;
-const DEADZONE: f32 = 0.005;
 const MAX_WEIGHT_NORM: f32 = 2.0;
-const ACTION_WEIGHT_DECAY: f32 = 0.01;
-const TONIC_CREDIT_SCALE: f32 = 0.5;
 const ENCODER_CREDIT_SCALE: f32 = 0.1;
 const CREDIT_EPSILON: f32 = 1e-6;
 const KLINOTAXIS_SENSITIVITY: f32 = 500.0;
 const MEMORY_BLEND_STRENGTH: f32 = 0.4;
 
+// ── TD(λ) credit constants ──────────────────────────────────────────────────
+
+// Per-brain-tick discount. Horizon 1/(1−γ) ≈ 33 brain ticks matches the
+// travel time from the edge of vision range to food at default speed.
+const TD_DISCOUNT: f32 = 0.97;
+// Eligibility trace decay. Combined per-tick trace retention is
+// TD_DISCOUNT × TD_LAMBDA ≈ 0.87; the critic's bootstrapping propagates
+// credit beyond the raw trace span across repeated experiences.
+const TD_LAMBDA: f32 = 0.9;
+// Critic learns 10× slower than the actor: the value estimate must be
+// stabler than the policy it evaluates.
+const CRITIC_LEARNING_RATE: f32 = 0.01;
+// Per-dimension trace updates scale inversely with the feature dimension:
+// the aggregate step (a sum of ENCODED_DIMENSION products of trace ×
+// feature, each O(1)) would otherwise grow with dimensionality and push
+// the bootstrapped critic past the linear-TD stability limit.
+const TD_VECTOR_SCALE: f32 = 1.0 / f32(ENCODED_DIMENSION);
+// Bound on the TD error. No single transition is allowed to teach more
+// than this; protects against respawn/clamp artifacts (mirrors the intent
+// of MAX_HOMEOSTATIC_DELTA on the reward side).
+const MAX_TD_ERROR: f32 = 1.0;
+
 // ═══════════════════════════════════════════════════════════════════════════
-// Buffer bindings — 15 storage + 2 uniform, single bind group
+// Buffer bindings — 14 storage + 2 uniform, single bind group
 // ═══════════════════════════════════════════════════════════════════════════
 
 @group(0) @binding(0)  var<storage, read_write> physics_state:        array<f32>;
@@ -293,7 +314,6 @@ const MEMORY_BLEND_STRENGTH: f32 = 0.4;
 @group(0) @binding(10) var<storage, read_write> sensory_buffer:       array<f32>;
 @group(0) @binding(11) var<storage, read_write> brain_state:       array<f32>;
 @group(0) @binding(12) var<storage, read_write> pattern_buffer:       array<f32>;
-@group(0) @binding(13) var<storage, read_write> history_buffer:       array<f32>;
 @group(0) @binding(14) var<uniform>             brain_config:      array<vec4<f32>, 3>;
 @group(0) @binding(15) var<storage, read_write> dispatch_args:     array<u32, 6>;
 

--- a/crates/xagent-brain/src/shaders/kernel/common.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/common.wgsl
@@ -298,7 +298,9 @@ const TD_VECTOR_SCALE: f32 = 1.0 / f32(ENCODED_DIMENSION);
 const MAX_TD_ERROR: f32 = 1.0;
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Buffer bindings — 14 storage + 2 uniform, single bind group
+// Buffer bindings — 13 storage + 2 uniform, single bind group
+// (binding 13 is intentionally unused; the numbering of the remaining
+// bindings is stable so the bind-group layout in gpu_kernel.rs stays aligned)
 // ═══════════════════════════════════════════════════════════════════════════
 
 @group(0) @binding(0)  var<storage, read_write> physics_state:        array<f32>;

--- a/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/kernel_tick.wgsl
@@ -377,10 +377,18 @@ fn agent_death_respawn(agent_id: u32, tick: u32) {
         brain_state[brain_base + O_PREV_ENCODED + i] = 0.0;
     }
 
-    let history_base = agent_id * HISTORY_STRIDE;
-    for (var i = 0u; i < HISTORY_STRIDE; i++) {
-        history_buffer[history_base + i] = 0.0;
+    // Reset TD transients: eligibility traces and the previous-state value
+    // are episodic — credit must never leak across the death boundary.
+    // The value weights themselves are learned knowledge and survive.
+    for (var i = 0u; i < ENCODED_DIMENSION; i++) {
+        brain_state[brain_base + O_TRACE_CRITIC + i] = 0.0;
+        brain_state[brain_base + O_TRACE_FWD + i] = 0.0;
+        brain_state[brain_base + O_TRACE_TURN + i] = 0.0;
     }
+    brain_state[brain_base + O_TRACE_BIASES] = 0.0;
+    brain_state[brain_base + O_TRACE_BIASES + 1u] = 0.0;
+    brain_state[brain_base + O_TRACE_BIASES + 2u] = 0.0;
+    brain_state[brain_base + O_PREV_VALUE] = 0.0;
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -489,8 +497,8 @@ fn kernel_tick(
 
         // Death/respawn: thread 0. Re-broadcasts `s_alive` because respawn may
         // flip `P_ALIVE` back to 1. `storageBarrier()` is required because
-        // respawn rewrites `physics_state`, `brain_state`, `pattern_buffer`,
-        // and `history_buffer`, all of which are read by the cooperative
+        // respawn rewrites `physics_state`, `brain_state`, and
+        // `pattern_buffer`, all of which are read by the cooperative
         // passes in `brain_tick_inner` below.
         if (tid == 0u) {
             agent_death_respawn(agent_id, base_tick);

--- a/crates/xagent-brain/src/shaders/kernel/phase_death.wgsl
+++ b/crates/xagent-brain/src/shaders/kernel/phase_death.wgsl
@@ -109,9 +109,16 @@ fn phase_death_respawn(tid: u32, tick: u32) {
         brain_state[brain_base + O_PREV_ENCODED + i] = 0.0;
     }
 
-    // Zero action history
-    let hist_base = tid * HISTORY_STRIDE;
-    for (var i = 0u; i < HISTORY_STRIDE; i++) {
-        history_buffer[hist_base + i] = 0.0;
+    // Reset TD transients: eligibility traces and the previous-state value
+    // are episodic — credit must never leak across the death boundary.
+    // The value weights themselves are learned knowledge and survive.
+    for (var i = 0u; i < ENCODED_DIMENSION; i++) {
+        brain_state[brain_base + O_TRACE_CRITIC + i] = 0.0;
+        brain_state[brain_base + O_TRACE_FWD + i] = 0.0;
+        brain_state[brain_base + O_TRACE_TURN + i] = 0.0;
     }
+    brain_state[brain_base + O_TRACE_BIASES] = 0.0;
+    brain_state[brain_base + O_TRACE_BIASES + 1u] = 0.0;
+    brain_state[brain_base + O_TRACE_BIASES + 2u] = 0.0;
+    brain_state[brain_base + O_PREV_VALUE] = 0.0;
 }

--- a/crates/xagent-sandbox/README.md
+++ b/crates/xagent-sandbox/README.md
@@ -416,7 +416,7 @@ pub struct Agent {
 }
 ```
 
-The `Agent` struct never owns brain state directly — the GPU kernel owns it. `brain_idx` is the agent's slot in `GpuKernel`'s `brain_state` / `pattern_buffer` / `history_buffer` storage rows; `brain_config` is kept on CPU for metabolic-drain computation, evolution mutation, and JSON serialization.
+The `Agent` struct never owns brain state directly — the GPU kernel owns it. `brain_idx` is the agent's slot in `GpuKernel`'s `brain_state` / `pattern_buffer` storage rows; `brain_config` is kept on CPU for metabolic-drain computation, evolution mutation, and JSON serialization.
 
 **Agent palette colors** — Each agent is assigned a static palette color at spawn. The same color is used in the 3D viewport (with an sRGB→linear conversion for correct GPU rendering) and in the egui sidebar. Dead agents render as dark gray `[0.3, 0.3, 0.3]` (the `DEAD_COLOR` constant in `crates/xagent-sandbox/src/agent/mod.rs`).
 

--- a/crates/xagent-sandbox/src/headless.rs
+++ b/crates/xagent-sandbox/src/headless.rs
@@ -269,11 +269,12 @@ pub fn run_headless(config: FullConfig, db_path: &str, resume: bool, _has_gpu: b
     );
 }
 
-/// Per-generation learning metrics: behavioral signal (food per life) plus
-/// the policy weight norms of the generation's best agent. These stay flat
-/// for a population that isn't learning and should trend upward once credit
-/// assignment reaches food-approach actions. Printed alongside the fitness
-/// line so headless runs double as before/after measurement records.
+/// Per-generation learning metrics: behavioral signal (food per 1k
+/// alive-ticks) plus the policy weight norms of the generation's best
+/// agent. These stay flat for a population that isn't learning and should
+/// trend upward once credit assignment reaches food-approach actions.
+/// Printed alongside the fitness line so headless runs double as
+/// before/after measurement records.
 fn log_learning_metrics(
     agents: &[Agent],
     best_state: Option<&AgentBrainState>,

--- a/crates/xagent-sandbox/src/headless.rs
+++ b/crates/xagent-sandbox/src/headless.rs
@@ -226,7 +226,11 @@ pub fn run_headless(config: FullConfig, db_path: &str, resume: bool, _has_gpu: b
         inherited_state = agents
             .get(best_idx)
             .map(|a| kernel.read_agent_state(a.brain_idx));
-        log_learning_metrics(&agents, inherited_state.as_ref(), &current_configs[0]);
+        // The weight-norm layout must come from the champion's own config —
+        // configs are per-agent, and a mismatched layout would misplace the
+        // tail offsets into the champion's brain_state.
+        let best_config = current_configs.get(best_idx).unwrap_or(&current_configs[0]);
+        log_learning_metrics(&agents, inherited_state.as_ref(), best_config);
         governor.log_generation(&fitness);
         println!(
             "  Time: {:.1}s | {:.0} ticks/sec",

--- a/crates/xagent-sandbox/src/headless.rs
+++ b/crates/xagent-sandbox/src/headless.rs
@@ -277,9 +277,17 @@ fn log_learning_metrics(
 ) {
     let total_food: u64 = agents.iter().map(|a| u64::from(a.food_consumed)).sum();
     let total_deaths: u64 = agents.iter().map(|a| u64::from(a.death_count)).sum();
-    // Every agent lives at least once; each death starts another life.
-    let lives = agents.len() as u64 + total_deaths;
-    let food_per_life = total_food as f64 / lives.max(1) as f64;
+    // Foraging rate per 1k alive-ticks: total food normalized by the
+    // life-time the population actually accrued. Unlike food-per-life this is
+    // robust to death count — an active forager that dies often still scores
+    // its foraging honestly — so it is the cleaner cross-generation learning
+    // signal. (`total_ticks_alive` is preserved across respawn.)
+    let total_alive_ticks: u64 = agents.iter().map(|a| a.total_ticks_alive).sum();
+    let food_per_1k = if total_alive_ticks > 0 {
+        total_food as f64 / total_alive_ticks as f64 * 1000.0
+    } else {
+        0.0
+    };
 
     let mut weight_norms = String::new();
     if let Some(state) = best_state {
@@ -306,7 +314,7 @@ fn log_learning_metrics(
             );
         }
     }
-    println!("  Food: {total_food} | Deaths: {total_deaths} | Food/life: {food_per_life:.2}{weight_norms}");
+    println!("  Food: {total_food} | Deaths: {total_deaths} | Food/1k-ticks: {food_per_1k:.3}{weight_norms}");
 }
 
 /// Print evolution tree from database and exit.

--- a/crates/xagent-sandbox/src/headless.rs
+++ b/crates/xagent-sandbox/src/headless.rs
@@ -9,7 +9,9 @@ use log::info;
 use xagent_shared::{BrainConfig, FullConfig};
 
 use xagent_brain::buffers::{
-    PHYS_STRIDE, P_ALIVE, P_DEATH_COUNT, P_FOOD_COUNT, P_POS_X, P_POS_Y, P_POS_Z, P_TICKS_ALIVE,
+    BrainLayout, ENCODED_DIMENSION, O_ACTION_FORWARD_WEIGHTS, O_ACTION_TURN_WEIGHTS,
+    O_PREDICTOR_CONTEXT_WEIGHT, PHYS_STRIDE, PREDICTOR_DIMENSION, P_ALIVE, P_DEATH_COUNT,
+    P_FOOD_COUNT, P_POS_X, P_POS_Y, P_POS_Z, P_TICKS_ALIVE,
 };
 use xagent_brain::{AgentBrainState, GpuKernel};
 
@@ -224,6 +226,7 @@ pub fn run_headless(config: FullConfig, db_path: &str, resume: bool, _has_gpu: b
         inherited_state = agents
             .get(best_idx)
             .map(|a| kernel.read_agent_state(a.brain_idx));
+        log_learning_metrics(&agents, inherited_state.as_ref(), &current_configs[0]);
         governor.log_generation(&fitness);
         println!(
             "  Time: {:.1}s | {:.0} ticks/sec",
@@ -260,6 +263,50 @@ pub fn run_headless(config: FullConfig, db_path: &str, resume: bool, _has_gpu: b
         total_time.as_secs_f64(),
         governor.generation,
     );
+}
+
+/// Per-generation learning metrics: behavioral signal (food per life) plus
+/// the policy weight norms of the generation's best agent. These stay flat
+/// for a population that isn't learning and should trend upward once credit
+/// assignment reaches food-approach actions. Printed alongside the fitness
+/// line so headless runs double as before/after measurement records.
+fn log_learning_metrics(
+    agents: &[Agent],
+    best_state: Option<&AgentBrainState>,
+    config: &BrainConfig,
+) {
+    let total_food: u64 = agents.iter().map(|a| u64::from(a.food_consumed)).sum();
+    let total_deaths: u64 = agents.iter().map(|a| u64::from(a.death_count)).sum();
+    // Every agent lives at least once; each death starts another life.
+    let lives = agents.len() as u64 + total_deaths;
+    let food_per_life = total_food as f64 / lives.max(1) as f64;
+
+    let mut weight_norms = String::new();
+    if let Some(state) = best_state {
+        let layout = BrainLayout::new(config.vision_width, config.vision_height);
+        // Tail offsets are vision-independent deltas from the context-weight
+        // slot; rebase them onto this layout's dynamic position.
+        let tail_base = layout.feature_count * ENCODED_DIMENSION
+            + ENCODED_DIMENSION
+            + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
+        let forward_base = tail_base + (O_ACTION_FORWARD_WEIGHTS - O_PREDICTOR_CONTEXT_WEIGHT);
+        let turn_base = tail_base + (O_ACTION_TURN_WEIGHTS - O_PREDICTOR_CONTEXT_WEIGHT);
+        if state.brain_state.len() >= turn_base + ENCODED_DIMENSION {
+            let l2_norm = |base: usize| -> f32 {
+                state.brain_state[base..base + ENCODED_DIMENSION]
+                    .iter()
+                    .map(|w| w * w)
+                    .sum::<f32>()
+                    .sqrt()
+            };
+            weight_norms = format!(
+                " | w_fwd {:.3} | w_turn {:.3}",
+                l2_norm(forward_base),
+                l2_norm(turn_base),
+            );
+        }
+    }
+    println!("  Food: {total_food} | Deaths: {total_deaths} | Food/life: {food_per_life:.2}{weight_norms}");
 }
 
 /// Print evolution tree from database and exit.

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1703,18 +1703,19 @@ const PROBE_GRID_SIDE: usize = 4;
 /// Spacing between probe agents. Greater than 2× the vision range (30) so
 /// no probe agent can ever see another agent or another agent's food item.
 const PROBE_AGENT_SPACING: f32 = 64.0;
-/// Horizontal agent→food distance. The lowest below-horizon vision ray row
-/// (vertical slope ≈ 0.18 on the default 8×6 grid) passes within the food
-/// hit radius (1.0) at this range before the ray strikes flat ground
-/// (≈ 5.5 units out), while staying beyond both the touch range (3.0) and
-/// the food consume radius (2.0) so a stationary agent neither touches nor
-/// eats its probe target.
+/// Horizontal agent→food distance. Comfortably inside the default
+/// 17×13 grid's full-bearing visibility band (the horizon ray row passes a
+/// constant 0.65 below eye level — within the 1.0 food hit radius — and at
+/// this range the per-column capture cones overlap, so any bearing inside
+/// the FOV sees the food), while staying beyond both the touch range (3.0)
+/// and the food consume radius (2.0) so a stationary agent neither touches
+/// nor eats its probe target.
 const PROBE_FOOD_DISTANCE: f32 = 5.0;
 /// Food bearing magnitude relative to the agent's initial facing.
-/// atan(3/7) aligns the food exactly with a ray column of the default
-/// 8-column vision grid (column offset u = ±3/7 at 45° half-FOV), which
+/// atan(3/8) aligns the food exactly with a ray column of the default
+/// 17-column vision grid (column offset u = ±3/8 at 45° half-FOV), which
 /// maximizes ray-hit reliability at the probe distance.
-const PROBE_FOOD_BEARING: f32 = 0.404_891_6;
+const PROBE_FOOD_BEARING: f32 = 0.358_770_67;
 /// Food rest height above flat terrain (matches the kernel's
 /// FOOD_HEIGHT_OFFSET).
 const PROBE_FOOD_Y: f32 = 0.35;
@@ -1746,6 +1747,11 @@ struct ProbeArena {
     kernel: xagent_brain::GpuKernel,
     agent_pos: Vec<glam::Vec3>,
     food_pos: Vec<(f32, f32, f32)>,
+    /// `food_pos` with every bearing sign flipped. Episodic training
+    /// alternates between the two layouts so a constant per-agent turn
+    /// bias earns nothing on average — only vision-conditional turning
+    /// pays off.
+    mirrored_food_pos: Vec<(f32, f32, f32)>,
     heights: Vec<f32>,
     biomes: Vec<u32>,
     agent_data: Vec<(glam::Vec3, f32, f32, usize, usize)>,
@@ -1754,15 +1760,26 @@ struct ProbeArena {
 impl ProbeArena {
     /// Reset every agent body to its spawn pose (full energy, facing +Z)
     /// and restore all food items, without touching learned brain state.
-    fn reset_bodies(&mut self) {
+    /// `mirror_food` selects the bearing-flipped food layout.
+    fn reset_bodies_with(&mut self, mirror_food: bool) {
+        let food = if mirror_food {
+            &self.mirrored_food_pos
+        } else {
+            &self.food_pos
+        };
         self.kernel.upload_world(
             &self.heights,
             &self.biomes,
-            &self.food_pos,
+            food,
             &vec![false; PROBE_AGENT_COUNT],
             &vec![0.0; PROBE_AGENT_COUNT],
         );
         self.kernel.upload_agents(&self.agent_data);
+    }
+
+    /// Reset with the canonical (unmirrored) food layout.
+    fn reset_bodies(&mut self) {
+        self.reset_bodies_with(false);
     }
 }
 
@@ -1787,6 +1804,7 @@ fn build_probe_arena(brain: &BrainConfig, brain_seed: u64) -> ProbeArena {
 
     let mut agent_pos = Vec::with_capacity(PROBE_AGENT_COUNT);
     let mut food_pos = Vec::with_capacity(PROBE_AGENT_COUNT);
+    let mut mirrored_food_pos = Vec::with_capacity(PROBE_AGENT_COUNT);
     let grid_center = (PROBE_GRID_SIDE - 1) as f32 / 2.0;
     for ix in 0..PROBE_GRID_SIDE {
         for iz in 0..PROBE_GRID_SIDE {
@@ -1801,6 +1819,11 @@ fn build_probe_arena(brain: &BrainConfig, brain_seed: u64) -> ProbeArena {
             };
             food_pos.push((
                 x + bearing.sin() * PROBE_FOOD_DISTANCE,
+                PROBE_FOOD_Y,
+                z + bearing.cos() * PROBE_FOOD_DISTANCE,
+            ));
+            mirrored_food_pos.push((
+                x - bearing.sin() * PROBE_FOOD_DISTANCE,
                 PROBE_FOOD_Y,
                 z + bearing.cos() * PROBE_FOOD_DISTANCE,
             ));
@@ -1823,6 +1846,7 @@ fn build_probe_arena(brain: &BrainConfig, brain_seed: u64) -> ProbeArena {
         kernel,
         agent_pos,
         food_pos,
+        mirrored_food_pos,
         heights,
         biomes,
         agent_data,
@@ -2023,14 +2047,129 @@ fn learning_probe_free_run_foraging_baseline() {
     );
 }
 
-/// Phase-1 gate: episodic food-reaching practice must teach the policy to
-/// turn toward food. Agents repeatedly start from the same pose with food
-/// at a fixed bearing; eating produces the energy reward that TD(λ) credit
-/// propagates back through the eligibility traces to the approach turns.
-/// After training, a stationary evaluation (same metric as the baseline
-/// probe) must score above the chance band's upper edge.
+/// Vision-acuity check: the default 17×13 grid has a horizon-grazing ray
+/// row (odd row count) that passes a constant 0.65 below eye level —
+/// inside the 1.0 food hit radius — so ground-level food straight ahead is
+/// visible at every probed distance out to near the 30-unit vision range.
+/// The 8×6 control documents what the upgrade buys: its lowest
+/// below-horizon row strikes flat ground ≈ 5.5 units out, so food at 20 is
+/// geometrically invisible regardless of bearing.
 #[test]
-fn learning_probe_td_learns_turn_alignment() {
+fn vision_horizon_row_sees_food_at_range() {
+    use xagent_brain::buffers::PHYS_STRIDE;
+    use xagent_brain::GpuKernel;
+
+    if !GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    /// Probed agent→food distances (one agent per distance). 25 stays
+    /// inside the 30-unit ray-march range with sampling slack.
+    const PROBE_DISTANCES: [f32; 5] = [5.0, 10.0, 15.0, 20.0, 25.0];
+    /// Row spacing for the five probe agents: exactly 2× the vision range
+    /// (mutual invisibility) while keeping the outermost agents at x = ±120,
+    /// inside the ±128 world bound — an agent clamped at the boundary would
+    /// slide off its food's ray column.
+    const RANGE_PROBE_SPACING: f32 = 60.0;
+
+    // One agent per distance, on the same spaced grid as the learning
+    // probes, each with one food item straight ahead (+Z) on flat ground.
+    let build = |brain: &BrainConfig| -> (GpuKernel, Vec<usize>) {
+        let world_config = WorldConfig {
+            seed: 1,
+            ..Default::default()
+        };
+        let count = PROBE_DISTANCES.len();
+        let mut kernel = GpuKernel::new(count as u32, count, brain, &world_config);
+        kernel.reset_agents_seeded(brain, 29);
+        let heights = vec![0.0_f32; PROBE_TERRAIN_VPS * PROBE_TERRAIN_VPS];
+        let biomes = vec![0_u32; PROBE_BIOME_RES * PROBE_BIOME_RES];
+        let mut agent_data = Vec::with_capacity(count);
+        let mut food_pos = Vec::with_capacity(count);
+        for (i, &dist) in PROBE_DISTANCES.iter().enumerate() {
+            let x = (i as f32 - (count - 1) as f32 / 2.0) * RANGE_PROBE_SPACING;
+            agent_data.push((
+                glam::Vec3::new(x, PROBE_AGENT_Y, 0.0),
+                100.0,
+                100.0,
+                brain.memory_capacity,
+                brain.processing_slots,
+            ));
+            food_pos.push((x, PROBE_FOOD_Y, dist));
+        }
+        kernel.upload_world(
+            &heights,
+            &biomes,
+            &food_pos,
+            &vec![false; count],
+            &vec![0.0; count],
+        );
+        kernel.upload_agents(&agent_data);
+        kernel.dispatch_batch(0, 1);
+        let mut seen = Vec::new();
+        let state_alive: Vec<f32> = kernel.read_full_state_blocking().to_vec();
+        for i in 0..count {
+            assert!(
+                state_alive[i * PHYS_STRIDE + xagent_brain::buffers::P_ALIVE] > 0.5,
+                "probe agent {i} died during the single vision tick"
+            );
+            let telemetry = kernel.read_agent_telemetry_blocking(i as u32);
+            if count_food_pixels(&telemetry.vision_color) > 0 {
+                seen.push(i);
+            }
+        }
+        (kernel, seen)
+    };
+
+    // Default grid (17×13): every distance must be visible.
+    let default_brain = probe_brain_config();
+    let (_, seen_default) = build(&default_brain);
+    assert_eq!(
+        seen_default,
+        (0..PROBE_DISTANCES.len()).collect::<Vec<_>>(),
+        "default grid: food must be visible at every probed distance \
+         {PROBE_DISTANCES:?} (missing indices = blind distances)"
+    );
+
+    // 8×6 control: distal food must be geometrically invisible. If this
+    // ever starts passing, the control no longer documents the contrast.
+    let legacy_brain = BrainConfig {
+        vision_width: 8,
+        vision_height: 6,
+        ..probe_brain_config()
+    };
+    let (_, seen_legacy) = build(&legacy_brain);
+    assert!(
+        !seen_legacy.contains(&3),
+        "8×6 control: food at distance 20 should be invisible (vertical ray \
+         gap), but was seen — the control premise broke"
+    );
+    eprintln!(
+        "vision range probe: 17×13 sees {:?}, 8×6 sees {:?} (indices into {PROBE_DISTANCES:?})",
+        seen_default, seen_legacy
+    );
+}
+
+/// Honest directional probe (confound-free protocol).
+///
+/// Each training episode mirrors the food side, so a constant per-agent
+/// turn bias earns nothing on average — only genuinely vision-conditional
+/// turning ("turn toward where the food is seen") is rewarded. After
+/// training, the stationary alignment evaluation currently lands at chance:
+/// TD(λ) credit through the random-projection encoder does **not** yet
+/// teach vision-conditional steering. This test pins that honest baseline
+/// (same falsifiable pattern as `learning_probe_baseline_turn_alignment_is_chance`):
+/// a representation/credit change that finally produces directional
+/// steering will push the rate out of the chance band and trip this test,
+/// which is the signal to re-pin it upward.
+///
+/// (An earlier version mirrored nothing and reported ~0.64 "learning"; that
+/// number was inflated by per-agent side-consistency — each agent always
+/// saw food on one side in both training and eval — not by directional
+/// learning. See docs/superpowers/specs/2026-06-10-learning-baseline.md.)
+#[test]
+fn learning_probe_mirrored_steering_is_chance() {
     use xagent_brain::buffers::{PHYS_STRIDE, P_FOOD_COUNT};
 
     if !xagent_brain::GpuKernel::is_available() {
@@ -2038,8 +2177,7 @@ fn learning_probe_td_learns_turn_alignment() {
         return;
     }
 
-    /// Training episodes. Each starts from the identical pose so the
-    /// food-approach experience repeats enough for value bootstrapping.
+    /// Training episodes, food side alternating each episode.
     const TRAIN_EPISODES: usize = 120;
     /// Ticks per episode: at single-tick strides and default speed an agent
     /// heading roughly toward its food (5 units away) eats within ~30
@@ -2049,9 +2187,6 @@ fn learning_probe_td_learns_turn_alignment() {
     const EVAL_TICKS: usize = 60;
     /// Minimum scored evaluation samples.
     const MIN_SCORED_SAMPLES: usize = 200;
-    /// The gate: the baseline chance band tops out at 0.62; trained
-    /// alignment must clear it.
-    const GATE_RATE: f64 = 0.62;
 
     // Training config: single-tick strides (fresh vision every tick —
     // densest TD transitions) with normal movement so food is reachable.
@@ -2063,29 +2198,22 @@ fn learning_probe_td_learns_turn_alignment() {
     let mut arena = build_probe_arena(&train_brain, 17);
 
     let mut tick_cursor = 0_u64;
-    let mut food_first_half = 0.0_f32;
-    let mut food_second_half = 0.0_f32;
+    let mut food_total = 0.0_f32;
     for episode in 0..TRAIN_EPISODES {
-        arena.reset_bodies();
+        // Alternate the food side so only vision-conditional turning pays.
+        arena.reset_bodies_with(episode % 2 == 1);
         arena.kernel.dispatch_batch(tick_cursor, EPISODE_TICKS);
         tick_cursor += u64::from(EPISODE_TICKS);
-
-        // Episode food count (upload_agents zeroes P_FOOD_COUNT each reset).
         let state = arena.kernel.read_full_state_blocking();
-        let mut episode_food = 0.0_f32;
         for a in 0..PROBE_AGENT_COUNT {
-            episode_food += state[a * PHYS_STRIDE + P_FOOD_COUNT];
-        }
-        if episode < TRAIN_EPISODES / 2 {
-            food_first_half += episode_food;
-        } else {
-            food_second_half += episode_food;
+            food_total += state[a * PHYS_STRIDE + P_FOOD_COUNT];
         }
     }
-    eprintln!(
-        "learning probe TD training: food first-half={food_first_half} \
-         second-half={food_second_half} (of {} possible per half)",
-        PROBE_AGENT_COUNT * TRAIN_EPISODES / 2
+    // Sanity: agents do reach food during training (the arena works and the
+    // policy is not paralyzed) — this is foraging, not directional steering.
+    assert!(
+        food_total > 0.0,
+        "no food eaten across {TRAIN_EPISODES} training episodes — arena broke"
     );
 
     // Evaluation: pin the agents (zero movement speed) via the heritable
@@ -2101,15 +2229,21 @@ fn learning_probe_td_learns_turn_alignment() {
     let (correct, scored) = score_turn_alignment(&mut arena, tick_cursor, EVAL_TICKS);
 
     let rate = correct as f64 / scored.max(1) as f64;
-    eprintln!("learning probe TD trained: turn/bearing alignment {correct}/{scored} = {rate:.3}");
+    eprintln!(
+        "mirrored steering probe: food={food_total}, turn/bearing alignment \
+         {correct}/{scored} = {rate:.3}"
+    );
     assert!(
         scored >= MIN_SCORED_SAMPLES,
         "only {scored} scored samples — evaluation geometry broke"
     );
+    // Honest baseline: vision-conditional steering is at chance. If a future
+    // change produces real directional steering, `rate` leaves this band and
+    // this assertion fires — re-pin it then.
     assert!(
-        rate > GATE_RATE,
-        "trained turn/bearing alignment {rate:.3} did not clear the gate {GATE_RATE} — \
-         TD credit is not reaching the food-approach turns"
+        (0.38..=0.62).contains(&rate),
+        "mirrored turn/bearing alignment {rate:.3} left the chance band [0.38, 0.62] — \
+         if directional steering emerged, re-pin this baseline upward"
     );
 }
 
@@ -2170,7 +2304,8 @@ fn td_critic_tracks_metabolic_drain() {
 #[test]
 fn td_traces_bounded_across_deaths() {
     use xagent_brain::buffers::{
-        O_TRACE_CRITIC, O_TRACE_FWD, O_TRACE_TURN, PHYS_STRIDE, P_DEATH_COUNT,
+        BrainLayout, ENCODED_DIMENSION, O_PREDICTOR_CONTEXT_WEIGHT, O_TRACE_CRITIC, O_TRACE_FWD,
+        O_TRACE_TURN, PHYS_STRIDE, PREDICTOR_DIMENSION, P_DEATH_COUNT,
     };
 
     if !xagent_brain::GpuKernel::is_available() {
@@ -2207,14 +2342,21 @@ fn td_traces_bounded_across_deaths() {
         "no deaths in the all-danger arena — the death path never ran"
     );
 
+    // Trace offsets, rebased onto the live layout: the tail deltas from
+    // O_PREDICTOR_CONTEXT_WEIGHT are vision-independent.
+    let layout = BrainLayout::new(brain.vision_width, brain.vision_height);
+    let tail_base = layout.feature_count * ENCODED_DIMENSION
+        + ENCODED_DIMENSION
+        + PREDICTOR_DIMENSION * ENCODED_DIMENSION;
     for a in 0..PROBE_AGENT_COUNT {
         let brain_state = arena.kernel.read_agent_state(a as u32).brain_state;
-        for d in 0..xagent_brain::buffers::ENCODED_DIMENSION {
-            for (name, off) in [
+        for d in 0..ENCODED_DIMENSION {
+            for (name, static_off) in [
                 ("critic", O_TRACE_CRITIC),
                 ("fwd", O_TRACE_FWD),
                 ("turn", O_TRACE_TURN),
             ] {
+                let off = tail_base + (static_off - O_PREDICTOR_CONTEXT_WEIGHT);
                 let z = brain_state[off + d];
                 assert!(
                     z.is_finite() && z.abs() <= TRACE_BOUND,

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1694,12 +1694,13 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
 // learning changes can be evaluated against recorded numbers instead of
 // intuition. See docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md.
 
-/// Probe agents per arena (4×4 grid). An even count keeps left/right food
-/// bearings balanced so a systematic turn bias cannot masquerade as
-/// food-seeking; 16 agents give several hundred scored samples per run.
-const PROBE_AGENT_COUNT: usize = 16;
-/// Agents per side of the square probe grid.
+/// Agents per side of the square probe grid. Must stay even so the derived
+/// agent count is even: alternating left/right food bearings then balance
+/// exactly, and a systematic turn bias cannot masquerade as food-seeking.
 const PROBE_GRID_SIDE: usize = 4;
+/// Probe agents per arena — derived from the grid side so the two can
+/// never drift. 16 agents give several hundred scored samples per run.
+const PROBE_AGENT_COUNT: usize = PROBE_GRID_SIDE * PROBE_GRID_SIDE;
 /// Spacing between probe agents. Greater than 2× the vision range (30) so
 /// no probe agent can ever see another agent or another agent's food item.
 const PROBE_AGENT_SPACING: f32 = 64.0;

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1739,17 +1739,35 @@ fn probe_brain_config() -> BrainConfig {
     }
 }
 
-/// Build a flat, hazard-free arena with one food item per agent at a fixed
-/// bearing (alternating right/left per agent index). Returns the kernel,
-/// the agent spawn positions, and the food positions.
-fn build_probe_arena(
-    brain: &BrainConfig,
-    brain_seed: u64,
-) -> (
-    xagent_brain::GpuKernel,
-    Vec<glam::Vec3>,
-    Vec<(f32, f32, f32)>,
-) {
+/// Flat, hazard-free probe arena: one food item per agent at a fixed
+/// bearing (alternating right/left per agent index), with everything
+/// needed to re-pin the bodies for episodic training.
+struct ProbeArena {
+    kernel: xagent_brain::GpuKernel,
+    agent_pos: Vec<glam::Vec3>,
+    food_pos: Vec<(f32, f32, f32)>,
+    heights: Vec<f32>,
+    biomes: Vec<u32>,
+    agent_data: Vec<(glam::Vec3, f32, f32, usize, usize)>,
+}
+
+impl ProbeArena {
+    /// Reset every agent body to its spawn pose (full energy, facing +Z)
+    /// and restore all food items, without touching learned brain state.
+    fn reset_bodies(&mut self) {
+        self.kernel.upload_world(
+            &self.heights,
+            &self.biomes,
+            &self.food_pos,
+            &vec![false; PROBE_AGENT_COUNT],
+            &vec![0.0; PROBE_AGENT_COUNT],
+        );
+        self.kernel.upload_agents(&self.agent_data);
+    }
+}
+
+/// Build the probe arena with freshly seeded brains.
+fn build_probe_arena(brain: &BrainConfig, brain_seed: u64) -> ProbeArena {
     let world_config = WorldConfig {
         seed: 1,
         ..Default::default()
@@ -1789,13 +1807,6 @@ fn build_probe_arena(
         }
     }
 
-    kernel.upload_world(
-        &heights,
-        &biomes,
-        &food_pos,
-        &vec![false; PROBE_AGENT_COUNT],
-        &vec![0.0; PROBE_AGENT_COUNT],
-    );
     let agent_data: Vec<(glam::Vec3, f32, f32, usize, usize)> = agent_pos
         .iter()
         .map(|&pos| {
@@ -1808,8 +1819,68 @@ fn build_probe_arena(
             )
         })
         .collect();
-    kernel.upload_agents(&agent_data);
-    (kernel, agent_pos, food_pos)
+    let mut arena = ProbeArena {
+        kernel,
+        agent_pos,
+        food_pos,
+        heights,
+        biomes,
+        agent_data,
+    };
+    arena.reset_bodies();
+    arena
+}
+
+/// Run `ticks` single-tick batches and score the sign of each turn output
+/// against the food bearing at the moment the brain's vision frame was
+/// captured (single-tick sensory lag). Assumes stationary agents (zero
+/// movement speed). Returns (correct, scored). Skips the first two ticks
+/// (no real frame yet), bearings outside the reliable vision window, and
+/// exactly-zero motor values.
+fn score_turn_alignment(arena: &mut ProbeArena, start_tick: u64, ticks: usize) -> (usize, usize) {
+    use std::f32::consts::{PI, TAU};
+    use xagent_brain::buffers::{PHYS_STRIDE, P_MOTOR_TURN_OUT, P_YAW};
+
+    /// Bearing window for scoring. Above 0.6 rad the food nears the FOV
+    /// edge (0.785 rad half-FOV) where ray coverage degrades; below
+    /// 0.05 rad the correct turn direction is ambiguous.
+    const BEARING_MAX: f32 = 0.6;
+    const BEARING_MIN: f32 = 0.05;
+
+    let mut prev_yaw = vec![0.0_f32; PROBE_AGENT_COUNT];
+    let mut correct = 0_usize;
+    let mut scored = 0_usize;
+
+    for t in 0..ticks {
+        arena.kernel.dispatch_batch(start_tick + t as u64, 1);
+        let state = arena.kernel.read_full_state_blocking();
+        for a in 0..PROBE_AGENT_COUNT {
+            let base = a * PHYS_STRIDE;
+            let yaw = state[base + P_YAW];
+            let motor_turn = state[base + P_MOTOR_TURN_OUT];
+            if t >= 2 {
+                let dx = arena.food_pos[a].0 - arena.agent_pos[a].x;
+                let dz = arena.food_pos[a].2 - arena.agent_pos[a].z;
+                let world_bearing = dx.atan2(dz);
+                let mut bearing = world_bearing - prev_yaw[a];
+                while bearing > PI {
+                    bearing -= TAU;
+                }
+                while bearing < -PI {
+                    bearing += TAU;
+                }
+                if bearing.abs() >= BEARING_MIN && bearing.abs() <= BEARING_MAX && motor_turn != 0.0
+                {
+                    scored += 1;
+                    if (motor_turn > 0.0) == (bearing > 0.0) {
+                        correct += 1;
+                    }
+                }
+            }
+            prev_yaw[a] = yaw;
+        }
+    }
+    (correct, scored)
 }
 
 /// Count vision rays reporting the food color (lime green, matching the
@@ -1835,15 +1906,15 @@ fn learning_probe_food_is_visible() {
         return;
     }
     let brain = probe_brain_config();
-    let (mut kernel, _, _) = build_probe_arena(&brain, 7);
+    let mut arena = build_probe_arena(&brain, 7);
 
     // One single-tick batch: pass order is kernel → global (grid rebuild)
     // → vision, so the food grid is populated and one vision frame exists.
-    kernel.dispatch_batch(0, 1);
+    arena.kernel.dispatch_batch(0, 1);
 
     let mut blind_agents = Vec::new();
     for agent in 0..PROBE_AGENT_COUNT {
-        let telemetry = kernel.read_agent_telemetry_blocking(agent as u32);
+        let telemetry = arena.kernel.read_agent_telemetry_blocking(agent as u32);
         if count_food_pixels(&telemetry.vision_color) == 0 {
             blind_agents.push(agent);
         }
@@ -1862,9 +1933,6 @@ fn learning_probe_food_is_visible() {
 /// documents (and pins) today's chance-level baseline.
 #[test]
 fn learning_probe_baseline_turn_alignment_is_chance() {
-    use std::f32::consts::{PI, TAU};
-    use xagent_brain::buffers::{PHYS_STRIDE, P_MOTOR_TURN_OUT, P_YAW};
-
     if !xagent_brain::GpuKernel::is_available() {
         eprintln!("Skipping: no GPU/fallback adapter available");
         return;
@@ -1872,56 +1940,14 @@ fn learning_probe_baseline_turn_alignment_is_chance() {
 
     /// Single-tick batches dispatched (= brain decisions sampled per agent).
     const PROBE_TICKS: usize = 60;
-    /// Bearing window for scoring. Above 0.6 rad the food nears the FOV
-    /// edge (0.785 rad half-FOV) where ray coverage degrades; below
-    /// 0.05 rad the correct turn direction is ambiguous.
-    const BEARING_MAX: f32 = 0.6;
-    const BEARING_MIN: f32 = 0.05;
     /// Minimum scored samples for the rate to be statistically meaningful
     /// (binomial σ ≈ 0.035 at n = 200).
     const MIN_SCORED_SAMPLES: usize = 200;
 
     let brain = probe_brain_config();
-    let (mut kernel, agent_pos, food_pos) = build_probe_arena(&brain, 11);
+    let mut arena = build_probe_arena(&brain, 11);
 
-    let mut prev_yaw = vec![0.0_f32; PROBE_AGENT_COUNT];
-    let mut correct = 0_usize;
-    let mut scored = 0_usize;
-
-    for t in 0..PROBE_TICKS {
-        kernel.dispatch_batch(t as u64, 1);
-        let state = kernel.read_full_state_blocking();
-        for a in 0..PROBE_AGENT_COUNT {
-            let base = a * PHYS_STRIDE;
-            let yaw = state[base + P_YAW];
-            let motor_turn = state[base + P_MOTOR_TURN_OUT];
-            // The motor value produced this tick was computed from the
-            // vision frame captured at the end of the previous tick, when
-            // the agent's yaw was `prev_yaw` (single-tick sensory lag).
-            // Skip the first two ticks: tick 0's brain saw zeroed senses
-            // and tick 1 is the first decision on a real frame.
-            if t >= 2 {
-                let dx = food_pos[a].0 - agent_pos[a].x;
-                let dz = food_pos[a].2 - agent_pos[a].z;
-                let world_bearing = dx.atan2(dz);
-                let mut bearing = world_bearing - prev_yaw[a];
-                while bearing > PI {
-                    bearing -= TAU;
-                }
-                while bearing < -PI {
-                    bearing += TAU;
-                }
-                if bearing.abs() >= BEARING_MIN && bearing.abs() <= BEARING_MAX && motor_turn != 0.0
-                {
-                    scored += 1;
-                    if (motor_turn > 0.0) == (bearing > 0.0) {
-                        correct += 1;
-                    }
-                }
-            }
-            prev_yaw[a] = yaw;
-        }
-    }
+    let (correct, scored) = score_turn_alignment(&mut arena, 0, PROBE_TICKS);
 
     let rate = correct as f64 / scored.max(1) as f64;
     eprintln!("learning probe baseline: turn/bearing alignment {correct}/{scored} = {rate:.3}");
@@ -1931,12 +1957,12 @@ fn learning_probe_baseline_turn_alignment_is_chance() {
          or the probe geometry broke"
     );
     // ±6σ band around chance for the sample sizes this probe produces.
-    // The current learner sits at ≈ 0.5; a working spatial learner must
-    // exceed the upper bound (re-pin the band when that lands).
+    // An untrained policy sits at ≈ 0.5; without reward events in this
+    // stationary arena, nothing should push it off chance.
     assert!(
         (0.38..=0.62).contains(&rate),
         "turn/bearing alignment {rate:.3} is outside the chance band [0.38, 0.62] — \
-         either learning emerged (update this baseline) or a directional bias crept in"
+         a directional bias crept into the untrained policy"
     );
 }
 
@@ -1961,20 +1987,20 @@ fn learning_probe_free_run_foraging_baseline() {
     const MAX_DEATH_TICK_GAP: f32 = 100.0;
 
     let brain = BrainConfig::default();
-    let (mut kernel, _, _) = build_probe_arena(&brain, 13);
+    let mut arena = build_probe_arena(&brain, 13);
 
-    let batch = kernel.kernel_batch_size();
+    let batch = arena.kernel.kernel_batch_size();
     assert!(
         RUN_TICKS % batch == 0,
         "RUN_TICKS {RUN_TICKS} must be a multiple of kernel_batch_size {batch}"
     );
     let mut tick = 0_u64;
     while tick < u64::from(RUN_TICKS) {
-        kernel.dispatch_batch(tick, batch);
+        arena.kernel.dispatch_batch(tick, batch);
         tick += u64::from(batch);
     }
 
-    let state = kernel.read_full_state_blocking();
+    let state = arena.kernel.read_full_state_blocking();
     let mut total_food = 0.0_f32;
     let mut total_deaths = 0.0_f32;
     for a in 0..PROBE_AGENT_COUNT {
@@ -1995,4 +2021,208 @@ fn learning_probe_free_run_foraging_baseline() {
         "learning probe baseline: food={total_food} deaths={total_deaths} \
          food/agent/1k-ticks={food_per_agent_per_1k:.3}"
     );
+}
+
+/// Phase-1 gate: episodic food-reaching practice must teach the policy to
+/// turn toward food. Agents repeatedly start from the same pose with food
+/// at a fixed bearing; eating produces the energy reward that TD(λ) credit
+/// propagates back through the eligibility traces to the approach turns.
+/// After training, a stationary evaluation (same metric as the baseline
+/// probe) must score above the chance band's upper edge.
+#[test]
+fn learning_probe_td_learns_turn_alignment() {
+    use xagent_brain::buffers::{PHYS_STRIDE, P_FOOD_COUNT};
+
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    /// Training episodes. Each starts from the identical pose so the
+    /// food-approach experience repeats enough for value bootstrapping.
+    const TRAIN_EPISODES: usize = 120;
+    /// Ticks per episode: at single-tick strides and default speed an agent
+    /// heading roughly toward its food (5 units away) eats within ~30
+    /// ticks, leaving slack for indirect paths.
+    const EPISODE_TICKS: u32 = 100;
+    /// Evaluation ticks (same scale as the baseline probe).
+    const EVAL_TICKS: usize = 60;
+    /// Minimum scored evaluation samples.
+    const MIN_SCORED_SAMPLES: usize = 200;
+    /// The gate: the baseline chance band tops out at 0.62; trained
+    /// alignment must clear it.
+    const GATE_RATE: f64 = 0.62;
+
+    // Training config: single-tick strides (fresh vision every tick —
+    // densest TD transitions) with normal movement so food is reachable.
+    let train_brain = BrainConfig {
+        brain_tick_stride: 1,
+        vision_stride: 1,
+        ..Default::default()
+    };
+    let mut arena = build_probe_arena(&train_brain, 17);
+
+    let mut tick_cursor = 0_u64;
+    let mut food_first_half = 0.0_f32;
+    let mut food_second_half = 0.0_f32;
+    for episode in 0..TRAIN_EPISODES {
+        arena.reset_bodies();
+        arena.kernel.dispatch_batch(tick_cursor, EPISODE_TICKS);
+        tick_cursor += u64::from(EPISODE_TICKS);
+
+        // Episode food count (upload_agents zeroes P_FOOD_COUNT each reset).
+        let state = arena.kernel.read_full_state_blocking();
+        let mut episode_food = 0.0_f32;
+        for a in 0..PROBE_AGENT_COUNT {
+            episode_food += state[a * PHYS_STRIDE + P_FOOD_COUNT];
+        }
+        if episode < TRAIN_EPISODES / 2 {
+            food_first_half += episode_food;
+        } else {
+            food_second_half += episode_food;
+        }
+    }
+    eprintln!(
+        "learning probe TD training: food first-half={food_first_half} \
+         second-half={food_second_half} (of {} possible per half)",
+        PROBE_AGENT_COUNT * TRAIN_EPISODES / 2
+    );
+
+    // Evaluation: pin the agents (zero movement speed) via the heritable
+    // config patch — learned weights stay intact — and score alignment
+    // exactly like the baseline probe.
+    let eval_brain = probe_brain_config();
+    for a in 0..PROBE_AGENT_COUNT {
+        arena
+            .kernel
+            .write_agent_heritable_config(a as u32, &eval_brain);
+    }
+    arena.reset_bodies();
+    let (correct, scored) = score_turn_alignment(&mut arena, tick_cursor, EVAL_TICKS);
+
+    let rate = correct as f64 / scored.max(1) as f64;
+    eprintln!("learning probe TD trained: turn/bearing alignment {correct}/{scored} = {rate:.3}");
+    assert!(
+        scored >= MIN_SCORED_SAMPLES,
+        "only {scored} scored samples — evaluation geometry broke"
+    );
+    assert!(
+        rate > GATE_RATE,
+        "trained turn/bearing alignment {rate:.3} did not clear the gate {GATE_RATE} — \
+         TD credit is not reaching the food-approach turns"
+    );
+}
+
+/// The critic must learn that the steady metabolic drain makes every state
+/// slightly negative-valued: with stationary agents and no food events, the
+/// value telemetry should settle below zero, and every TD error must
+/// respect the MAX_TD_ERROR clamp.
+#[test]
+fn td_critic_tracks_metabolic_drain() {
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    /// Enough ticks for the linear critic to converge on the constant-drain
+    /// signal (time constant ≈ 100 brain ticks at the critic rate).
+    const RUN_TICKS: usize = 300;
+
+    let brain = probe_brain_config();
+    let mut arena = build_probe_arena(&brain, 19);
+
+    for t in 0..RUN_TICKS {
+        arena.kernel.dispatch_batch(t as u64, 1);
+    }
+
+    let mut value_sum = 0.0_f32;
+    for a in 0..PROBE_AGENT_COUNT {
+        let telemetry = arena.kernel.read_agent_telemetry_blocking(a as u32);
+        assert!(
+            telemetry.value.is_finite() && telemetry.td_error.is_finite(),
+            "agent {a}: non-finite critic telemetry (value={}, td_error={})",
+            telemetry.value,
+            telemetry.td_error
+        );
+        assert!(
+            telemetry.td_error.abs() <= 1.0,
+            "agent {a}: td_error {} exceeds the MAX_TD_ERROR clamp",
+            telemetry.td_error
+        );
+        value_sum += telemetry.value;
+    }
+    let mean_value = value_sum / PROBE_AGENT_COUNT as f32;
+    eprintln!("td critic drain probe: mean value {mean_value:.5}");
+    assert!(
+        mean_value < -1e-4,
+        "mean value {mean_value:.5} did not go negative under constant drain — \
+         the critic is not learning"
+    );
+    assert!(
+        mean_value > -1.0,
+        "mean value {mean_value:.5} is implausibly negative for a drain of ~1e-3/tick"
+    );
+}
+
+/// Eligibility traces are episodic: after deaths they must have been reset
+/// (and rebuilt only from post-respawn experience), so they stay bounded by
+/// the geometric trace limit instead of accumulating across lives.
+#[test]
+fn td_traces_bounded_across_deaths() {
+    use xagent_brain::buffers::{
+        O_TRACE_CRITIC, O_TRACE_FWD, O_TRACE_TURN, PHYS_STRIDE, P_DEATH_COUNT,
+    };
+
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    /// Hazard damage (1.0/tick at default rates) kills a 100-integrity
+    /// agent in ~100 ticks; 350 ticks guarantees repeated deaths.
+    const RUN_TICKS: usize = 350;
+    /// Geometric trace bound: |s_encoded| ≤ 1 per dim and noise ≤ 0.5, so
+    /// |z| ≤ 1/(1 − γλ) ≈ 7.9. Allow generous slack for the brief
+    /// post-respawn rebuild before asserting runaway accumulation.
+    const TRACE_BOUND: f32 = 50.0;
+
+    let brain = probe_brain_config();
+    let mut arena = build_probe_arena(&brain, 23);
+    // All-danger biome: every spawn fallback lands in hazard, so agents die
+    // on a ~100-tick cycle.
+    arena.biomes = vec![2_u32; PROBE_BIOME_RES * PROBE_BIOME_RES];
+    arena.reset_bodies();
+
+    for t in 0..RUN_TICKS {
+        arena.kernel.dispatch_batch(t as u64, 1);
+    }
+
+    let state = arena.kernel.read_full_state_blocking();
+    let mut total_deaths = 0.0_f32;
+    for a in 0..PROBE_AGENT_COUNT {
+        total_deaths += state[a * PHYS_STRIDE + P_DEATH_COUNT];
+    }
+    assert!(
+        total_deaths >= 1.0,
+        "no deaths in the all-danger arena — the death path never ran"
+    );
+
+    for a in 0..PROBE_AGENT_COUNT {
+        let brain_state = arena.kernel.read_agent_state(a as u32).brain_state;
+        for d in 0..xagent_brain::buffers::ENCODED_DIMENSION {
+            for (name, off) in [
+                ("critic", O_TRACE_CRITIC),
+                ("fwd", O_TRACE_FWD),
+                ("turn", O_TRACE_TURN),
+            ] {
+                let z = brain_state[off + d];
+                assert!(
+                    z.is_finite() && z.abs() <= TRACE_BOUND,
+                    "agent {a}: {name} trace[{d}] = {z} out of bounds after \
+                     {total_deaths} deaths — traces are leaking across lives"
+                );
+            }
+        }
+    }
+    eprintln!("td trace death probe: {total_deaths} deaths, traces bounded");
 }

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -2047,11 +2047,11 @@ fn learning_probe_free_run_foraging_baseline() {
     );
 }
 
-/// Vision-acuity check: the default 17×13 grid has a horizon-grazing ray
+/// Vision-acuity check: the 17×13 odd grid has a horizon-grazing ray
 /// row (odd row count) that passes a constant 0.65 below eye level —
 /// inside the 1.0 food hit radius — so ground-level food straight ahead is
 /// visible at every probed distance out to near the 30-unit vision range.
-/// The 8×6 control documents what the upgrade buys: its lowest
+/// The 8×6 default documents what the upgrade buys: its lowest
 /// below-horizon row strikes flat ground ≈ 5.5 units out, so food at 20 is
 /// geometrically invisible regardless of bearing.
 #[test]

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1703,19 +1703,18 @@ const PROBE_GRID_SIDE: usize = 4;
 /// Spacing between probe agents. Greater than 2× the vision range (30) so
 /// no probe agent can ever see another agent or another agent's food item.
 const PROBE_AGENT_SPACING: f32 = 64.0;
-/// Horizontal agent→food distance. Comfortably inside the default
-/// 17×13 grid's full-bearing visibility band (the horizon ray row passes a
-/// constant 0.65 below eye level — within the 1.0 food hit radius — and at
-/// this range the per-column capture cones overlap, so any bearing inside
-/// the FOV sees the food), while staying beyond both the touch range (3.0)
-/// and the food consume radius (2.0) so a stationary agent neither touches
-/// nor eats its probe target.
+/// Horizontal agent→food distance. The lowest below-horizon vision ray row
+/// (vertical slope ≈ 0.18 on the default 8×6 grid) passes within the food
+/// hit radius (1.0) at this range before the ray strikes flat ground
+/// (≈ 5.5 units out), while staying beyond both the touch range (3.0) and
+/// the food consume radius (2.0) so a stationary agent neither touches nor
+/// eats its probe target.
 const PROBE_FOOD_DISTANCE: f32 = 5.0;
 /// Food bearing magnitude relative to the agent's initial facing.
-/// atan(3/8) aligns the food exactly with a ray column of the default
-/// 17-column vision grid (column offset u = ±3/8 at 45° half-FOV), which
+/// atan(3/7) aligns the food exactly with a ray column of the default
+/// 8-column vision grid (column offset u = ±3/7 at 45° half-FOV), which
 /// maximizes ray-hit reliability at the probe distance.
-const PROBE_FOOD_BEARING: f32 = 0.358_770_67;
+const PROBE_FOOD_BEARING: f32 = 0.404_891_6;
 /// Food rest height above flat terrain (matches the kernel's
 /// FOOD_HEIGHT_OFFSET).
 const PROBE_FOOD_Y: f32 = 0.35;
@@ -2122,18 +2121,23 @@ fn vision_horizon_row_sees_food_at_range() {
         (kernel, seen)
     };
 
-    // Default grid (17×13): every distance must be visible.
-    let default_brain = probe_brain_config();
-    let (_, seen_default) = build(&default_brain);
+    // The odd-grid 17×13: a horizon ray row makes every distance visible.
+    let odd_grid = BrainConfig {
+        vision_width: 17,
+        vision_height: 13,
+        ..probe_brain_config()
+    };
+    let (_, seen_odd) = build(&odd_grid);
     assert_eq!(
-        seen_default,
+        seen_odd,
         (0..PROBE_DISTANCES.len()).collect::<Vec<_>>(),
-        "default grid: food must be visible at every probed distance \
+        "17×13: food must be visible at every probed distance \
          {PROBE_DISTANCES:?} (missing indices = blind distances)"
     );
 
-    // 8×6 control: distal food must be geometrically invisible. If this
-    // ever starts passing, the control no longer documents the contrast.
+    // 8×6 (current default): distal food must be geometrically invisible —
+    // this is the information defect the odd grid fixes. If this ever starts
+    // passing, the contrast premise broke.
     let legacy_brain = BrainConfig {
         vision_width: 8,
         vision_height: 6,
@@ -2142,12 +2146,12 @@ fn vision_horizon_row_sees_food_at_range() {
     let (_, seen_legacy) = build(&legacy_brain);
     assert!(
         !seen_legacy.contains(&3),
-        "8×6 control: food at distance 20 should be invisible (vertical ray \
+        "8×6: food at distance 20 should be invisible (vertical ray \
          gap), but was seen — the control premise broke"
     );
     eprintln!(
         "vision range probe: 17×13 sees {:?}, 8×6 sees {:?} (indices into {PROBE_DISTANCES:?})",
-        seen_default, seen_legacy
+        seen_odd, seen_legacy
     );
 }
 

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -2145,9 +2145,10 @@ fn vision_horizon_row_sees_food_at_range() {
     };
     let (_, seen_legacy) = build(&legacy_brain);
     assert!(
-        !seen_legacy.contains(&3),
-        "8×6: food at distance 20 should be invisible (vertical ray \
-         gap), but was seen — the control premise broke"
+        seen_legacy.contains(&0) && !seen_legacy.contains(&3),
+        "8×6: the near food (distance 5) must be visible and the distance-20 \
+         food invisible (vertical ray gap); got {seen_legacy:?} — the \
+         contrast premise broke"
     );
     eprintln!(
         "vision range probe: 17×13 sees {:?}, 8×6 sees {:?} (indices into {PROBE_DISTANCES:?})",

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -2251,6 +2251,101 @@ fn learning_probe_mirrored_steering_is_chance() {
     );
 }
 
+/// Diagnostic: does the encoder keep food-left and food-right linearly
+/// separable? Presents one agent (one encoder) the same scene with food on
+/// the right, then on the left, and reads the pre-habituation encoded state
+/// (`O_PREV_ENCODED`) for each. The directional signal the policy must read
+/// is `encoded(right) − encoded(left)`; this measures whether that signal
+/// rises above the within-class noise (two right-side scenes at slightly
+/// different distances).
+///
+/// Reports `between` (cosine of right vs left) against `within` (cosine of
+/// two right-side scenes). If `between ≈ within ≈ 1`, the encoder collapses
+/// the food side below the readout floor — the encoder is the binding
+/// constraint for directional steering. If `1 − between` is clearly larger
+/// than `1 − within`, the side is represented and the bottleneck is the
+/// credit/temporal path instead. Measurement-first: prints the numbers and
+/// asserts only that the read succeeded.
+#[test]
+fn encoder_food_side_separability_diagnostic() {
+    use xagent_brain::buffers::{
+        BrainLayout, ENCODED_DIMENSION, O_PREDICTOR_CONTEXT_WEIGHT, O_PREV_ENCODED,
+        PREDICTOR_DIMENSION,
+    };
+
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    let brain = probe_brain_config();
+    let world_config = WorldConfig {
+        seed: 1,
+        ..Default::default()
+    };
+    let mut kernel = xagent_brain::GpuKernel::new(1, 1, &brain, &world_config);
+    kernel.reset_agents_seeded(&brain, 31);
+    let heights = vec![0.0_f32; PROBE_TERRAIN_VPS * PROBE_TERRAIN_VPS];
+    let biomes = vec![0_u32; PROBE_BIOME_RES * PROBE_BIOME_RES];
+    let agent_data = vec![(
+        glam::Vec3::new(0.0, PROBE_AGENT_Y, 0.0),
+        100.0_f32,
+        100.0_f32,
+        brain.memory_capacity,
+        brain.processing_slots,
+    )];
+
+    let layout = BrainLayout::new(brain.vision_width, brain.vision_height);
+    let prev_encoded_off = layout.feature_count * ENCODED_DIMENSION
+        + ENCODED_DIMENSION
+        + PREDICTOR_DIMENSION * ENCODED_DIMENSION
+        + (O_PREV_ENCODED - O_PREDICTOR_CONTEXT_WEIGHT);
+
+    // Present food at a given bearing/distance and return the encoded state.
+    // Two single-tick batches: the first runs vision, the second lets the
+    // brain encode that frame into O_PREV_ENCODED.
+    let mut tick = 0_u64;
+    let mut present = |kernel: &mut xagent_brain::GpuKernel, bearing: f32, dist: f32| -> Vec<f32> {
+        let food = vec![(bearing.sin() * dist, PROBE_FOOD_Y, bearing.cos() * dist)];
+        kernel.upload_world(&heights, &biomes, &food, &[false], &[0.0]);
+        kernel.upload_agents(&agent_data); // re-pin pose (facing +Z, full energy)
+        kernel.dispatch_batch(tick, 1);
+        kernel.dispatch_batch(tick + 1, 1);
+        tick += 2;
+        let bs = kernel.read_agent_state(0).brain_state;
+        bs[prev_encoded_off..prev_encoded_off + ENCODED_DIMENSION].to_vec()
+    };
+
+    let cosine = |a: &[f32], b: &[f32]| -> f32 {
+        let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+        let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if na < 1e-8 || nb < 1e-8 {
+            0.0
+        } else {
+            dot / (na * nb)
+        }
+    };
+
+    let e_right = present(&mut kernel, PROBE_FOOD_BEARING, PROBE_FOOD_DISTANCE);
+    let e_right2 = present(&mut kernel, PROBE_FOOD_BEARING, PROBE_FOOD_DISTANCE + 1.0);
+    let e_left = present(&mut kernel, -PROBE_FOOD_BEARING, PROBE_FOOD_DISTANCE);
+
+    assert!(
+        e_right.iter().any(|v| v.abs() > 1e-6) && e_left.iter().any(|v| v.abs() > 1e-6),
+        "encoded states are all-zero — vision/encode path did not run"
+    );
+
+    let within = cosine(&e_right, &e_right2);
+    let between = cosine(&e_right, &e_left);
+    eprintln!(
+        "encoder separability: within(right,right') cos={within:.4} (dist {:.4}), \
+         between(right,left) cos={between:.4} (dist {:.4})",
+        1.0 - within,
+        1.0 - between,
+    );
+}
+
 /// The critic must learn that the steady metabolic drain makes every state
 /// slightly negative-valued: with stationary agents and no food events, the
 /// value telemetry should settle below zero, and every TD error must

--- a/crates/xagent-sandbox/tests/integration.rs
+++ b/crates/xagent-sandbox/tests/integration.rs
@@ -1685,3 +1685,314 @@ fn gpu_agents_y_matches_terrain_after_single_tick() {
         );
     }
 }
+
+// ── Learning Probe Tests ────────────────────────────────────────────────
+//
+// A controlled flat-world arena where each agent has exactly one food item
+// at a known bearing. These tests pin down the measurable baseline of the
+// current learner (turn/bearing alignment ≈ chance, foraging rate) so that
+// learning changes can be evaluated against recorded numbers instead of
+// intuition. See docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md.
+
+/// Probe agents per arena (4×4 grid). An even count keeps left/right food
+/// bearings balanced so a systematic turn bias cannot masquerade as
+/// food-seeking; 16 agents give several hundred scored samples per run.
+const PROBE_AGENT_COUNT: usize = 16;
+/// Agents per side of the square probe grid.
+const PROBE_GRID_SIDE: usize = 4;
+/// Spacing between probe agents. Greater than 2× the vision range (30) so
+/// no probe agent can ever see another agent or another agent's food item.
+const PROBE_AGENT_SPACING: f32 = 64.0;
+/// Horizontal agent→food distance. The lowest below-horizon vision ray row
+/// (vertical slope ≈ 0.18 on the default 8×6 grid) passes within the food
+/// hit radius (1.0) at this range before the ray strikes flat ground
+/// (≈ 5.5 units out), while staying beyond both the touch range (3.0) and
+/// the food consume radius (2.0) so a stationary agent neither touches nor
+/// eats its probe target.
+const PROBE_FOOD_DISTANCE: f32 = 5.0;
+/// Food bearing magnitude relative to the agent's initial facing.
+/// atan(3/7) aligns the food exactly with a ray column of the default
+/// 8-column vision grid (column offset u = ±3/7 at 45° half-FOV), which
+/// maximizes ray-hit reliability at the probe distance.
+const PROBE_FOOD_BEARING: f32 = 0.404_891_6;
+/// Food rest height above flat terrain (matches the kernel's
+/// FOOD_HEIGHT_OFFSET).
+const PROBE_FOOD_Y: f32 = 0.35;
+/// Agent center height above flat terrain (matches the kernel's
+/// AGENT_HALF_HEIGHT).
+const PROBE_AGENT_Y: f32 = 1.0;
+/// Terrain vertices per side (matches the kernel's TERRAIN_VPS).
+const PROBE_TERRAIN_VPS: usize = 129;
+/// Biome grid resolution (matches the kernel's BIOME_GRID_RES).
+const PROBE_BIOME_RES: usize = 256;
+
+/// Probe brain config: single-tick strides give one vision frame and one
+/// brain decision per physics tick (sensory lag = 1 tick), and zero
+/// movement speed pins each agent at its spawn point — turning still works,
+/// so the food bearing changes only through the agent's own rotation.
+fn probe_brain_config() -> BrainConfig {
+    BrainConfig {
+        brain_tick_stride: 1,
+        vision_stride: 1,
+        movement_speed: 0.0,
+        ..Default::default()
+    }
+}
+
+/// Build a flat, hazard-free arena with one food item per agent at a fixed
+/// bearing (alternating right/left per agent index). Returns the kernel,
+/// the agent spawn positions, and the food positions.
+fn build_probe_arena(
+    brain: &BrainConfig,
+    brain_seed: u64,
+) -> (
+    xagent_brain::GpuKernel,
+    Vec<glam::Vec3>,
+    Vec<(f32, f32, f32)>,
+) {
+    let world_config = WorldConfig {
+        seed: 1,
+        ..Default::default()
+    };
+    let mut kernel = xagent_brain::GpuKernel::new(
+        PROBE_AGENT_COUNT as u32,
+        PROBE_AGENT_COUNT,
+        brain,
+        &world_config,
+    );
+    kernel.reset_agents_seeded(brain, brain_seed);
+
+    // Flat terrain and a uniform food-rich biome: no hazards, no slopes —
+    // the only structure in the world is each agent's probe food item.
+    let heights = vec![0.0_f32; PROBE_TERRAIN_VPS * PROBE_TERRAIN_VPS];
+    let biomes = vec![0_u32; PROBE_BIOME_RES * PROBE_BIOME_RES];
+
+    let mut agent_pos = Vec::with_capacity(PROBE_AGENT_COUNT);
+    let mut food_pos = Vec::with_capacity(PROBE_AGENT_COUNT);
+    let grid_center = (PROBE_GRID_SIDE - 1) as f32 / 2.0;
+    for ix in 0..PROBE_GRID_SIDE {
+        for iz in 0..PROBE_GRID_SIDE {
+            let i = ix * PROBE_GRID_SIDE + iz;
+            let x = (ix as f32 - grid_center) * PROBE_AGENT_SPACING;
+            let z = (iz as f32 - grid_center) * PROBE_AGENT_SPACING;
+            agent_pos.push(glam::Vec3::new(x, PROBE_AGENT_Y, z));
+            let bearing = if i % 2 == 0 {
+                PROBE_FOOD_BEARING
+            } else {
+                -PROBE_FOOD_BEARING
+            };
+            food_pos.push((
+                x + bearing.sin() * PROBE_FOOD_DISTANCE,
+                PROBE_FOOD_Y,
+                z + bearing.cos() * PROBE_FOOD_DISTANCE,
+            ));
+        }
+    }
+
+    kernel.upload_world(
+        &heights,
+        &biomes,
+        &food_pos,
+        &vec![false; PROBE_AGENT_COUNT],
+        &vec![0.0; PROBE_AGENT_COUNT],
+    );
+    let agent_data: Vec<(glam::Vec3, f32, f32, usize, usize)> = agent_pos
+        .iter()
+        .map(|&pos| {
+            (
+                pos,
+                100.0,
+                100.0,
+                brain.memory_capacity,
+                brain.processing_slots,
+            )
+        })
+        .collect();
+    kernel.upload_agents(&agent_data);
+    (kernel, agent_pos, food_pos)
+}
+
+/// Count vision rays reporting the food color (lime green, matching the
+/// hit color written by the vision shader).
+fn count_food_pixels(vision_color: &[f32]) -> usize {
+    vision_color
+        .chunks_exact(4)
+        .filter(|px| {
+            (px[0] - 0.7).abs() < 0.01 && (px[1] - 0.95).abs() < 0.01 && (px[2] - 0.2).abs() < 0.01
+        })
+        .count()
+}
+
+/// Information-path check: the probe geometry must actually be visible.
+/// After one vision pass, every probe agent must have at least one ray
+/// reporting the food color. If this fails, the arena geometry (distance,
+/// bearing, ray layout) is broken and the other probe metrics are
+/// meaningless.
+#[test]
+fn learning_probe_food_is_visible() {
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+    let brain = probe_brain_config();
+    let (mut kernel, _, _) = build_probe_arena(&brain, 7);
+
+    // One single-tick batch: pass order is kernel → global (grid rebuild)
+    // → vision, so the food grid is populated and one vision frame exists.
+    kernel.dispatch_batch(0, 1);
+
+    let mut blind_agents = Vec::new();
+    for agent in 0..PROBE_AGENT_COUNT {
+        let telemetry = kernel.read_agent_telemetry_blocking(agent as u32);
+        if count_food_pixels(&telemetry.vision_color) == 0 {
+            blind_agents.push(agent);
+        }
+    }
+    assert!(
+        blind_agents.is_empty(),
+        "agents {blind_agents:?} see no food pixel at distance {PROBE_FOOD_DISTANCE} \
+         bearing ±{PROBE_FOOD_BEARING}; probe geometry no longer matches the vision ray layout"
+    );
+}
+
+/// Baseline directional-learning probe: with the current learner, the sign
+/// of the turn output should be uncorrelated with the food's bearing —
+/// alignment ≈ chance. A learner that acquires food-approach behavior must
+/// push this rate decisively above the asserted band; the band itself
+/// documents (and pins) today's chance-level baseline.
+#[test]
+fn learning_probe_baseline_turn_alignment_is_chance() {
+    use std::f32::consts::{PI, TAU};
+    use xagent_brain::buffers::{PHYS_STRIDE, P_MOTOR_TURN_OUT, P_YAW};
+
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    /// Single-tick batches dispatched (= brain decisions sampled per agent).
+    const PROBE_TICKS: usize = 60;
+    /// Bearing window for scoring. Above 0.6 rad the food nears the FOV
+    /// edge (0.785 rad half-FOV) where ray coverage degrades; below
+    /// 0.05 rad the correct turn direction is ambiguous.
+    const BEARING_MAX: f32 = 0.6;
+    const BEARING_MIN: f32 = 0.05;
+    /// Minimum scored samples for the rate to be statistically meaningful
+    /// (binomial σ ≈ 0.035 at n = 200).
+    const MIN_SCORED_SAMPLES: usize = 200;
+
+    let brain = probe_brain_config();
+    let (mut kernel, agent_pos, food_pos) = build_probe_arena(&brain, 11);
+
+    let mut prev_yaw = vec![0.0_f32; PROBE_AGENT_COUNT];
+    let mut correct = 0_usize;
+    let mut scored = 0_usize;
+
+    for t in 0..PROBE_TICKS {
+        kernel.dispatch_batch(t as u64, 1);
+        let state = kernel.read_full_state_blocking();
+        for a in 0..PROBE_AGENT_COUNT {
+            let base = a * PHYS_STRIDE;
+            let yaw = state[base + P_YAW];
+            let motor_turn = state[base + P_MOTOR_TURN_OUT];
+            // The motor value produced this tick was computed from the
+            // vision frame captured at the end of the previous tick, when
+            // the agent's yaw was `prev_yaw` (single-tick sensory lag).
+            // Skip the first two ticks: tick 0's brain saw zeroed senses
+            // and tick 1 is the first decision on a real frame.
+            if t >= 2 {
+                let dx = food_pos[a].0 - agent_pos[a].x;
+                let dz = food_pos[a].2 - agent_pos[a].z;
+                let world_bearing = dx.atan2(dz);
+                let mut bearing = world_bearing - prev_yaw[a];
+                while bearing > PI {
+                    bearing -= TAU;
+                }
+                while bearing < -PI {
+                    bearing += TAU;
+                }
+                if bearing.abs() >= BEARING_MIN && bearing.abs() <= BEARING_MAX && motor_turn != 0.0
+                {
+                    scored += 1;
+                    if (motor_turn > 0.0) == (bearing > 0.0) {
+                        correct += 1;
+                    }
+                }
+            }
+            prev_yaw[a] = yaw;
+        }
+    }
+
+    let rate = correct as f64 / scored.max(1) as f64;
+    eprintln!("learning probe baseline: turn/bearing alignment {correct}/{scored} = {rate:.3}");
+    assert!(
+        scored >= MIN_SCORED_SAMPLES,
+        "only {scored} scored samples — agents rotated out of the bearing window too fast \
+         or the probe geometry broke"
+    );
+    // ±6σ band around chance for the sample sizes this probe produces.
+    // The current learner sits at ≈ 0.5; a working spatial learner must
+    // exceed the upper bound (re-pin the band when that lands).
+    assert!(
+        (0.38..=0.62).contains(&rate),
+        "turn/bearing alignment {rate:.3} is outside the chance band [0.38, 0.62] — \
+         either learning emerged (update this baseline) or a directional bias crept in"
+    );
+}
+
+/// Free-running foraging baseline in the probe arena with the default
+/// config (normal movement, default strides): records food eaten and deaths
+/// over a fixed tick budget. The printed numbers are the recorded baseline
+/// that learning changes must improve.
+#[test]
+fn learning_probe_free_run_foraging_baseline() {
+    use xagent_brain::buffers::{PHYS_STRIDE, P_DEATH_COUNT, P_FOOD_COUNT, P_TICKS_ALIVE};
+
+    if !xagent_brain::GpuKernel::is_available() {
+        eprintln!("Skipping: no GPU/fallback adapter available");
+        return;
+    }
+
+    /// Total physics ticks. Long enough for several food encounters and the
+    /// full energy-drain arc, short enough to stay fast on slow adapters.
+    const RUN_TICKS: u32 = 3000;
+    /// One death costs exactly one un-incremented alive tick (death and
+    /// respawn happen in the same kernel cycle), so allow a small gap.
+    const MAX_DEATH_TICK_GAP: f32 = 100.0;
+
+    let brain = BrainConfig::default();
+    let (mut kernel, _, _) = build_probe_arena(&brain, 13);
+
+    let batch = kernel.kernel_batch_size();
+    assert!(
+        RUN_TICKS % batch == 0,
+        "RUN_TICKS {RUN_TICKS} must be a multiple of kernel_batch_size {batch}"
+    );
+    let mut tick = 0_u64;
+    while tick < u64::from(RUN_TICKS) {
+        kernel.dispatch_batch(tick, batch);
+        tick += u64::from(batch);
+    }
+
+    let state = kernel.read_full_state_blocking();
+    let mut total_food = 0.0_f32;
+    let mut total_deaths = 0.0_f32;
+    for a in 0..PROBE_AGENT_COUNT {
+        let base = a * PHYS_STRIDE;
+        total_food += state[base + P_FOOD_COUNT];
+        total_deaths += state[base + P_DEATH_COUNT];
+        let ticks_alive = state[base + P_TICKS_ALIVE];
+        // Liveness accounting: ticks_alive survives respawn, so it must
+        // track the dispatched budget minus at most a small death gap.
+        // A zero here means the simulation never ran.
+        assert!(
+            ticks_alive >= RUN_TICKS as f32 - MAX_DEATH_TICK_GAP && ticks_alive <= RUN_TICKS as f32,
+            "agent {a}: ticks_alive {ticks_alive} outside expected range for budget {RUN_TICKS}"
+        );
+    }
+    let food_per_agent_per_1k = total_food / PROBE_AGENT_COUNT as f32 / (RUN_TICKS as f32 / 1000.0);
+    eprintln!(
+        "learning probe baseline: food={total_food} deaths={total_deaths} \
+         food/agent/1k-ticks={food_per_agent_per_1k:.3}"
+    );
+}

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -70,10 +70,15 @@ pub struct BrainConfig {
     /// Heritable: mutated during breeding, clamped to [0.05, 0.4]. Default 0.1.
     #[serde(default = "default_fatigue_floor")]
     pub fatigue_floor: f32,
-    /// Visual field width in pixels. Default 8.
+    /// Visual field width in pixels. Default 17 — an odd count puts one ray
+    /// column straight ahead, pairing with the horizon row for distal food
+    /// detection.
     #[serde(default = "default_vision_width", alias = "vision_w")]
     pub vision_width: u32,
-    /// Visual field height in pixels. Default 6.
+    /// Visual field height in pixels. Default 13 — an odd count puts one ray
+    /// row exactly on the horizon, which tracks ground-level food at any
+    /// distance (the vertical ray gap, not horizontal acuity, is what bounds
+    /// ground-food visibility).
     #[serde(default = "default_vision_height", alias = "vision_h")]
     pub vision_height: u32,
     /// Physics ticks per brain+vision cycle. Higher = faster but less responsive.
@@ -144,11 +149,11 @@ fn default_fatigue_floor() -> f32 {
 }
 
 fn default_vision_width() -> u32 {
-    8
+    17
 }
 
 fn default_vision_height() -> u32 {
-    6
+    13
 }
 
 fn default_seed() -> u64 {
@@ -462,8 +467,10 @@ mod tests {
         let config = BrainConfig::default();
         assert_eq!(config.brain_tick_stride, 10);
         assert_eq!(config.vision_stride, 10);
-        assert_eq!(config.vision_width, 8);
-        assert_eq!(config.vision_height, 6);
+        // Odd × odd grid: one horizon-grazing ray row plus one straight-ahead
+        // column, which is what bounds ground-food visibility at range.
+        assert_eq!(config.vision_width, 17);
+        assert_eq!(config.vision_height, 13);
         assert!((config.metabolic_rate - 0.5).abs() < 1e-6);
         assert!((config.integrity_scale - 0.5).abs() < 1e-6);
         assert!((config.movement_speed - 20.0).abs() < 1e-6);

--- a/crates/xagent-shared/src/config.rs
+++ b/crates/xagent-shared/src/config.rs
@@ -70,15 +70,15 @@ pub struct BrainConfig {
     /// Heritable: mutated during breeding, clamped to [0.05, 0.4]. Default 0.1.
     #[serde(default = "default_fatigue_floor")]
     pub fatigue_floor: f32,
-    /// Visual field width in pixels. Default 17 — an odd count puts one ray
-    /// column straight ahead, pairing with the horizon row for distal food
-    /// detection.
+    /// Visual field width in pixels. Default 8. Odd × odd grids (e.g. 17×13)
+    /// give the best distal-food visibility — an odd height puts a ray row on
+    /// the horizon and an odd width a column straight ahead — but the default
+    /// stays 8×6 until the learner can act on directional vision (see
+    /// `docs/superpowers/specs/2026-06-10-learning-baseline.md`).
     #[serde(default = "default_vision_width", alias = "vision_w")]
     pub vision_width: u32,
-    /// Visual field height in pixels. Default 13 — an odd count puts one ray
-    /// row exactly on the horizon, which tracks ground-level food at any
-    /// distance (the vertical ray gap, not horizontal acuity, is what bounds
-    /// ground-food visibility).
+    /// Visual field height in pixels. Default 6. See `vision_width` for the
+    /// odd-grid range-visibility note.
     #[serde(default = "default_vision_height", alias = "vision_h")]
     pub vision_height: u32,
     /// Physics ticks per brain+vision cycle. Higher = faster but less responsive.
@@ -149,11 +149,11 @@ fn default_fatigue_floor() -> f32 {
 }
 
 fn default_vision_width() -> u32 {
-    17
+    8
 }
 
 fn default_vision_height() -> u32 {
-    13
+    6
 }
 
 fn default_seed() -> u64 {
@@ -467,10 +467,8 @@ mod tests {
         let config = BrainConfig::default();
         assert_eq!(config.brain_tick_stride, 10);
         assert_eq!(config.vision_stride, 10);
-        // Odd × odd grid: one horizon-grazing ray row plus one straight-ahead
-        // column, which is what bounds ground-food visibility at range.
-        assert_eq!(config.vision_width, 17);
-        assert_eq!(config.vision_height, 13);
+        assert_eq!(config.vision_width, 8);
+        assert_eq!(config.vision_height, 6);
         assert!((config.metabolic_rate - 0.5).abs() < 1e-6);
         assert!((config.integrity_scale - 0.5).abs() < 1e-6);
         assert!((config.movement_speed - 20.0).abs() < 1e-6);

--- a/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
+++ b/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
@@ -66,6 +66,14 @@ workgroup model.
 
 ### 4. Vision acuity — ADOPT at 16×12; 32×24 and stride changes measured separately
 
+> **Superseded by the Phase 3 outcome.** Building the Phase-0 probes showed
+> the *vertical* ray layout, not horizontal spacing, binds ground-food
+> visibility, so Phase 3 implemented a **17×13 odd grid** (one ray row on the
+> horizon + one column straight ahead, 221 rays — still under the 256-thread
+> workgroup) instead of the 16×12 analyzed below — and the **default stayed
+> 8×6** after measurement. The original 16×12 analysis is kept below as the
+> pre-measurement reasoning.
+
 At 8×6 over 90° FOV, ray spacing at distance 20 is ~3.9 units against a food
 diameter of 2 — distant food is usually invisible (issue #14: "Depth won't
 fix this"). At 16×12 (192 rays) spacing at distance 20 is ~2.0 units —

--- a/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
+++ b/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
@@ -193,42 +193,47 @@ review. So the gates come first.
   alignment 0.498 (chance), foraging 0.042 food/agent/1k-ticks, visibility
   16/16.
 
-## Phase 1: TD(λ) critic and trace-based actor credit
+## Phase 1: TD(λ) critic and trace-based actor credit — DONE
 
-- [ ] **Step 1: Layout.** Add the six new regions to `common.wgsl` and
-  `buffers.rs` (single canonical derivation, no hardcoded strides). Remove
-  `O_MOTOR_RING`/`O_STATE_RING` history layout and the `history_buffer`
-  plumbing in `gpu_kernel.rs`. Net per-agent memory: −8514 floats (ring)
-  +516 floats (head + traces).
-- [ ] **Step 2: Critic forward + TD error.** In pass 6, threads 0..127
-  compute `v = dot(value_weights, s_encoded) + bias` via the existing
-  parallel-reduction idiom; thread 0 forms
-  `δ = clamp(r + TD_DISCOUNT·v − prev_value, ±MAX_TD_ERROR)` with
-  `r = s_homeo[1]` (raw amplified gradient — immediate signal per journey
-  rule 3), stores `v` into `O_PREV_VALUE`, publishes δ via shared memory.
-- [ ] **Step 3: Trace + weight updates.** Threads 0..127: decay traces by
-  `TD_DISCOUNT * TD_LAMBDA`, accumulate (`z_critic += s_encoded[d]`,
-  `z_fwd += noise_forward·s_encoded[d]`, `z_turn += noise_turn·s_encoded[d]`),
-  apply `Δ = lr·δ·z` to value/forward/turn weights. Keep existing decay +
-  L2-ball normalization for actor weights; add the same for value weights.
-  `s_credit[d] = δ·(z_fwd[d]+z_turn[d])` keeps the encoder-credit interface.
-- [ ] **Step 4: Delete the old branch.** Remove `DEADZONE`,
+- [x] **Step 1: Layout.** Added the value head + trace regions to
+  `common.wgsl` and `buffers.rs` (single canonical derivation). Removed the
+  history layout and the entire `history_buffer` binding/plumbing in
+  `gpu_kernel.rs` (binding 13 retired; layout intentionally non-contiguous).
+  `AgentBrainState` dropped its `history` vector.
+- [x] **Step 2: Critic forward + TD error.** Pass 6 reduces
+  `v = dot(value_weights, s_encoded) + bias` across `ENCODED_DIMENSION`
+  threads; thread 0 forms `δ = clamp(r + TD_DISCOUNT·v − prev_value,
+  ±MAX_TD_ERROR)` with `r = s_homeo[1]` (urgency-amplified raw gradient),
+  stores `v` into `O_PREV_VALUE`, publishes δ via `s_td_error`.
+- [x] **Step 3: Trace + weight updates.** Per-dimension threads decay traces
+  by `TD_DISCOUNT·TD_LAMBDA`, accumulate critic (`+s_encoded`) and actor
+  (`+noise·s_encoded`) terms, and apply `Δ = lr·TD_VECTOR_SCALE·δ·z`. The
+  motor block publishes its exploration noise to `s_explore` so the trace
+  update (end of pass) sees this tick's action. `s_credit[d] = δ·(z_fwd+z_turn)`
+  feeds the encoder. Value head gets the same L2-ball clamp as the actor.
+- [x] **Step 4: Delete the old branch.** Removed `DEADZONE`,
   `TONIC_CREDIT_SCALE`, `PAIN_AMP`, `CREDIT_DECAY`, `ACTION_HISTORY_LEN`,
-  the phase-1/phase-2 credit loop, and the undocumented `* 0.1` bias
-  multiplier (biases now update from δ·trace like weights). Grep all
-  shaders and docs for dangling references per CONTRIBUTING.md.
-- [ ] **Step 5: Death boundary.** Zero `O_TRACE_*` and `O_PREV_VALUE` in
-  `phase_death.wgsl` — credit must not leak across lives (journey rule 4).
-- [ ] **Step 6: Inheritance.** Include value weights in exported brain state;
-  length-mismatch on import logs a warning and starts fresh (no silent skip).
-- [ ] **Step 7: Unit + probe tests.** Critic converges to `r/(1−γ)` under
-  constant reward; δ > 0 on an unexpected energy gain; traces zeroed on
-  death; directional probe beats Phase-0 baseline with statistical margin;
-  TPS within 10% of baseline (expected: improvement — the serial loop is
-  gone). `cargo fmt`, `clippy -D warnings`, full test suite. Commit.
+  `ACTION_WEIGHT_DECAY`, the history-ring offsets, and the serial credit
+  loop. READMEs and CLAUDE.md updated; no dangling references remain.
+- [x] **Step 5: Death boundary.** Traces and `O_PREV_VALUE` zeroed in both
+  `phase_death.wgsl` and the fused `kernel_tick.wgsl` respawn path.
+- [x] **Step 6: Inheritance.** Value weights live in `brain_state` and ride
+  the existing inherit/mutate path; `mutate_brain_state`'s `FIXED_TAIL_SIZE`
+  math absorbs the larger tail unchanged.
+- [x] **Step 7: Tests.** `td_critic_tracks_metabolic_drain` (value goes
+  negative under drain, δ within clamp), `td_traces_bounded_across_deaths`,
+  and the gate `learning_probe_td_learns_turn_alignment`. `fmt`, `clippy
+  -D warnings`, 128 tests green.
 
-**Gate:** directional probe above chance, food-per-life ≥ baseline over a
-fixed-seed 20-generation headless run, no TPS regression > 10%.
+**Gate — PASSED.** Trained turn/bearing alignment **0.643** (was 0.498 at
+chance), clearing the 0.62 band edge; training food rises 588→730 across
+halves; TPS unchanged (serial loop gone). Numbers recorded in the baseline
+spec. One adjustment vs the plan: per-dimension trace updates needed a
+`TD_VECTOR_SCALE = 1/ENCODED_DIMENSION` factor to keep the bootstrapped
+critic inside the linear-TD stability limit (the aggregate step is a sum of
+128 trace×feature products), and per-tick weight decay was dropped (it bled
+away the learned policy and the initial forward bias; δ being
+surprise-driven plus the L2 ball already bound magnitude).
 
 ## Phase 2: Encoder self-supervision (tied-weight reconstruction)
 

--- a/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
+++ b/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
@@ -252,6 +252,46 @@ surprise-driven plus the L2 ball already bound magnitude).
 **Gate:** separability test passes; directional probe improves over Phase 1;
 TPS cost < 15%.
 
+### Phase 2 outcome — NOT MERGED (documented negative result)
+
+Tied-weight vision reconstruction was implemented (vision-only target, decode
+through the transposed encoder weights, `Δw = rate·(x−x̂)·encoded`, vision
+features only) and measured against the Phase-1 directional gate on the
+fixed training seed:
+
+| Reconstruction rate | Trained alignment | Phase-1 reference |
+|---|---|---|
+| 0.001 | 0.603 | 0.643 |
+| 0.0003 | 0.613 | 0.643 |
+| 0 (Phase 1) | 0.643 | 0.643 |
+
+Reconstruction was **neutral-to-slightly-negative** at every rate tried and
+never cleared the gate's "improves over Phase 1" bar; lowering the rate only
+walked the metric back toward the Phase-1 value. (Training-time foraging rose
+slightly — 588→730 vs 609→770 — but the post-training behavioral readout did
+not.) Two compounding reasons:
+
+1. **The encoder is not the currently-binding constraint.** Phase 1 already
+   reaches 0.643 ≫ chance with the random-projection encoder, so the
+   8×6 random projection preserves enough food-direction signal for the
+   policy. There was little representational headroom for reconstruction to
+   add.
+2. **Moving-target cost.** Reshaping the encoder while the policy reads it
+   makes the policy chase a shifting code, which slightly slowed policy
+   convergence — visible as the rate-dependent dip (0.001 worse than 0.0003).
+
+Per the plan's own discipline ("No phase merges on 'should work'"), the
+reconstruction code was reverted; `develop`/this branch keep the validated
+Phase-1 learner. The trainable-encoder idea is not refuted in general — it is
+not worthwhile *at 8×6 with TD(λ) already extracting the signal*. It should be
+revisited only if a later phase makes the encoder the binding constraint (e.g.
+much higher vision resolution where a random projection dilutes a small food
+signal across many pixels), and then with an objective that emphasizes the
+*varying* part of the input rather than dominant background variance.
+
+**Re-scope:** proceed directly to Phase 3 (vision acuity), the next plausibly
+binding constraint — can the agent see food at range at all.
+
 ## Phase 3: Vision acuity
 
 - [ ] **Step 1: Default 16×12.** Change config defaults; verify the

--- a/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
+++ b/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
@@ -292,21 +292,38 @@ signal across many pixels), and then with an objective that emphasizes the
 **Re-scope:** proceed directly to Phase 3 (vision acuity), the next plausibly
 binding constraint — can the agent see food at range at all.
 
-## Phase 3: Vision acuity
+## Phase 3: Vision acuity — DONE (+ a more important discovery)
 
-- [ ] **Step 1: Default 16×12.** Change config defaults; verify the
-  layout-aware paths (`BrainLayout`, overrides, readback) end-to-end —
-  this is config + tests, the WGSL already derives from `VISION_W/H`.
-- [ ] **Step 2: Ray-hit instrumentation test.** Place food at distances
-  {5, 10, 15, 20, 25}; assert hit-rate at d=20 materially exceeds the 8×6
-  baseline.
-- [ ] **Step 3: Measured `vision_stride` sweep.** Headless A/B at stride
-  {10, 5} × resolution {8×6, 16×12}; record food-per-life vs TPS. Adopt
-  the best point that keeps TPS acceptable; document the choice.
+- [x] **Step 1: Default 17×13** (better than the planned 16×12: odd counts
+  put a ray row on the horizon and a column straight ahead). Verified the
+  layout-aware paths end-to-end; pinned-count tests rebased onto the live
+  layout so default and reference (8×6) are both covered. Feature vector
+  grows 265 → 1130.
+- [x] **Step 2: Range-visibility test.** `vision_horizon_row_sees_food_at_range`
+  places food at {5,10,15,20,25}: 17×13 sees all five, 8×6 sees only the
+  nearest — proving the horizon row fixes the distal-food blindness.
+- [x] **Step 3: Evolution-scale measurement.** 16-generation run at 17×13:
+  foraging rate 0.192 → 0.254, comparable to 8×6 (no clear win — the learner
+  can't yet use directional vision, so the added information isn't cashed in).
 
-**Gate:** food visible at range in the probe; combined Phases 1–3 show a
-rising food-per-life trend across generations — the first time this metric
-has ever trended.
+**Gate result.** Food visible at range: **met**. "Rising food-per-life
+trend": already validated at evolution scale in Phase 1 (foraging rate +74%,
+fitness +62%) and reconfirmed at 17×13.
+
+**The unplanned discovery (more important than the acuity work).** Validating
+the directional probe at the new resolution exposed that the Phase-1 "0.643
+learned to turn toward food" was **confounded**: each agent saw food on one
+fixed side in both training and eval, so a per-agent constant turn bias scored
+above chance without any vision-conditional steering. The confound-free probe
+(`learning_probe_mirrored_steering_is_chance`, food side mirrored every
+training episode) sits at **0.52 — chance**, and more episodes don't move it.
+**Genuine vision-conditional steering is not being learned at any resolution.**
+This re-opens the encoder/representation question (Phase 2 had dismissed it
+using the confounded metric): a random-projection encoder likely does not make
+"food-left" vs "food-right" linearly separable for the policy readout, so a
+constant bias is learnable but a conditional response is not. The TD(λ) critic
+and the evolution-scale foraging/fitness/survival gains stand; the directional
+claim does not. See the baseline spec's Phase 3 section.
 
 ## Phase 4 (deferred — separate issues, not in this plan's scope)
 

--- a/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
+++ b/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
@@ -294,11 +294,13 @@ binding constraint — can the agent see food at range at all.
 
 ## Phase 3: Vision acuity — DONE (+ a more important discovery)
 
-- [x] **Step 1: Default 17×13** (better than the planned 16×12: odd counts
-  put a ray row on the horizon and a column straight ahead). Verified the
-  layout-aware paths end-to-end; pinned-count tests rebased onto the live
-  layout so default and reference (8×6) are both covered. Feature vector
-  grows 265 → 1130.
+- [x] **Step 1: 17×13 odd grid** (better than the planned 16×12: odd counts
+  put a ray row on the horizon and a column straight ahead). Implemented and
+  verified end-to-end, but the **default stays 8×6** — 17×13 costs 4.3× more
+  features (265 → 1130) with no measured behavioral win and the directional
+  learner can't use it yet, so shipping it as default would be an
+  unmeasured-benefit cost increase (same discipline as the Phase-2 revert).
+  The capability and its test are kept for when directional learning lands.
 - [x] **Step 2: Range-visibility test.** `vision_horizon_row_sees_food_at_range`
   places food at {5,10,15,20,25}: 17×13 sees all five, 8×6 sees only the
   nearest — proving the horizon row fixes the distal-food blindness.

--- a/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
+++ b/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
@@ -172,21 +172,26 @@ The audit's core lesson: every constant change was individually plausible and
 collectively wrong, and the two changes that fully froze learning passed
 review. So the gates come first.
 
-- [ ] **Step 1: Directional learning probe (integration test).** Construct a
-  `GpuKernel` with one agent and one food item placed at a fixed bearing
-  (±30°, distance 15). Run N brain ticks, read motor telemetry, score
-  turn-sign correctness against the food bearing over M seeded trials.
-  Assert the *baseline* (current code) scores ≈ chance — this makes the
-  probe falsifiable and gives the number future phases must beat. Gate
-  behind the existing GPU-test mechanism.
-- [ ] **Step 2: Approach-rate metric.** Same scaffold, free-running: count
-  food-visible→distance-decreased transitions per 1k brain ticks, and
-  food-per-life from `P_FOOD_COUNT`/`P_DEATH_COUNT`.
-- [ ] **Step 3: Headless A/B logging.** Extend `run_headless` to log per
-  generation: food-per-life, policy weight norms, exploration rate mean.
-  Fixed seed → reproducible before/after comparison.
-- [ ] **Step 4: Record baseline numbers** in the PR body and in a short
-  `docs/superpowers/specs/` baseline note. Commit.
+- [x] **Step 1: Directional learning probe (integration test).** Built as a
+  16-agent flat-world arena (4×4 grid, 64-unit spacing — beyond vision
+  range, so independent trials), one food item per agent at bearing
+  ±atan(3/7) (exactly on a ray column) at distance 5 — the distance the
+  default 8×6 ray rows can actually see ground food (the vertical ray
+  layout, not horizontal acuity, binds visibility; see the baseline note).
+  Single-tick strides + zero movement speed pin the geometry; turn-sign
+  correctness is scored against the per-tick bearing. Baseline asserted to
+  the chance band [0.38, 0.62]. Includes a separate information-path test
+  asserting all agents see a food pixel.
+- [x] **Step 2: Foraging-rate metric.** Free-running probe arena with the
+  default config: food-per-agent-per-1k-ticks and deaths over 3000 ticks,
+  with liveness accounting asserted.
+- [x] **Step 3: Headless A/B logging.** `run_headless` now prints per
+  generation: food, deaths, food-per-life, and the best agent's policy
+  weight norms (`w_fwd`, `w_turn`).
+- [x] **Step 4: Record baseline numbers** —
+  [`docs/superpowers/specs/2026-06-10-learning-baseline.md`](../specs/2026-06-10-learning-baseline.md):
+  alignment 0.498 (chance), foraging 0.042 food/agent/1k-ticks, visibility
+  16/16.
 
 ## Phase 1: TD(λ) critic and trace-based actor credit
 

--- a/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
+++ b/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
@@ -1,0 +1,275 @@
+# Emergent Learning Pathway: TD Credit, Encoder Self-Supervision, Vision Acuity
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give agents a credit pathway that can actually assign a sparse, delayed, interoceptive reward (eating) to the distal navigational action that earned it (turning toward food 30 brain ticks earlier), and an encoder that becomes spatially discriminative without needing a working policy first. This is the mechanism gap that keeps issue #13 open after all suppression bugs (#14–#17, #87–#100) were fixed.
+
+**Issue:** #13
+
+**Reference:** `EVOLUTION_JOURNEY.md` §19–20, `docs/superpowers/specs/2026-04-21-credit-assignment-audit.md`, `docs/reviews/2026-04-15-gemini-31-pro.md`, `docs/reviews/2026-04-15-gpt-54-high.md`.
+
+---
+
+## Evaluation of the four candidate mechanisms
+
+The investigation on #13 surfaced four missing mechanisms. Verdicts:
+
+### 1. Long-horizon credit assignment — ADOPT (core of this plan)
+
+The current learner is REINFORCE with an `exp(-age * 0.3)` eligibility window
+(~7 meaningful brain ticks) against an action→reward delay of ~30 brain ticks
+(food visible at `VISION_MAX_DIST = 30`, ~1 unit of travel per brain tick at
+defaults). The decisive turn is outside the window when the energy spike
+fires. PR #102's own conclusion: "The REINFORCE credit signal has too low SNR
+for spatial learning."
+
+Two options were considered:
+
+- **Longer decaying trace over the existing history ring.** Rejected: REINFORCE
+  variance grows with horizon, the ring loop is the serial thread-0 bottleneck
+  that caused the #95 perf regression, and the #13 comment's arithmetic
+  (~64M food encounters to break even) gets *worse* with more random terms.
+- **TD(λ) critic + advantage-based actor updates.** Adopted. A linear value
+  head over `s_encoded` learns "states with food in view are worth more";
+  the TD error δ then propagates the terminal eating reward backwards along
+  approach trajectories *across episodes*, and per-dimension eligibility
+  traces carry credit to actions ~1/(1−γ) ≈ 33 brain ticks back at O(128)
+  cost per tick — fully parallel, no history ring, no serial loop.
+
+This preserves the project philosophy: the reward is still only the
+homeostatic gradient. The value function is learned, not hardcoded.
+
+### 2. Proximal approach signal — SUBSUMED by the critic; anticipation deferred
+
+Approaching food currently yields zero gradient; only eating does. The TD
+error δ fixes this for *credit* purposes: once the critic learns that
+food-in-view states have higher value, any action that increases proximity
+produces positive δ immediately. Re-enabling prospective motor blending
+(removed in PR #100 for the `s_habituated`/`s_encoded` scale mismatch, dead
+constant deleted in #140) is a separate *motor-side* feature. Deferred to a
+follow-up issue, gated on Phase 1+2 results showing predictor quality is the
+remaining bottleneck.
+
+### 3. Self-supervised encoder — ADOPT (tied-weight reconstruction)
+
+The encoder is Xavier-random at birth and trained only by action credit
+(`ENCODER_CREDIT_SCALE`), which is the same degenerate signal it is supposed
+to fix — the chicken-and-egg from `EVOLUTION_JOURNEY.md` §20B. Tuning the
+scale was tried three times (0.001 → 0.01 → 0.1) without spatial features
+emerging. A reconstruction objective (decode `s_encoded` back to `s_features`
+through the transposed encoder weights) is dense from tick 0, needs no
+working policy, and guarantees information preservation: food-left and
+food-right *must* encode differently to reconstruct differently.
+Alternatives rejected: pure predictability objectives collapse to constants;
+contrastive losses need negative sampling that does not fit the one-agent
+workgroup model.
+
+### 4. Vision acuity — ADOPT at 16×12; 32×24 and stride changes measured separately
+
+At 8×6 over 90° FOV, ray spacing at distance 20 is ~3.9 units against a food
+diameter of 2 — distant food is usually invisible (issue #14: "Depth won't
+fix this"). At 16×12 (192 rays) spacing at distance 20 is ~2.0 units —
+comparable to the food diameter, so at least one ray reliably hits.
+16×12 stays under the 256-thread `vision_tick` workgroup (no strided-loop fix
+needed) and `s_features` grows to ~985 floats ≈ 3.9 KB of workgroup memory —
+well inside the 16 KB default limit. 32×24 (768 rays, ~15.5 KB shared memory)
+is deferred: it needs the `vision_tick` strided loop from the dynamic-vision
+plan and a workgroup-storage budget audit. `vision_stride` (default 10 —
+only ~3 distinct visual frames per food approach) is a measured sweep in
+Phase 3, not a blind change.
+
+### What stays untouched
+
+- **Klinotaxis stays.** It is the reactive substrate that generates correlated
+  approach/escape trajectories for the critic to learn values along.
+- **Pattern memory, valence learning, memory blend stay** as-is in this plan.
+- **The reward definition stays interoceptive-only** (`raw_gradient`).
+
+---
+
+## Architecture
+
+```
+                    s_features (per brain tick, one vision frame per batch)
+                        │
+                  encoder (trainable: reconstruction + value-aligned credit)
+                        │
+                    s_encoded ──────────────┬─────────────────┐
+                        │                   │                 │
+                  policy (actor)      value head (critic)   pattern memory
+                  fwd/turn weights    v = w·s + b           (unchanged)
+                        │                   │
+                  motor + noise       δ = r + γ·v' − v   ← r = raw homeostatic gradient
+                        │                   │
+                  actor traces  ←──── δ ────┴──→ critic trace
+                  z_fwd, z_turn       (replaces improvement/deadzone/tonic/PAIN_AMP)
+```
+
+Per brain tick:
+
+```
+z_critic = γλ·z_critic + s_encoded            (128 floats)
+z_fwd    = γλ·z_fwd    + noise_fwd·s_encoded  (128 floats)
+z_turn   = γλ·z_turn   + noise_turn·s_encoded (128 floats)
+δ        = clamp(r + γ·v(s') − v(s), ±MAX_TD_ERROR)
+Δv_w     = CRITIC_LR · δ · z_critic
+Δw_fwd   = ACTOR_LR  · δ · z_fwd
+Δw_turn  = ACTOR_LR  · δ · z_turn
+```
+
+All trace and weight updates are per-dimension → threads 0..127 in parallel.
+The 64-entry history ring, its thread-0 serial credit loop, and the
+`DEADZONE` / `TONIC_CREDIT_SCALE` / `PAIN_AMP` / `CREDIT_DECAY` branch are
+removed. δ replaces `improvement` as the single credit signal.
+
+**Constants (named per CONTRIBUTING.md, each with a why-comment):**
+
+| Constant | Value | Why |
+|---|---|---|
+| `TD_DISCOUNT` | 0.97 | horizon 1/(1−γ) ≈ 33 brain ticks ≈ travel time from `VISION_MAX_DIST` at default speed |
+| `TD_LAMBDA` | 0.9 | trace decay; effective credit span γλ ≈ 0.87 per tick reaches the full approach |
+| `CRITIC_LEARNING_RATE` | 0.01 | 10× slower than actor — the critic must be stabler than the policy it evaluates |
+| `MAX_TD_ERROR` | 1.0 | bounds δ against respawn/clamp artifacts (mirrors `MAX_HOMEOSTATIC_DELTA` intent) |
+| `MAX_VALUE_WEIGHT_NORM` | 2.0 | same budget as action weights |
+| `ENCODER_RECON_RATE` | 0.001 | reconstruction is dense (every tick, every dim) so the per-step rate must be small |
+
+**Known limitation (documented, accepted):** vision runs once per kernel
+batch, so `s_encoded` is constant within a batch (`vision_stride` brain
+ticks). TD steps within a batch see a static state; state transitions are
+batch-granular. δ still spikes on the eating tick because `r` reads
+physics-fresh energy. This is the existing one-batch sensory lag invariant;
+Phase 3 measures whether tightening `vision_stride` pays for its cost.
+
+**Risks and mitigations:**
+
+| Risk | Mitigation |
+|---|---|
+| Critic diverges (linear TD with function approximation) | clamp δ, L2-ball value weights, slow critic LR; Phase-0 probe catches it |
+| Critic can't see food on random encoder | random projections of 240 vision floats keep "food present" linearly decodable; Phase 2 reconstruction sharpens it; probe measures both orders |
+| Layout change breaks inheritance | `BRAIN_STRIDE` changes; length-mismatch import guards must log and skip (journey lesson 15), evolution DB weight blobs invalidated by documented version bump |
+| Repeat of #94/#97/#99 oscillation | every phase lands with before/after probe numbers in the PR body; no constant tuning without a measurement |
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `crates/xagent-brain/src/shaders/kernel/common.wgsl` | Modify | new offsets (`O_VALUE_WEIGHTS`, `O_VALUE_BIAS`, `O_PREV_VALUE`, `O_TRACE_CRITIC`, `O_TRACE_FWD`, `O_TRACE_TURN`), new constants, delete `DEADZONE`/`TONIC_CREDIT_SCALE`/`PAIN_AMP`/`CREDIT_DECAY`/history offsets |
+| `crates/xagent-brain/src/shaders/kernel/brain_passes.wgsl` | Modify | pass 6 credit block → TD update; pass 7b encoder reconstruction; delete history-ring writes |
+| `crates/xagent-brain/src/shaders/kernel/phase_death.wgsl` | Modify | zero traces + `O_PREV_VALUE` on death (life-boundary discontinuity) |
+| `crates/xagent-brain/src/buffers.rs` | Modify | mirror offsets, `BRAIN_STRIDE`, init (value head small-random), drop history init |
+| `crates/xagent-brain/src/gpu_kernel.rs` | Modify | buffer sizing, telemetry (expose `value`, `td_error`), remove history buffer plumbing |
+| `crates/xagent-sandbox/tests/integration.rs` | Modify | Phase-0 probes + per-phase learning tests |
+| `crates/xagent-sandbox/src/headless.rs` | Modify | A/B metric logging (food-per-life, weight norms, δ stats) |
+| `crates/xagent-shared/src/config.rs` | Modify (Phase 3) | default `vision_width`/`vision_height` 8×6 → 16×12 |
+
+---
+
+## Phase 0: Measurement harness (prerequisite — nothing merges without it)
+
+The audit's core lesson: every constant change was individually plausible and
+collectively wrong, and the two changes that fully froze learning passed
+review. So the gates come first.
+
+- [ ] **Step 1: Directional learning probe (integration test).** Construct a
+  `GpuKernel` with one agent and one food item placed at a fixed bearing
+  (±30°, distance 15). Run N brain ticks, read motor telemetry, score
+  turn-sign correctness against the food bearing over M seeded trials.
+  Assert the *baseline* (current code) scores ≈ chance — this makes the
+  probe falsifiable and gives the number future phases must beat. Gate
+  behind the existing GPU-test mechanism.
+- [ ] **Step 2: Approach-rate metric.** Same scaffold, free-running: count
+  food-visible→distance-decreased transitions per 1k brain ticks, and
+  food-per-life from `P_FOOD_COUNT`/`P_DEATH_COUNT`.
+- [ ] **Step 3: Headless A/B logging.** Extend `run_headless` to log per
+  generation: food-per-life, policy weight norms, exploration rate mean.
+  Fixed seed → reproducible before/after comparison.
+- [ ] **Step 4: Record baseline numbers** in the PR body and in a short
+  `docs/superpowers/specs/` baseline note. Commit.
+
+## Phase 1: TD(λ) critic and trace-based actor credit
+
+- [ ] **Step 1: Layout.** Add the six new regions to `common.wgsl` and
+  `buffers.rs` (single canonical derivation, no hardcoded strides). Remove
+  `O_MOTOR_RING`/`O_STATE_RING` history layout and the `history_buffer`
+  plumbing in `gpu_kernel.rs`. Net per-agent memory: −8514 floats (ring)
+  +516 floats (head + traces).
+- [ ] **Step 2: Critic forward + TD error.** In pass 6, threads 0..127
+  compute `v = dot(value_weights, s_encoded) + bias` via the existing
+  parallel-reduction idiom; thread 0 forms
+  `δ = clamp(r + TD_DISCOUNT·v − prev_value, ±MAX_TD_ERROR)` with
+  `r = s_homeo[1]` (raw amplified gradient — immediate signal per journey
+  rule 3), stores `v` into `O_PREV_VALUE`, publishes δ via shared memory.
+- [ ] **Step 3: Trace + weight updates.** Threads 0..127: decay traces by
+  `TD_DISCOUNT * TD_LAMBDA`, accumulate (`z_critic += s_encoded[d]`,
+  `z_fwd += noise_forward·s_encoded[d]`, `z_turn += noise_turn·s_encoded[d]`),
+  apply `Δ = lr·δ·z` to value/forward/turn weights. Keep existing decay +
+  L2-ball normalization for actor weights; add the same for value weights.
+  `s_credit[d] = δ·(z_fwd[d]+z_turn[d])` keeps the encoder-credit interface.
+- [ ] **Step 4: Delete the old branch.** Remove `DEADZONE`,
+  `TONIC_CREDIT_SCALE`, `PAIN_AMP`, `CREDIT_DECAY`, `ACTION_HISTORY_LEN`,
+  the phase-1/phase-2 credit loop, and the undocumented `* 0.1` bias
+  multiplier (biases now update from δ·trace like weights). Grep all
+  shaders and docs for dangling references per CONTRIBUTING.md.
+- [ ] **Step 5: Death boundary.** Zero `O_TRACE_*` and `O_PREV_VALUE` in
+  `phase_death.wgsl` — credit must not leak across lives (journey rule 4).
+- [ ] **Step 6: Inheritance.** Include value weights in exported brain state;
+  length-mismatch on import logs a warning and starts fresh (no silent skip).
+- [ ] **Step 7: Unit + probe tests.** Critic converges to `r/(1−γ)` under
+  constant reward; δ > 0 on an unexpected energy gain; traces zeroed on
+  death; directional probe beats Phase-0 baseline with statistical margin;
+  TPS within 10% of baseline (expected: improvement — the serial loop is
+  gone). `cargo fmt`, `clippy -D warnings`, full test suite. Commit.
+
+**Gate:** directional probe above chance, food-per-life ≥ baseline over a
+fixed-seed 20-generation headless run, no TPS regression > 10%.
+
+## Phase 2: Encoder self-supervision (tied-weight reconstruction)
+
+- [ ] **Step 1: Reconstruction pass.** In pass 7b, all 256 threads
+  cooperatively compute `x̂ = Wᵀ·s_encoded` over `FEATURE_COUNT` (strided
+  loop), then update `Δw[j][d] = ENCODER_RECON_RATE · (x[j] − x̂[j]) ·
+  s_encoded[d]`, clamped to the existing encoder weight budget. Keep the
+  δ-driven encoder credit path (now secondary).
+- [ ] **Step 2: Separability test.** Build two synthetic sensory frames
+  (food-pixels left vs right), tick the brain T times on alternating
+  frames, assert encoded-state cosine similarity *decreases* from its
+  random-init value (falsifiable: frozen encoder keeps it constant).
+- [ ] **Step 3: Probe re-run + cost check.** Reconstruction adds one
+  encoder-sized matmul per brain tick; measure TPS. Commit with numbers.
+
+**Gate:** separability test passes; directional probe improves over Phase 1;
+TPS cost < 15%.
+
+## Phase 3: Vision acuity
+
+- [ ] **Step 1: Default 16×12.** Change config defaults; verify the
+  layout-aware paths (`BrainLayout`, overrides, readback) end-to-end —
+  this is config + tests, the WGSL already derives from `VISION_W/H`.
+- [ ] **Step 2: Ray-hit instrumentation test.** Place food at distances
+  {5, 10, 15, 20, 25}; assert hit-rate at d=20 materially exceeds the 8×6
+  baseline.
+- [ ] **Step 3: Measured `vision_stride` sweep.** Headless A/B at stride
+  {10, 5} × resolution {8×6, 16×12}; record food-per-life vs TPS. Adopt
+  the best point that keeps TPS acceptable; document the choice.
+
+**Gate:** food visible at range in the probe; combined Phases 1–3 show a
+rising food-per-life trend across generations — the first time this metric
+has ever trended.
+
+## Phase 4 (deferred — separate issues, not in this plan's scope)
+
+- Prospective/anticipation motor blending retrained in `s_encoded` space.
+- 32×24 vision (needs `vision_tick` strided loop + workgroup-storage audit).
+- Adaptive normalization of δ (the audit's "adaptive thresholds" ask, now
+  reduced to one signal instead of two constants).
+- Neuroevolution of action/value weights (journey "Path B").
+
+---
+
+## Validation discipline
+
+Every phase is its own PR with: baseline → after numbers from the Phase-0
+probes in the PR body, fixed seeds, and CI green (`fmt`, `clippy
+-D warnings`, full suite). No phase merges on "should work" — journey rule 7.

--- a/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
+++ b/docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md
@@ -161,8 +161,8 @@ Phase 3 measures whether tightening `vision_stride` pays for its cost.
 | `crates/xagent-brain/src/buffers.rs` | Modify | mirror offsets, `BRAIN_STRIDE`, init (value head small-random), drop history init |
 | `crates/xagent-brain/src/gpu_kernel.rs` | Modify | buffer sizing, telemetry (expose `value`, `td_error`), remove history buffer plumbing |
 | `crates/xagent-sandbox/tests/integration.rs` | Modify | Phase-0 probes + per-phase learning tests |
-| `crates/xagent-sandbox/src/headless.rs` | Modify | A/B metric logging (food-per-life, weight norms, δ stats) |
-| `crates/xagent-shared/src/config.rs` | Modify (Phase 3) | default `vision_width`/`vision_height` 8×6 → 16×12 |
+| `crates/xagent-sandbox/src/headless.rs` | Modify | A/B metric logging (food per 1k alive-ticks, weight norms) |
+| `crates/xagent-shared/src/config.rs` | Modify (Phase 3) | vision-grid doc guidance only — the default stays 8×6 (see Phase 3 outcome) |
 
 ---
 
@@ -186,8 +186,8 @@ review. So the gates come first.
   default config: food-per-agent-per-1k-ticks and deaths over 3000 ticks,
   with liveness accounting asserted.
 - [x] **Step 3: Headless A/B logging.** `run_headless` now prints per
-  generation: food, deaths, food-per-life, and the best agent's policy
-  weight norms (`w_fwd`, `w_turn`).
+  generation: food, deaths, food per 1k alive-ticks, and the best agent's
+  policy weight norms (`w_fwd`, `w_turn`).
 - [x] **Step 4: Record baseline numbers** —
   [`docs/superpowers/specs/2026-06-10-learning-baseline.md`](../specs/2026-06-10-learning-baseline.md):
   alignment 0.498 (chance), foraging 0.042 food/agent/1k-ticks, visibility
@@ -308,9 +308,9 @@ binding constraint — can the agent see food at range at all.
   foraging rate 0.192 → 0.254, comparable to 8×6 (no clear win — the learner
   can't yet use directional vision, so the added information isn't cashed in).
 
-**Gate result.** Food visible at range: **met**. "Rising food-per-life
-trend": already validated at evolution scale in Phase 1 (foraging rate +74%,
-fitness +62%) and reconfirmed at 17×13.
+**Gate result.** Food visible at range: **met**. Rising foraging-rate trend
+(food per 1k alive-ticks): already validated at evolution scale in Phase 1
+(+74%, fitness +62%) and reconfirmed at 17×13.
 
 **The unplanned discovery (more important than the acuity work).** Validating
 the directional probe at the new resolution exposed that the Phase-1 "0.643

--- a/docs/superpowers/specs/2026-06-10-learning-baseline.md
+++ b/docs/superpowers/specs/2026-06-10-learning-baseline.md
@@ -102,3 +102,16 @@ gain comes from reward-driven learning, not a directional bias artifact.
 
 TPS unchanged within noise (the serial history-ring credit loop is gone;
 the TD path is fully parallel across the 128 trace dimensions).
+
+## Phase 2 (encoder self-supervision) — negative result, not merged
+
+Tied-weight vision reconstruction was implemented and measured against the
+Phase-1 gate (same training seed): alignment **0.603** at rate 0.001 and
+**0.613** at 0.0003, versus **0.643** for Phase 1 with no reconstruction.
+Reconstruction was neutral-to-slightly-negative at every rate and never
+cleared the "improves over Phase 1" bar, so it was reverted (see the plan's
+"Phase 2 outcome" section for the mechanism analysis). The headline: TD(λ)
+already extracts the food-direction signal from the random-projection
+encoder at 8×6, so encoder representation is not the binding constraint and
+reshaping it only adds a moving-target cost. Work proceeds to Phase 3
+(vision acuity).

--- a/docs/superpowers/specs/2026-06-10-learning-baseline.md
+++ b/docs/superpowers/specs/2026-06-10-learning-baseline.md
@@ -161,21 +161,31 @@ cleared the "improves over Phase 1" bar, so it was reverted (see the plan's
 
 Two outcomes, one expected and one not.
 
-**1. Vision acuity (the planned work).** Default vision changed from 8×6 to
-**17×13**. The odd row/column counts put one ray row exactly on the horizon
+**1. Vision acuity (the planned work).** The **17×13** odd grid was
+implemented and measured, but the **default stays 8×6** (see the decision
+below). The odd row/column counts put one ray row exactly on the horizon
 (passing a constant 0.65 below eye level — inside the 1.0 food hit radius)
 and one column straight ahead. `vision_horizon_row_sees_food_at_range`
-proves the payoff: at 17×13 ground-level food is visible at distances
-{5,10,15,20,25}; at 8×6 only at distance 5 (the lowest below-horizon ray
-strikes flat ground ≈ 5.5 units out, so distal food falls between rows).
-This fixes a real information defect — agents previously could not see food
-at range *at all*. Cost: the feature vector grows 4.3× (265 → 1130).
+proves the payoff with explicit configs: at 17×13 ground-level food is
+visible at distances {5,10,15,20,25}; at 8×6 only at distance 5 (the lowest
+below-horizon ray strikes flat ground ≈ 5.5 units out, so distal food falls
+between rows). This is a real information defect the odd grid fixes.
 
 At evolution scale (16 generations, seed 42) the foraging-rate trend at
 17×13 (0.192 → 0.254) is **comparable to 8×6** (0.164 → 0.285) — no clear
-behavioral win from the extra visibility yet. Consistent with outcome 2:
-the information is now available, but the learner cannot yet act on
-directional vision, so it is not cashed in.
+behavioral win from the extra visibility. Consistent with outcome 2: the
+information is now available, but the learner cannot act on directional
+vision, so it is not cashed in.
+
+**Decision: default reverted to 8×6.** 17×13 costs 4.3× more features
+(265 → 1130) with no measured behavioral win, and the directional learner
+cannot use the added information yet — so shipping it as the default would
+be an unmeasured-benefit cost increase (the same discipline that reverted
+Phase 2). The odd-grid capability and its range-visibility test are kept;
+17×13 becomes the default once directional steering works and can exploit
+it. The information path is *proven fixable*, which is the prerequisite the
+journey's rule #1 ("verify the information path before optimizing the
+algorithm") asks for.
 
 **2. The directional-steering confound (unplanned, more important).**
 Validating Phase 1 at the new resolution surfaced that the 0.643 directional

--- a/docs/superpowers/specs/2026-06-10-learning-baseline.md
+++ b/docs/superpowers/specs/2026-06-10-learning-baseline.md
@@ -86,22 +86,29 @@ encoder. New constants: `TD_DISCOUNT=0.97`, `TD_LAMBDA=0.9`,
 
 | Metric | Test | Baseline | Phase 1 |
 |---|---|---|---|
-| Trained turn/bearing alignment | `learning_probe_td_learns_turn_alignment` | 0.498 (chance, untrained) | **0.643** after 120 episodes of food-reaching practice |
+| Trained turn/bearing alignment (confounded — see correction) | `learning_probe_mirrored_steering_is_chance` (renamed) | 0.498 (chance, untrained) | 0.643 (confounded); **0.52 confound-free** |
 | Episode food (first half → second half of training) | same test | — | **588 → 730** of 960/half (rising) |
 | Critic value under constant drain | `td_critic_tracks_metabolic_drain` | n/a | **−0.002** (correctly negative, finite, δ within clamp) |
 | Trace bound across deaths | `td_traces_bounded_across_deaths` | n/a | bounded after 16 deaths (no cross-life leak) |
 | Untrained stationary alignment | `learning_probe_baseline_turn_alignment_is_chance` | 0.498 | 0.50 (still chance — nothing to learn from with no reward events) |
 | Free-run foraging (debug adapter, single run) | `learning_probe_free_run_foraging_baseline` | 2 food | 7 food (noisy single-seed; not a gate) |
 
-The directional gate is the load-bearing result: with food visible and the
-TD reward arriving on contact, **alignment rises from chance (0.498) to
-0.643** — clearing the baseline chance band's upper edge (0.62). This is the
-first time the policy's turn direction has carried information about food
-bearing. The untrained stationary probe stays at chance, confirming the
-gain comes from reward-driven learning, not a directional bias artifact.
+The directional probe reported **0.643** (vs 0.498 chance) after 120 episodes
+of food-reaching practice, and TPS was unchanged (the serial history-ring
+credit loop is gone; the TD path is fully parallel across the 128 trace
+dimensions).
 
-TPS unchanged within noise (the serial history-ring credit loop is gone;
-the TD path is fully parallel across the 128 trace dimensions).
+> **Correction (Phase 3).** The 0.643 figure was **confounded** and overstated
+> directional learning. In that protocol each agent always saw food on the
+> same side in *both* training and evaluation, so a per-agent constant turn
+> bias scored above chance without any vision-conditional steering. The
+> confound-free protocol (`learning_probe_mirrored_steering_is_chance`, which
+> mirrors the food side every training episode) lands at **0.52 — chance**.
+> See the Phase 3 section. What Phase 1 genuinely delivered is intact: the
+> TD(λ) critic learns (value tracks drain, traces stay episodic), foraging and
+> fitness rise at evolution scale, and the brittle deadzone/tonic/pain credit
+> pile is gone. What it did *not* deliver is genuine vision-conditional
+> steering — that remains open.
 
 ## Phase 1 at evolution scale (validation)
 
@@ -140,8 +147,60 @@ Phase-1 gate (same training seed): alignment **0.603** at rate 0.001 and
 **0.613** at 0.0003, versus **0.643** for Phase 1 with no reconstruction.
 Reconstruction was neutral-to-slightly-negative at every rate and never
 cleared the "improves over Phase 1" bar, so it was reverted (see the plan's
-"Phase 2 outcome" section for the mechanism analysis). The headline: TD(λ)
-already extracts the food-direction signal from the random-projection
-encoder at 8×6, so encoder representation is not the binding constraint and
-reshaping it only adds a moving-target cost. Work proceeds to Phase 3
-(vision acuity).
+"Phase 2 outcome" section for the mechanism analysis).
+
+> **Caveat (Phase 3).** This section's "TD(λ) already extracts the
+> food-direction signal" conclusion rested on the **confounded** 0.643
+> directional number. The confound-free probe shows directional steering at
+> chance, so the encoder/representation question is *not* settled — it is
+> re-opened under correct measurement. Reconstruction-as-implemented was
+> still neutral-to-negative, so reverting it remains correct; but "encoder is
+> not the binding constraint" no longer follows.
+
+## Phase 3 (vision acuity) — range-visibility fixed; directional confound found
+
+Two outcomes, one expected and one not.
+
+**1. Vision acuity (the planned work).** Default vision changed from 8×6 to
+**17×13**. The odd row/column counts put one ray row exactly on the horizon
+(passing a constant 0.65 below eye level — inside the 1.0 food hit radius)
+and one column straight ahead. `vision_horizon_row_sees_food_at_range`
+proves the payoff: at 17×13 ground-level food is visible at distances
+{5,10,15,20,25}; at 8×6 only at distance 5 (the lowest below-horizon ray
+strikes flat ground ≈ 5.5 units out, so distal food falls between rows).
+This fixes a real information defect — agents previously could not see food
+at range *at all*. Cost: the feature vector grows 4.3× (265 → 1130).
+
+At evolution scale (16 generations, seed 42) the foraging-rate trend at
+17×13 (0.192 → 0.254) is **comparable to 8×6** (0.164 → 0.285) — no clear
+behavioral win from the extra visibility yet. Consistent with outcome 2:
+the information is now available, but the learner cannot yet act on
+directional vision, so it is not cashed in.
+
+**2. The directional-steering confound (unplanned, more important).**
+Validating Phase 1 at the new resolution surfaced that the 0.643 directional
+result was an artifact. The probe trained each agent with food always on one
+side and evaluated on the same side, so a per-agent constant turn bias scored
+above chance. The confound-free protocol mirrors the food side every training
+episode (`learning_probe_mirrored_steering_is_chance`):
+
+| Protocol | Resolution | Trained alignment |
+|---|---|---|
+| Unmirrored (confounded) | 8×6 | 0.643 |
+| Unmirrored (confounded) | 17×13 | 0.586 |
+| **Mirrored (honest)** | **17×13** | **0.52 (chance)** |
+
+More training episodes do not move the mirrored number (120 → 0.523,
+240 → 0.516). **Genuine vision-conditional steering — "turn toward the side
+where food is seen" — is not being learned**, at either resolution. The
+likely cause is the one issue #13 and both reviews named: a random-projection
+encoder does not make "food-left" and "food-right" linearly separable for the
+policy's readout, so a constant bias is learnable but a conditional response
+is not. This re-opens the encoder/representation problem under a correct
+measurement (Phase 2 had dismissed it using the confounded metric).
+
+**Net:** Phase 3 delivers the information substrate (food visible at range)
+and, more valuably, a confound-free directional probe that correctly reports
+the open problem. The TD(λ) critic and the evolution-scale foraging/fitness
+/survival gains from Phase 1 stand; the specific claim of learned directional
+steering does not.

--- a/docs/superpowers/specs/2026-06-10-learning-baseline.md
+++ b/docs/superpowers/specs/2026-06-10-learning-baseline.md
@@ -103,6 +103,36 @@ gain comes from reward-driven learning, not a directional bias artifact.
 TPS unchanged within noise (the serial history-ring credit loop is gone;
 the TD path is fully parallel across the 128 trace dimensions).
 
+## Phase 1 at evolution scale (validation)
+
+The probe measures within-lifetime learning in isolation; the real question
+is whether it compounds across generations through inheritance. A 24-generation
+headless run (`--config` with `tick_budget=120000`, `population_size=12`,
+`patience` disabled, world seed 42) on lavapipe:
+
+| Signal | Gen 0 | Gen ~22 | Trend |
+|---|---|---|---|
+| Champion composite fitness (`survival·0.4 + foraging·0.3 + exploration·0.3`) | 0.239 | 0.386 | **+62%**, rising then plateauing |
+| Foraging rate (food per 1k alive-ticks, population) | 0.164 | 0.285 | **+74%**, monotone-ish |
+| Total food consumed (population) | ~240 | ~400 | **+60%** |
+| Inherited policy weight norms (`w_fwd` / `w_turn`) | ~0.005 | ~0.29 | monotone growth, bounded |
+
+The monotone growth of the inherited policy weight norms is the direct
+evidence that learned weights persist and **compound across generations** via
+the inherit/mutate path (not just within a lifetime). Champion fitness rising
++62% while the survival term is weighted 0.4 confirms the best lineage is
+genuinely improving, not just trading deaths for food.
+
+**Metric note.** An earlier population-aggregate *food-per-life* proxy
+(`food / (agents + deaths)`) *fell* over the same run because its denominator
+is dominated by the aggregate death count across all 12 agents (active
+foragers and exploratory mutants die often). It was replaced by
+**food-per-1k-alive-ticks**, which normalizes by accrued lifetime and is
+robust to death count — that is the metric `run_headless` now prints, and it
+rises as expected. Death rate climbing alongside foraging flags
+danger-avoidance / energy economics as a live tension (the next plausibly
+binding constraint), consistent with the journey's energy-economics notes.
+
 ## Phase 2 (encoder self-supervision) — negative result, not merged
 
 Tied-weight vision reconstruction was implemented and measured against the

--- a/docs/superpowers/specs/2026-06-10-learning-baseline.md
+++ b/docs/superpowers/specs/2026-06-10-learning-baseline.md
@@ -59,10 +59,11 @@ real hardware when convenient.
 ## Per-generation metrics (headless)
 
 `run_headless` now prints per generation:
-`Food | Deaths | Food/life | w_fwd | w_turn` — the behavioral signal plus
-the best agent's policy weight norms. For evolution-level A/B runs, use a
-fixed `--db` seed config and compare these lines across the same generation
-counts.
+`Food | Deaths | Food/1k-ticks | w_fwd | w_turn` — the behavioral signal
+(food per 1k alive-ticks; see the metric note in the evolution-scale
+section) plus the best agent's policy weight norms. For evolution-level A/B
+runs, use a fixed `--db` seed config and compare these lines across the same
+generation counts.
 
 ## Merge gates (from the plan)
 
@@ -71,8 +72,8 @@ counts.
   20-generation headless run, TPS within 10% of pre-change.
 - Phase 2 (encoder self-supervision): encoded-state separability test
   passes; alignment improves over Phase 1; TPS cost < 15%.
-- Phase 3 (vision acuity): food visible at range in the probe; food/life
-  trends upward across generations.
+- Phase 3 (vision acuity): food visible at range in the probe; foraging rate
+  (food per 1k alive-ticks) trends upward across generations.
 
 ## Phase 1 results (TD(λ) actor-critic)
 

--- a/docs/superpowers/specs/2026-06-10-learning-baseline.md
+++ b/docs/superpowers/specs/2026-06-10-learning-baseline.md
@@ -73,3 +73,32 @@ counts.
   passes; alignment improves over Phase 1; TPS cost < 15%.
 - Phase 3 (vision acuity): food visible at range in the probe; food/life
   trends upward across generations.
+
+## Phase 1 results (TD(λ) actor-critic)
+
+Same lavapipe environment, same probe seeds. The windowed-REINFORCE credit
+path (history ring, deadzone, tonic fallback, pain amplifier) was replaced
+by a linear TD(λ) value head with per-dimension eligibility traces; the TD
+error δ is the sole credit signal for critic, both policy channels, and the
+encoder. New constants: `TD_DISCOUNT=0.97`, `TD_LAMBDA=0.9`,
+`CRITIC_LEARNING_RATE=0.01`, `TD_VECTOR_SCALE=1/ENCODED_DIMENSION`,
+`MAX_TD_ERROR=1.0`. Per-tick action-weight decay removed.
+
+| Metric | Test | Baseline | Phase 1 |
+|---|---|---|---|
+| Trained turn/bearing alignment | `learning_probe_td_learns_turn_alignment` | 0.498 (chance, untrained) | **0.643** after 120 episodes of food-reaching practice |
+| Episode food (first half → second half of training) | same test | — | **588 → 730** of 960/half (rising) |
+| Critic value under constant drain | `td_critic_tracks_metabolic_drain` | n/a | **−0.002** (correctly negative, finite, δ within clamp) |
+| Trace bound across deaths | `td_traces_bounded_across_deaths` | n/a | bounded after 16 deaths (no cross-life leak) |
+| Untrained stationary alignment | `learning_probe_baseline_turn_alignment_is_chance` | 0.498 | 0.50 (still chance — nothing to learn from with no reward events) |
+| Free-run foraging (debug adapter, single run) | `learning_probe_free_run_foraging_baseline` | 2 food | 7 food (noisy single-seed; not a gate) |
+
+The directional gate is the load-bearing result: with food visible and the
+TD reward arriving on contact, **alignment rises from chance (0.498) to
+0.643** — clearing the baseline chance band's upper edge (0.62). This is the
+first time the policy's turn direction has carried information about food
+bearing. The untrained stationary probe stays at chance, confirming the
+gain comes from reward-driven learning, not a directional bias artifact.
+
+TPS unchanged within noise (the serial history-ring credit loop is gone;
+the TD path is fully parallel across the 128 trace dimensions).

--- a/docs/superpowers/specs/2026-06-10-learning-baseline.md
+++ b/docs/superpowers/specs/2026-06-10-learning-baseline.md
@@ -1,0 +1,75 @@
+# Learning Baseline: Phase-0 Probe Measurements
+
+**Date:** 2026-06-10
+**Plan:** [`docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md`](../plans/2026-06-10-emergent-learning-pathway.md)
+**Status:** Baseline recorded. Phases 1–3 must beat these numbers to merge.
+
+## Purpose
+
+Pin the current learner's measurable behavior before any learning-pathway
+change lands. Every number below comes from a deterministic, seeded probe
+(`crates/xagent-sandbox/tests/integration.rs`, "Learning Probe Tests"
+section), so before/after comparisons are reproducible.
+
+## Probe arena
+
+Flat terrain, uniform food-rich biome (no hazards), 16 agents on a 4×4 grid
+spaced 64 units apart (beyond the 30-unit vision range — fully independent
+arenas). Each agent has exactly one food item at bearing ±atan(3/7)
+(≈ ±23.2°, exactly on a vision ray column, alternating left/right) at
+horizontal distance 5 — inside the band where the lowest below-horizon ray
+row intersects ground-level food, outside both touch range (3.0) and
+consume radius (2.0).
+
+A geometry note that fell out of building this: on the default 8×6 grid the
+**vertical** ray layout is the binding constraint on food visibility, not
+horizontal acuity. The rows closest to horizontal sit at ≈ ±10.4°, so a ray
+aimed below the horizon both passes the food's height band and strikes flat
+ground at ≈ 5.5 units out. Ground-level food much beyond that distance falls
+between ray rows and is invisible regardless of bearing. This sharpens the
+Phase 3 vision work: row count / a horizon-grazing row matters at least as
+much as column count.
+
+## Baseline numbers
+
+Measured on Mesa lavapipe (software Vulkan, `llvmpipe`), debug build,
+seeds fixed in the tests. Rates are statistics over hundreds of samples, so
+adapter-level float differences do not move them materially; re-record on
+real hardware when convenient.
+
+| Metric | Test | Value |
+|---|---|---|
+| Turn/bearing alignment (food visible, stationary agent) | `learning_probe_baseline_turn_alignment_is_chance` | **325/653 = 0.498** (chance = 0.5; asserted band 0.38–0.62) |
+| Free-run foraging, default config, 3000 ticks | `learning_probe_free_run_foraging_baseline` | **food = 2 total (16 agents), 0.042 food/agent/1k-ticks, deaths = 0** |
+| Food visibility at probe geometry | `learning_probe_food_is_visible` | **16/16 agents** see ≥ 1 food pixel |
+
+## Reading the numbers
+
+- **0.498 alignment** is the headline: with food *visible* and the agent
+  free to turn, the turn direction carries zero information about where the
+  food is. This is the direct, quantified form of the failure that keeps
+  the parent issue open. A working spatial learner must push this decisively
+  above 0.62 (the test's upper band edge documents the re-pin point).
+- **0.042 food/agent/1k-ticks** with food spawned 5 units away and visible
+  means essentially all eating is accidental contact. Klinotaxis alone does
+  not convert visibility into approach in this arena.
+- **16/16 visibility** confirms the probe measures the learner, not the
+  information path.
+
+## Per-generation metrics (headless)
+
+`run_headless` now prints per generation:
+`Food | Deaths | Food/life | w_fwd | w_turn` — the behavioral signal plus
+the best agent's policy weight norms. For evolution-level A/B runs, use a
+fixed `--db` seed config and compare these lines across the same generation
+counts.
+
+## Merge gates (from the plan)
+
+- Phase 1 (TD credit): alignment probe above the 0.62 band edge with the
+  band re-pinned, foraging rate above baseline over a fixed-seed
+  20-generation headless run, TPS within 10% of pre-change.
+- Phase 2 (encoder self-supervision): encoded-state separability test
+  passes; alignment improves over Phase 1; TPS cost < 15%.
+- Phase 3 (vision acuity): food visible at range in the probe; food/life
+  trends upward across generations.


### PR DESCRIPTION
Replaces the windowed-REINFORCE credit path with a TD(λ) actor-critic and
builds the measurement harness that gates every learning change on issue #13.
Started as the plan document; the implementation phases landed on the same
branch with per-phase measurements.

## Runtime changes (GPU kernel)

- **TD(λ) actor-critic credit** (`brain_passes.wgsl`, `common.wgsl`): linear
  value head over `s_encoded`; TD error δ is the single credit signal for the
  critic, both policy channels, and the encoder, applied through per-dimension
  eligibility traces. `TD_VECTOR_SCALE = 1/ENCODED_DIMENSION` keeps the
  bootstrapped critic inside the linear-TD stability limit.
- **Removed**: the 64-entry history ring (buffer, binding 13, all plumbing),
  `DEADZONE`, `TONIC_CREDIT_SCALE`, `PAIN_AMP`, `CREDIT_DECAY`,
  `ACTION_WEIGHT_DECAY`, and the serial thread-0 credit loop.
- Traces + previous value are episodic (zeroed on death in both respawn
  paths); value weights are learned knowledge and ride the existing
  inherit/mutate path. `value`/`td_error` exposed in telemetry.

## Measurement harness (tests + headless)

- Learning-probe arena (deterministic, seeded): visibility check, baseline
  turn/bearing alignment, free-run foraging, TD critic/trace probes, encoder
  separability diagnostic, and a confound-free mirrored steering probe.
- `vision_horizon_row_sees_food_at_range`: documents that a 17×13 odd grid
  (horizon ray row) sees ground food at {5,10,15,20,25} while 8×6 only sees
  distance 5. The 17×13 capability is kept but the default stays 8×6.
- Headless per-generation metrics: food, deaths, food per 1k alive-ticks,
  champion policy weight norms.

## Measured results

- Evolution scale (24 generations, fixed seed): champion fitness 0.239 → 0.386
  (+62%), foraging rate 0.164 → 0.285 food/1k alive-ticks (+74%), inherited
  policy weight norms grow monotonically — learning compounds across
  generations through inheritance.
- Honest negative results recorded in the docs: encoder reconstruction does
  not help (two protocols), and the original "0.643 directional steering"
  number was a protocol confound — the mirrored probe pins genuine
  vision-conditional steering at chance, which is the open problem.

Docs: the plan (`docs/superpowers/plans/2026-06-10-emergent-learning-pathway.md`)
and baseline spec (`docs/superpowers/specs/2026-06-10-learning-baseline.md`)
carry the full phase-by-phase record, gates, and corrections.

Refs #13

https://claude.ai/code/session_01D37FXkXaaKjttgims4oPEf