### PR TITLE
test(sandbox): poll instead of fixed-sleep in undrained-worker test

### DIFF
--- a/crates/xagent-sandbox/src/sim_runtime.rs
+++ b/crates/xagent-sandbox/src/sim_runtime.rs
@@ -1213,20 +1213,33 @@ mod tests {
         assert!(ready.is_some(), "kernel should become ready");
         let _ = runtime.drain_events();
 
-        // Run undrained for a window, then read how far the worker got on its
-        // own. A nonzero tick proves it advances without the main thread.
-        std::thread::sleep(Duration::from_millis(400));
-        let first = max_tick(&runtime).expect("snapshots after the first window");
-        assert!(
-            first > 0,
-            "worker should advance ticks while undrained, got {first}"
-        );
+        // Sample the worker's progress over an undrained window: never drain
+        // mid-window, so this proves the worker advances without the main thread
+        // consuming events. Poll generously across windows rather than trusting
+        // a single fixed wall-clock budget — a software adapter (CI lavapipe) is
+        // far slower than a hardware GPU at shader compilation and the first
+        // async readback, so a fixed sleep races the first published snapshot.
+        // Mirrors the `drain_until` budget used by the sibling GPU tests. Each
+        // iteration's pre-sample sleep is itself a real undrained window.
+        let advance_past = |minimum: u64| -> Option<u64> {
+            for _ in 0..50 {
+                std::thread::sleep(Duration::from_millis(200));
+                if let Some(tick) = max_tick(&runtime) {
+                    if tick > minimum {
+                        return Some(tick);
+                    }
+                }
+            }
+            None
+        };
 
-        // A second undrained window must show further progress: the worker is
-        // not gated on event consumption (the redraw-stall guarantee), and it
-        // never blocked on the (now-drained) snapshot channel.
-        std::thread::sleep(Duration::from_millis(400));
-        let second = max_tick(&runtime).expect("snapshots after the second window");
+        // A nonzero tick proves the worker advances without the main thread.
+        let first = advance_past(0).expect("worker should advance ticks while undrained");
+
+        // Further progress must follow: the worker is not gated on event
+        // consumption (the redraw-stall guarantee), and it never blocked on the
+        // (now-drained) snapshot channel.
+        let second = advance_past(first).expect("worker should keep advancing while undrained");
         assert!(
             second > first,
             "worker should keep advancing while undrained: {second} !> {first}"


### PR DESCRIPTION
## Problem

CI on `develop` is red. The failing job is `cargo test -p xagent-sandbox`, not a build error:

```
test sim_runtime::tests::worker_advances_independently_of_event_draining ... FAILED
thread '...' panicked at crates/xagent-sandbox/src/sim_runtime.rs:1220:9
```

## Root cause

Plan 0014 (`Post-0010-Review-Hardening`) added Mesa lavapipe + `XAGENT_REQUIRE_GPU=1` to CI so the GPU-gated suite actually executes (previously it self-skipped with no adapter). This test was always present but had **never run in CI before**.

It used two fixed `sleep(400ms)` windows and then asserted `first > 0` / `second > first`. On the lavapipe **software** renderer, shader compilation and the first async readback are far slower than on a hardware GPU, so within the first 400ms there was either no published snapshot (panic at `.expect`, seen in the plan-0014 run) or a tick-0 snapshot (panic at `first > 0`, seen in the docs-0013 run).

The sibling GPU test `worker_runs_generation_budget_handoff` — which drives a full 400-tick generation — **passes** on lavapipe because it polls via `drain_until` (up to 10s). This test was the lone outlier using fixed sleeps.

## Fix

Replace the fixed sleeps with a generous poll (50 × 200ms per window) that samples until the worker has advanced, mirroring the `drain_until` budget the sibling tests already use. The undrained guarantee is preserved — each pre-sample sleep is a real window during which the main thread never drains events. Fast hardware GPUs return on the first iteration, so local runtimes are unchanged.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p xagent-sandbox --all-targets -- -D warnings` clean
- `XAGENT_REQUIRE_GPU=1 LIBGL_ALWAYS_SOFTWARE=1 cargo test -p xagent-sandbox` → 223 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)